### PR TITLE
feat: add task management pages

### DIFF
--- a/dashboard-ui/app/components/tasks/TaskForm.tsx
+++ b/dashboard-ui/app/components/tasks/TaskForm.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useForm } from 'react-hook-form'
+import { useRouter } from 'next/navigation'
+import Field from '@/ui/Field/Field'
+import TextArea from '@/ui/TextArea/TextArea'
+import Button from '@/ui/Button/Button'
+import {
+  ITask,
+  TaskPriority,
+  TaskStatus,
+} from '@/shared/interfaces/task.interface'
+import { TaskService } from '@/services/task/task.service'
+
+interface Props {
+  task?: ITask
+}
+
+const TaskForm = ({ task }: Props) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ITask>({
+    defaultValues: {
+      title: task?.title || '',
+      description: task?.description || '',
+      executor: task?.executor || '',
+      deadline: task?.deadline ? task.deadline.slice(0, 10) : '',
+      priority: task?.priority || TaskPriority.Medium,
+      status: task?.status || TaskStatus.Pending,
+    },
+  })
+
+  const router = useRouter()
+
+  const onSubmit = (data: ITask) => {
+    const method = task
+      ? TaskService.update(task.id, data)
+      : TaskService.create(data)
+    method.then(() => router.push('/tasks'))
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 max-w-md">
+      <Field
+        {...register('title', { required: 'Введите заголовок' })}
+        placeholder="Заголовок"
+        error={errors.title}
+      />
+      <TextArea
+        {...register('description')}
+        placeholder="Описание"
+      />
+      <Field
+        {...register('executor')}
+        placeholder="Исполнитель"
+      />
+      <Field type="date" {...register('deadline', { required: true })} />
+      <select
+        {...register('priority')}
+        className="border border-neutral-300 rounded px-2 py-1 w-full"
+      >
+        {Object.values(TaskPriority).map(p => (
+          <option key={p} value={p}>
+            {p}
+          </option>
+        ))}
+      </select>
+      <select
+        {...register('status')}
+        className="border border-neutral-300 rounded px-2 py-1 w-full"
+      >
+        {Object.values(TaskStatus).map(s => (
+          <option key={s} value={s}>
+            {s}
+          </option>
+        ))}
+      </select>
+      <Button
+        type="submit"
+        className="bg-primary-500 text-white px-4 py-1"
+      >
+        Сохранить
+      </Button>
+    </form>
+  )
+}
+
+export default TaskForm

