### PR TITLE
Add delete actions to tables

### DIFF
--- a/dashboard-ui/app/components/products/ProductsTable.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.tsx
@@ -35,6 +35,16 @@ const ProductsTable = () => {
       .catch(e => setError(e.message))
   }
 
+  const handleDelete = async (id: number) => {
+    try {
+      await ProductService.delete(id)
+      setProducts(prev => prev.filter(p => p.id !== id))
+      if (selected?.id === id) setSelected(null)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Error deleting product')
+    }
+  }
+
   return (
     <div>
       <div className="flex justify-between mb-4">
@@ -74,6 +84,7 @@ const ProductsTable = () => {
             <th className="p-2">Category</th>
             <th className="p-2">Balance</th>
             <th className="p-2">Price</th>
+            <th className="p-2">Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -92,6 +103,17 @@ const ProductsTable = () => {
                 )}
               </td>
               <td className="p-2">${prod.salePrice}</td>
+              <td className="p-2">
+                <Button
+                  className="bg-error text-white px-4 py-1"
+                  onClick={e => {
+                    e.stopPropagation()
+                    handleDelete(prod.id)
+                  }}
+                >
+                  Delete
+                </Button>
+              </td>
             </tr>
           ))}
         </tbody>

--- a/dashboard-ui/app/components/tasks/TasksTable.tsx
+++ b/dashboard-ui/app/components/tasks/TasksTable.tsx
@@ -18,6 +18,15 @@ const TasksTable = () => {
       .catch(e => setError(e.message))
   }, [])
 
+  const handleDelete = async (id: number) => {
+    try {
+      await TaskService.delete(id)
+      setTasks(prev => prev.filter(task => task.id !== id))
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Error deleting task')
+    }
+  }
+
   const filtered = tasks.filter(task => {
     const matchesDate = !date || task.deadline.slice(0, 10) === date
     const matchesPriority = !priority || task.priority === priority
@@ -62,6 +71,7 @@ const TasksTable = () => {
             <th className="p-2">Дедлайн</th>
             <th className="p-2">Приоритет</th>
             <th className="p-2">Статус</th>
+            <th className="p-2">Действия</th>
           </tr>
         </thead>
         <tbody>
@@ -79,6 +89,14 @@ const TasksTable = () => {
               </td>
               <td className="p-2">{task.priority}</td>
               <td className="p-2">{task.status}</td>
+              <td className="p-2">
+                <Button
+                  className="bg-error text-white px-4 py-1"
+                  onClick={() => handleDelete(task.id)}
+                >
+                  Удалить
+                </Button>
+              </td>
             </tr>
           ))}
         </tbody>

--- a/dashboard-ui/app/services/task/task.service.ts
+++ b/dashboard-ui/app/services/task/task.service.ts
@@ -21,4 +21,8 @@ export const TaskService = {
     const response = await axiosClassic.put<ITask>(`/task/${id}`, data)
     return response.data
   },
+
+  async delete(id: number) {
+    await axiosClassic.delete(`/task/${id}`)
+  },
 }


### PR DESCRIPTION
## Summary
- add API support for removing tasks
- wire product and task tables with delete buttons and optimistic removal

## Testing
- `npx eslint .` *(fails: Unexpected any in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68948936967483299e472dc9d182b195