### PR TITLE
feat: add loading states

### DIFF
--- a/dashboard-ui/app/components/products/ProductsTable.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.tsx
@@ -10,12 +10,15 @@ const ProductsTable = () => {
   const [category, setCategory] = useState('')
   const [selected, setSelected] = useState<IProduct | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
 
   // Загружаем список продуктов при монтировании
   useEffect(() => {
+    setIsLoading(true)
     ProductService.getAll()
       .then(setProducts)
       .catch(e => setError(e.message))
+      .finally(() => setIsLoading(false))
   }, [])
 
   const categories = Array.from(
@@ -30,9 +33,11 @@ const ProductsTable = () => {
   const isLow = (balance: number) => balance <= 5
 
   const selectProduct = (id: number) => {
+    setIsLoading(true)
     ProductService.getById(id)
       .then(setSelected)
       .catch(e => setError(e.message))
+      .finally(() => setIsLoading(false))
   }
 
   return (
@@ -67,35 +72,39 @@ const ProductsTable = () => {
         </div>
       </div>
 
-      <table className="min-w-full bg-neutral-100 rounded shadow-md">
-        <thead>
-          <tr className="text-left border-b border-neutral-300">
-            <th className="p-2">Name</th>
-            <th className="p-2">Category</th>
-            <th className="p-2">Balance</th>
-            <th className="p-2">Price</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filtered.map(prod => (
-            <tr
-              key={prod.id}
-              onClick={() => selectProduct(prod.id)}
-              className={`cursor-pointer border-b border-neutral-200 hover:bg-neutral-200 ${isLow(prod.remains) ? 'bg-warning/20' : ''}`}
-            >
-              <td className="p-2">{prod.name}</td>
-              <td className="p-2">{prod.category?.name || '-'}</td>
-              <td className="p-2">
-                {prod.remains}
-                {isLow(prod.remains) && (
-                  <span className="text-error ml-1">(!)</span>
-                )}
-              </td>
-              <td className="p-2">${prod.salePrice}</td>
+      {isLoading ? (
+        <div className="py-4 text-center">Loading...</div>
+      ) : (
+        <table className="min-w-full bg-neutral-100 rounded shadow-md">
+          <thead>
+            <tr className="text-left border-b border-neutral-300">
+              <th className="p-2">Name</th>
+              <th className="p-2">Category</th>
+              <th className="p-2">Balance</th>
+              <th className="p-2">Price</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {filtered.map(prod => (
+              <tr
+                key={prod.id}
+                onClick={() => selectProduct(prod.id)}
+                className={`cursor-pointer border-b border-neutral-200 hover:bg-neutral-200 ${isLow(prod.remains) ? 'bg-warning/20' : ''}`}
+              >
+                <td className="p-2">{prod.name}</td>
+                <td className="p-2">{prod.category?.name || '-'}</td>
+                <td className="p-2">
+                  {prod.remains}
+                  {isLow(prod.remains) && (
+                    <span className="text-error ml-1">(!)</span>
+                  )}
+                </td>
+                <td className="p-2">${prod.salePrice}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
 
       {error && <p className="text-error mt-2">{error}</p>}
       {selected && (

--- a/dashboard-ui/app/components/tasks/TasksTable.tsx
+++ b/dashboard-ui/app/components/tasks/TasksTable.tsx
@@ -11,11 +11,14 @@ const TasksTable = () => {
   const [date, setDate] = useState('')
   const [priority, setPriority] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
 
   useEffect(() => {
+    setIsLoading(true)
     TaskService.getAll()
       .then(setTasks)
       .catch(e => setError(e.message))
+      .finally(() => setIsLoading(false))
   }, [])
 
   const filtered = tasks.filter(task => {
@@ -54,35 +57,39 @@ const TasksTable = () => {
         </Link>
       </div>
 
-      <table className="min-w-full bg-neutral-100 rounded shadow-md">
-        <thead>
-          <tr className="text-left border-b border-neutral-300">
-            <th className="p-2">Задача</th>
-            <th className="p-2">Исполнитель</th>
-            <th className="p-2">Дедлайн</th>
-            <th className="p-2">Приоритет</th>
-            <th className="p-2">Статус</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filtered.map(task => (
-            <tr
-              key={task.id}
-              className="border-b border-neutral-200 hover:bg-neutral-200"
-            >
-              <td className="p-2">
-                <Link href={`/tasks/${task.id}`}>{task.title}</Link>
-              </td>
-              <td className="p-2">{task.executor || '-'}</td>
-              <td className="p-2">
-                {new Date(task.deadline).toLocaleDateString()}
-              </td>
-              <td className="p-2">{task.priority}</td>
-              <td className="p-2">{task.status}</td>
+      {isLoading ? (
+        <div className="py-4 text-center">Loading...</div>
+      ) : (
+        <table className="min-w-full bg-neutral-100 rounded shadow-md">
+          <thead>
+            <tr className="text-left border-b border-neutral-300">
+              <th className="p-2">Задача</th>
+              <th className="p-2">Исполнитель</th>
+              <th className="p-2">Дедлайн</th>
+              <th className="p-2">Приоритет</th>
+              <th className="p-2">Статус</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {filtered.map(task => (
+              <tr
+                key={task.id}
+                className="border-b border-neutral-200 hover:bg-neutral-200"
+              >
+                <td className="p-2">
+                  <Link href={`/tasks/${task.id}`}>{task.title}</Link>
+                </td>
+                <td className="p-2">{task.executor || '-'}</td>
+                <td className="p-2">
+                  {new Date(task.deadline).toLocaleDateString()}
+                </td>
+                <td className="p-2">{task.priority}</td>
+                <td className="p-2">{task.status}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
       {error && <p className="text-error mt-2">{error}</p>}
     </div>
   )

--- a/dashboard-ui/app/reports/page.tsx
+++ b/dashboard-ui/app/reports/page.tsx
@@ -16,17 +16,21 @@ export default function ReportsPage() {
   const [employee, setEmployee] = useState('')
   const [data, setData] = useState<any>(null)
   const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
 
   useEffect(() => {
-    ReportService.getAvailable()
-      .then(setAvailable)
+    setIsLoading(true)
+    Promise.all([ReportService.getAvailable(), ReportService.getHistory()])
+      .then(([avail, hist]) => {
+        setAvailable(avail)
+        setHistory(hist)
+      })
       .catch(e => setError(e.message))
-    ReportService.getHistory()
-      .then(setHistory)
-      .catch(e => setError(e.message))
+      .finally(() => setIsLoading(false))
   }, [])
 
   const generate = async () => {
+    setIsLoading(true)
     try {
       const report = await ReportService.generate({
         type,
@@ -37,107 +41,116 @@ export default function ReportsPage() {
       setHistory(hist)
     } catch (e: any) {
       setError(e.message)
+    } finally {
+      setIsLoading(false)
     }
   }
 
   const exportReport = async (format: string) => {
+    setIsLoading(true)
     try {
       if (!history.length) return
       const last = history[history.length - 1]
       await ReportService.export(last.id, format)
     } catch (e: any) {
       setError(e.message)
+    } finally {
+      setIsLoading(false)
     }
   }
 
   return (
     <Layout>
-      <div className="space-y-6">
-        <div>
-          <h2 className="text-xl font-semibold mb-2">Доступные отчёты</h2>
-          <ul className="list-disc pl-4">
-            {available.map(r => (
-              <li key={r.id}>{r.name}</li>
-            ))}
-          </ul>
-          <Button
-            className="mt-2 bg-primary-500 text-white px-4 py-1"
-            onClick={generate}
-          >
-            Generate a new report
-          </Button>
-        </div>
-
-        <div className="space-y-2">
-          <h3 className="text-lg font-medium">Параметры</h3>
-          <div className="flex flex-wrap gap-2">
-            <input
-              type="date"
-              value={start}
-              onChange={e => setStart(e.target.value)}
-              className="border border-neutral-300 rounded px-2 py-1"
-            />
-            <input
-              type="date"
-              value={end}
-              onChange={e => setEnd(e.target.value)}
-              className="border border-neutral-300 rounded px-2 py-1"
-            />
-            <input
-              placeholder="Product"
-              value={product}
-              onChange={e => setProduct(e.target.value)}
-              className="border border-neutral-300 rounded px-2 py-1"
-            />
-            <input
-              placeholder="Employee"
-              value={employee}
-              onChange={e => setEmployee(e.target.value)}
-              className="border border-neutral-300 rounded px-2 py-1"
-            />
+      {isLoading ? (
+        <div className="py-4 text-center">Loading...</div>
+      ) : (
+        <div className="space-y-6">
+          <div>
+            <h2 className="text-xl font-semibold mb-2">Доступные отчёты</h2>
+            <ul className="list-disc pl-4">
+              {available.map(r => (
+                <li key={r.id}>{r.name}</li>
+              ))}
+            </ul>
+            <Button
+              className="mt-2 bg-primary-500 text-white px-4 py-1"
+              onClick={generate}
+            >
+              Generate a new report
+            </Button>
           </div>
-        </div>
 
-        {data && (
           <div className="space-y-2">
-            <h3 className="text-lg font-medium">Результаты</h3>
-            <table className="min-w-full bg-neutral-100 rounded shadow-md">
-              <tbody>
-                <tr>
-                  <td className="p-2">Пример данных</td>
-                  <td className="p-2">{JSON.stringify(data)}</td>
-                </tr>
-              </tbody>
-            </table>
-            <div className="flex space-x-2">
-              <Button
-                className="bg-primary-500 text-white px-4 py-1"
-                onClick={() => exportReport('pdf')}
-              >
-                Export to PDF
-              </Button>
-              <Button
-                className="bg-primary-500 text-white px-4 py-1"
-                onClick={() => exportReport('excel')}
-              >
-                Export to Excel
-              </Button>
+            <h3 className="text-lg font-medium">Параметры</h3>
+            <div className="flex flex-wrap gap-2">
+              <input
+                type="date"
+                value={start}
+                onChange={e => setStart(e.target.value)}
+                className="border border-neutral-300 rounded px-2 py-1"
+              />
+              <input
+                type="date"
+                value={end}
+                onChange={e => setEnd(e.target.value)}
+                className="border border-neutral-300 rounded px-2 py-1"
+              />
+              <input
+                placeholder="Product"
+                value={product}
+                onChange={e => setProduct(e.target.value)}
+                className="border border-neutral-300 rounded px-2 py-1"
+              />
+              <input
+                placeholder="Employee"
+                value={employee}
+                onChange={e => setEmployee(e.target.value)}
+                className="border border-neutral-300 rounded px-2 py-1"
+              />
             </div>
           </div>
-        )}
 
-        <div>
-          <h3 className="text-lg font-medium mb-2">История</h3>
-          <ul className="list-disc pl-4">
-            {history.map(h => (
-              <li key={h.id}>
-                {h.type} - {new Date(h.createdAt).toLocaleString()}
-              </li>
-            ))}
-          </ul>
+          {data && (
+            <div className="space-y-2">
+              <h3 className="text-lg font-medium">Результаты</h3>
+              <table className="min-w-full bg-neutral-100 rounded shadow-md">
+                <tbody>
+                  <tr>
+                    <td className="p-2">Пример данных</td>
+                    <td className="p-2">{JSON.stringify(data)}</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div className="flex space-x-2">
+                <Button
+                  className="bg-primary-500 text-white px-4 py-1"
+                  onClick={() => exportReport('pdf')}
+                >
+                  Export to PDF
+                </Button>
+                <Button
+                  className="bg-primary-500 text-white px-4 py-1"
+                  onClick={() => exportReport('excel')}
+                >
+                  Export to Excel
+                </Button>
+              </div>
+            </div>
+          )}
+
+          <div>
+            <h3 className="text-lg font-medium mb-2">История</h3>
+            <ul className="list-disc pl-4">
+              {history.map(h => (
+                <li key={h.id}>
+                  {h.type} - {new Date(h.createdAt).toLocaleString()}
+                </li>
+              ))}
+            </ul>
+          </div>
+          {error && <p className="text-error">{error}</p>}
         </div>
-        {error && <p className="text-error">{error}</p>}
-      </div>
+      )}
     </Layout>
   )
 }


### PR DESCRIPTION
## Summary
- show loading placeholder for tasks table, products table, and reports page
- toggle isLoading state around API requests

## Testing
- `npm run lint` *(fails: Invalid Options)*
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6894893cd07c8329b2026ffa0b21d1f6