### PR TITLE
feat: add dashboard home overview

### DIFF
--- a/dashboard-ui/app/components/home/Metrics.tsx
+++ b/dashboard-ui/app/components/home/Metrics.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+const Metrics = () => {
+    return (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            <div className="bg-neutral-100 p-4 rounded-card shadow-card">
+                <h3 className="text-lg font-semibold mb-2">Оборот</h3>
+                <p className="text-2xl font-bold">1 500 000 ₽</p>
+                <p className="text-sm text-neutral-700 mt-1">За неделю: 350 000 ₽</p>
+            </div>
+            <div className="bg-neutral-100 p-4 rounded-card shadow-card">
+                <h3 className="text-lg font-semibold mb-2">Заказы</h3>
+                <p className="text-2xl font-bold">32 сегодня</p>
+                <p className="text-sm text-neutral-700 mt-1">За неделю: 210</p>
+            </div>
+            <div className="bg-neutral-100 p-4 rounded-card shadow-card">
+                <h3 className="text-lg font-semibold mb-2">Товары на складе</h3>
+                <p className="text-2xl font-bold">1 200 шт.</p>
+            </div>
+            <div className="bg-neutral-100 p-4 rounded-card shadow-card">
+                <h3 className="text-lg font-semibold mb-2">Открытые задачи</h3>
+                <p className="text-2xl font-bold">8</p>
+            </div>
+        </div>
+    );
+};
+
+export default Metrics;

--- a/dashboard-ui/app/components/home/Notifications.tsx
+++ b/dashboard-ui/app/components/home/Notifications.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+const Notifications = () => {
+    const items = [
+        "Низкий баланс на счёте",
+        "Важно: завершить отчёт по проекту",
+        "Задержка поставки товара #123",
+    ];
+    return (
+        <div className="bg-neutral-100 p-4 rounded-card shadow-card">
+            <h3 className="text-lg font-semibold mb-4">Уведомления</h3>
+            <ul className="space-y-2">
+                {items.map((item, idx) => (
+                    <li key={idx} className="border-l-4 border-warning pl-2 text-neutral-900">{item}</li>
+                ))}
+            </ul>
+        </div>
+    );
+};
+
+export default Notifications;

--- a/dashboard-ui/app/components/home/QuickActions.tsx
+++ b/dashboard-ui/app/components/home/QuickActions.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import Link from "next/link";
+import Button from "@/ui/Button/Button";
+
+const QuickActions = () => {
+    return (
+        <div className="flex flex-col sm:flex-row gap-4">
+            <Link href="/tasks/new">
+                <Button className="w-full">Добавить задачу</Button>
+            </Link>
+            <Link href="/reports/new">
+                <Button className="w-full">Создать отчёт</Button>
+            </Link>
+            <Link href="/products/receipt">
+                <Button className="w-full">Приход товара</Button>
+            </Link>
+        </div>
+    );
+};
+
+export default QuickActions;

--- a/dashboard-ui/app/components/home/SalesChart.tsx
+++ b/dashboard-ui/app/components/home/SalesChart.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+const data = [50, 75, 60, 90, 120, 80, 100];
+const labels = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс"];
+
+const SalesChart = () => {
+    const max = Math.max(...data);
+    return (
+        <div className="bg-neutral-100 p-4 rounded-card shadow-card">
+            <h3 className="text-lg font-semibold mb-4">Продажи за неделю</h3>
+            <div className="flex items-end space-x-2 h-40">
+                {data.map((value, idx) => (
+                    <div key={idx} className="flex flex-col items-center flex-1">
+                        <div
+                            className="bg-primary-500 w-full rounded-t"
+                            style={{height: `${(value / max) * 100}%`}}
+                        ></div>
+                        <span className="mt-2 text-sm text-neutral-800">{labels[idx]}</span>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default SalesChart;

--- a/dashboard-ui/app/page.tsx
+++ b/dashboard-ui/app/page.tsx
@@ -1,6 +1,10 @@
 import Layout from "@/ui/Layout";
 import React from "react";
 import type { Metadata } from "next";
+import Metrics from "@/components/home/Metrics";
+import SalesChart from "@/components/home/SalesChart";
+import Notifications from "@/components/home/Notifications";
+import QuickActions from "@/components/home/QuickActions";
 
 export const metadata: Metadata = {
   title: "Главная",
@@ -10,9 +14,12 @@ export const metadata: Metadata = {
 export default function Home() {
     return (
         <Layout>
-            <h1>
-                Главная
-            </h1>
+            <div className="space-y-8">
+                <Metrics/>
+                <SalesChart/>
+                <Notifications/>
+                <QuickActions/>
+            </div>
         </Layout>
     );
 }


### PR DESCRIPTION
## Summary
- add summary cards for turnover, orders, stock and open issues
- show a simple weekly sales chart
- list notifications and provide quick action buttons

## Testing
- `yarn lint` *(fails: Unknown options: useEslintrc, extensions)*
- `yarn build` *(fails: Type error in TextArea.tsx, ESLint invalid options)*

------
https://chatgpt.com/codex/tasks/task_e_68946afbbbd88329ab5d924a4b32a7b6