--- a/dashboard-ui/app/components/tasks/TasksTable.tsx
+++ b/dashboard-ui/app/components/tasks/TasksTable.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import Button from '@/ui/Button/Button'
+import { TaskService } from '@/services/task/task.service'
+import { ITask, TaskPriority } from '@/shared/interfaces/task.interface'
+
+const TasksTable = () => {
+  const [tasks, setTasks] = useState<ITask[]>([])
+  const [date, setDate] = useState('')
+  const [priority, setPriority] = useState('')
+
+  useEffect(() => {
+    TaskService.getAll().then(setTasks)
+  }, [])
+
+  const filtered = tasks.filter(task => {
+    const matchesDate = !date || task.deadline.slice(0, 10) === date
+    const matchesPriority = !priority || task.priority === priority
+    return matchesDate && matchesPriority
+  })
+
+  return (
+    <div>
+      <div className="flex justify-between mb-4">
+        <div className="flex space-x-2">
+          <input
+            type="date"
+            value={date}
+            onChange={e => setDate(e.target.value)}
+            className="border border-neutral-300 rounded px-2 py-1"
+          />
+          <select
+            value={priority}
+            onChange={e => setPriority(e.target.value)}
+            className="border border-neutral-300 rounded px-2 py-1"
+          >
+            <option value="">Все приоритеты</option>
+            {Object.values(TaskPriority).map(p => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        </div>
+        <Link href="/tasks/new">
+          <Button className="bg-primary-500 text-white px-4 py-1">
+            Добавить задачу
+          </Button>
+        </Link>
+      </div>
+
+      <table className="min-w-full bg-neutral-100 rounded shadow-md">
+        <thead>
+          <tr className="text-left border-b border-neutral-300">
+            <th className="p-2">Задача</th>
+            <th className="p-2">Исполнитель</th>
+            <th className="p-2">Дедлайн</th>
+            <th className="p-2">Приоритет</th>
+            <th className="p-2">Статус</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map(task => (
+            <tr
+              key={task.id}
+              className="border-b border-neutral-200 hover:bg-neutral-200"
+            >
+              <td className="p-2">
+                <Link href={`/tasks/${task.id}`}>{task.title}</Link>
+              </td>
+              <td className="p-2">{task.executor || '-'}</td>
+              <td className="p-2">
+                {new Date(task.deadline).toLocaleDateString()}
+              </td>
+              <td className="p-2">{task.priority}</td>
+              <td className="p-2">{task.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default TasksTable

--- a/dashboard-ui/app/services/task/task.service.ts
+++ b/dashboard-ui/app/services/task/task.service.ts
@@ -1,0 +1,24 @@
+import { axiosClassic } from '@/api/interceptor'
+import { ITask } from '@/shared/interfaces/task.interface'
+
+export const TaskService = {
+  async getAll() {
+    const response = await axiosClassic.get<ITask[]>('/task')
+    return response.data
+  },
+
+  async getById(id: string | number) {
+    const response = await axiosClassic.get<ITask>(`/task/${id}`)
+    return response.data
+  },
+
+  async create(data: Omit<ITask, 'id'>) {
+    const response = await axiosClassic.post<ITask>('/task', data)
+    return response.data
+  },
+
+  async update(id: string | number, data: Partial<ITask>) {
+    const response = await axiosClassic.put<ITask>(`/task/${id}`, data)
+    return response.data
+  },
+}

--- a/dashboard-ui/app/shared/interfaces/task.interface.ts
+++ b/dashboard-ui/app/shared/interfaces/task.interface.ts
@@ -10,10 +10,18 @@ export enum TaskStatus {
   Completed = 'Готово',
 }
 
+export enum TaskPriority {
+  Low = 'Низкий',
+  Medium = 'Средний',
+  High = 'Высокий',
+}
+
 export interface ITask {
-  id: string
+  id: number
   title: string
   description?: string
-  deadline: Date
+  deadline: string
   status: TaskStatus
+  executor?: string
+  priority: TaskPriority
 }

--- a/dashboard-ui/app/tasks/[id]/page.tsx
+++ b/dashboard-ui/app/tasks/[id]/page.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Layout from '@/ui/Layout'
+import TaskForm from '@/components/tasks/TaskForm'
+import { TaskService } from '@/services/task/task.service'
+import { ITask } from '@/shared/interfaces/task.interface'
+
+interface Props {
+  params: { id: string }
+}
+
+export default function TaskPage({ params }: Props) {
+  const [task, setTask] = useState<ITask | null>(null)
+
+  useEffect(() => {
+    TaskService.getById(params.id).then(setTask)
+  }, [params.id])
+
+  if (!task)
+    return (
+      <Layout>
+        <div>Загрузка...</div>
+      </Layout>
+    )
+
+  return (
+    <Layout>
+      <TaskForm task={task} />
+    </Layout>
+  )
+}

--- a/dashboard-ui/app/tasks/new/page.tsx
+++ b/dashboard-ui/app/tasks/new/page.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/ui/Layout'
+import TaskForm from '@/components/tasks/TaskForm'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'New Task',
+}
+
+export default function NewTaskPage() {
+  return (
+    <Layout>
+      <TaskForm />
+    </Layout>
+  )
+}

--- a/dashboard-ui/app/tasks/page.tsx
+++ b/dashboard-ui/app/tasks/page.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/ui/Layout'
+import TasksTable from '@/components/tasks/TasksTable'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Tasks',
+}
+
+export default function TasksPage() {
+  return (
+    <Layout>
+      <TasksTable />
+    </Layout>
+  )
+}

--- a/server/src/task/dto/task.dto.ts
+++ b/server/src/task/dto/task.dto.ts
@@ -1,11 +1,11 @@
 import {
-	IsDateString,
-	IsEnum,
-	IsNotEmpty,
-	IsOptional,
-	IsString
+        IsDateString,
+        IsEnum,
+        IsNotEmpty,
+        IsOptional,
+        IsString
 } from 'class-validator'
-import { TaskStatus } from '../task.model'
+import { TaskStatus, TaskPriority } from '../task.model'
 
 export class CreateTaskDto {
 	@IsString()
@@ -19,11 +19,15 @@ export class CreateTaskDto {
 	@IsDateString()
 	deadline: string
 
-	@IsEnum(TaskStatus)
-	@IsOptional()
-	status?: TaskStatus
+        @IsEnum(TaskStatus)
+        @IsOptional()
+        status?: TaskStatus
 
-	@IsString()
-	@IsOptional()
-	executor?: string
+        @IsEnum(TaskPriority)
+        @IsOptional()
+        priority?: TaskPriority
+
+        @IsString()
+        @IsOptional()
+        executor?: string
 }

--- a/server/src/task/task.model.ts
+++ b/server/src/task/task.model.ts
@@ -1,16 +1,26 @@
 import { Column, DataType, Model, Table } from 'sequelize-typescript'
 
 export enum TaskStatus {
-	Pending = 'Ожидает',
-	InProgress = 'Выполняется',
-	Completed = 'Готово'
+        Pending = 'Ожидает',
+        InProgress = 'Выполняется',
+        Completed = 'Готово'
+}
+
+export enum TaskPriority {
+        Low = 'Низкий',
+        Medium = 'Средний',
+        High = 'Высокий'
 }
 
 @Table({
-	tableName: 'Task',
-	deletedAt: false,
-	version: false,
-	indexes: [{ fields: ['deadline'] }, { fields: ['status'] }]
+        tableName: 'Task',
+        deletedAt: false,
+        version: false,
+        indexes: [
+                { fields: ['deadline'] },
+                { fields: ['status'] },
+                { fields: ['priority'] }
+        ]
 })
 export class TaskModel extends Model {
 	@Column(DataType.TEXT)
@@ -19,15 +29,21 @@ export class TaskModel extends Model {
 	@Column(DataType.TEXT)
 	description?: string // Описание задачи
 
-	@Column(DataType.DATE)
-	deadline: Date // Дедлайн задачи
+        @Column(DataType.DATE)
+        deadline: Date // Дедлайн задачи
 
-	@Column({
-		type: DataType.ENUM(...Object.values(TaskStatus)),
-		defaultValue: TaskStatus.Pending
-	})
-	status: TaskStatus // Статус задачи
+        @Column({
+                type: DataType.ENUM(...Object.values(TaskStatus)),
+                defaultValue: TaskStatus.Pending
+        })
+        status: TaskStatus // Статус задачи
 
-	@Column(DataType.STRING)
-	executor?: string // Исполнитель задачи
+        @Column({
+                type: DataType.ENUM(...Object.values(TaskPriority)),
+                defaultValue: TaskPriority.Medium
+        })
+        priority: TaskPriority // Приоритет задачи
+
+        @Column(DataType.STRING)
+        executor?: string // Исполнитель задачи
 }


### PR DESCRIPTION
## Summary
- extend task model with priority field
- add CRUD pages for tasks with filtering, creation and editing
- provide client service for tasks API

## Testing
- `npm test` (server)
- `npm run lint` (dashboard-ui) *(fails: Invalid Options: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_6894736bd924832987248d51a9d62672