### PR TITLE
fix: define page metadata without mutation

### DIFF
--- a/dashboard-ui/app/page.tsx
+++ b/dashboard-ui/app/page.tsx
@@ -1,9 +1,10 @@
 import Layout from "@/ui/Layout";
 import React from "react";
-import {metadata} from "./layout";
+import type { Metadata } from "next";
 
-
-metadata.title = "Главная";
+export const metadata: Metadata = {
+  title: "Главная",
+};
 
 
 export default function Home() {


### PR DESCRIPTION
## Summary
- define Home page metadata locally instead of mutating layout metadata

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Invalid options: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_6894578fd0948329988ec5288e0cb991