### PR TITLE
Add routes to header navigation links

### DIFF
--- a/dashboard-ui/app/components/ui/header/Header.tsx
+++ b/dashboard-ui/app/components/ui/header/Header.tsx
@@ -7,10 +7,10 @@ import Link from "next/link";
 const Header: FC = () => {
     return <header className={styles.header}>
         <Logo/>
-        <Link href={""} className={styles.link}> Главная </Link>
-        <Link href={""} className={styles.link}> Склад   </Link>
-        <Link href={""} className={styles.link}> Задачи  </Link>
-        <Link href={""} className={styles.link}> Отчёты  </Link>
+        <Link href="/" className={styles.link}> Главная </Link>
+        <Link href="/products" className={styles.link}> Склад   </Link>
+        <Link href="/tasks" className={styles.link}> Задачи  </Link>
+        <Link href="/reports" className={styles.link}> Отчёты  </Link>
         <LoginForm/>
     </header>
 }


### PR DESCRIPTION
## Summary
- add home, products, tasks, and reports routes to header links

## Testing
- `npm run lint` *(fails: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*
- `npx eslint .` *(fails: ESLint couldn't find the config "next/typescript" to extend from)*
- `npm run dev` (Next.js started; curl to / returned 200, /products, /tasks, /reports returned 404)


------
https://chatgpt.com/codex/tasks/task_e_689457ce673c8329aca4db36eb5c506b