### PR TITLE
feat: enable jwt auth

### DIFF
--- a/server/src/analytics/analytics.controller.ts
+++ b/server/src/analytics/analytics.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get, Query } from '@nestjs/common'
+import { Controller, Get, Query, UseGuards } from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
 import { AnalyticsService } from './analytics.service'
 import { ProductModel } from '../product/product.model'
 
@@ -11,6 +12,7 @@ function parseCategories(value?: string): number[] | undefined {
 		.filter((n) => !isNaN(n))
 }
 
+@UseGuards(AuthGuard('jwt'))
 @Controller('analytics')
 export class AnalyticsController {
 	constructor(private readonly analyticsService: AnalyticsService) {}

--- a/server/src/app.controller.ts
+++ b/server/src/app.controller.ts
@@ -1,6 +1,8 @@
-import { Controller, Get } from '@nestjs/common'
+import { Controller, Get, UseGuards } from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
 import { AppService } from './app.service'
 
+@UseGuards(AuthGuard('jwt'))
 @Controller()
 export class AppController {
 	constructor(private readonly appService: AppService) {}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -3,6 +3,7 @@ import { AppController } from './app.controller'
 import { AppService } from './app.service'
 import { SequelizeModule } from '@nestjs/sequelize'
 import { ConfigModule, ConfigService } from '@nestjs/config'
+import { PassportModule } from '@nestjs/passport'
 import { getSequelizeConfig } from './config/db.config'
 import { join } from 'path'
 import { AuthModule } from './auth/auth.module'
@@ -19,14 +20,15 @@ import { ReportModule } from './report/report.module'
 			isGlobal: true,
 			envFilePath: join(__dirname, '..', '.env')
 		}),
-		SequelizeModule.forRootAsync({
-			imports: [ConfigModule],
-			inject: [ConfigService],
-			useFactory: getSequelizeConfig
-		}),
-		AuthModule,
-		ProductModule,
-		SaleModule,
+                SequelizeModule.forRootAsync({
+                        imports: [ConfigModule],
+                        inject: [ConfigService],
+                        useFactory: getSequelizeConfig
+                }),
+                PassportModule.register({ defaultStrategy: 'jwt' }),
+                AuthModule,
+                ProductModule,
+                SaleModule,
                 TaskModule,
                 CategoryModule,
                 AnalyticsModule,

--- a/server/src/auth/auth.module.ts
+++ b/server/src/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { UserModel } from './user.model'
 import { JWTStrategy } from './strategies/auth.strategy'
 import { JwtModule } from '@nestjs/jwt'
 import { ConfigModule, ConfigService } from '@nestjs/config'
+import { PassportModule } from '@nestjs/passport'
 import { getJWTConfig } from '../config/jwt.config'
 
 /**
@@ -17,23 +18,27 @@ import { getJWTConfig } from '../config/jwt.config'
 		// Регистрируем модель User для использования в сервисе
 		SequelizeModule.forFeature([UserModel]),
 
-		// Подключаем модуль конфигурации (для доступа к переменным окружения)
-		ConfigModule,
+                // Подключаем модуль конфигурации (для доступа к переменным окружения)
+                ConfigModule,
 
-		// Регистрируем JWT модуль с асинхронной настройкой через useFactory
-		JwtModule.registerAsync({
-			imports: [ConfigModule],
-			inject: [ConfigService],
-			useFactory: getJWTConfig
-		})
-	],
+                // Регистрируем PassportModule с стратегией JWT по умолчанию
+                PassportModule.register({ defaultStrategy: 'jwt' }),
+
+                // Регистрируем JWT модуль с асинхронной настройкой через useFactory
+                JwtModule.registerAsync({
+                        imports: [ConfigModule],
+                        inject: [ConfigService],
+                        useFactory: getJWTConfig
+                })
+        ],
 	// Контроллеры, обрабатывающие HTTP-запросы
 	controllers: [AuthController],
 
 	// Сервисы и стратегии, используемые внутри модуля
-	providers: [
-		AuthService, // Логика аутентификации и регистрации
-		JWTStrategy // JWT-стратегия для проверки токенов
-	]
+        providers: [
+                AuthService, // Логика аутентификации и регистрации
+                JWTStrategy // JWT-стратегия для проверки токенов
+        ],
+        exports: [PassportModule]
 })
 export class AuthModule {}

--- a/server/src/category/category.controller.ts
+++ b/server/src/category/category.controller.ts
@@ -1,18 +1,21 @@
 import {
-	Body,
-	Controller,
-	Delete,
-	Get,
-	Param,
-	ParseIntPipe,
-	Post,
-	Put
+        Body,
+        Controller,
+        Delete,
+        Get,
+        Param,
+        ParseIntPipe,
+        Post,
+        Put,
+        UseGuards
 } from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
 import { CategoryService } from './category.service'
 import { CategoryModel } from './category.model'
 import { CreateCategoryDto } from './dto/category.dto'
 import { UpdateCategoryDto } from './dto/update.category.dto'
 
+@UseGuards(AuthGuard('jwt'))
 @Controller('category')
 export class CategoryController {
 	constructor(private readonly categoryService: CategoryService) {}

--- a/server/src/product/product.controller.ts
+++ b/server/src/product/product.controller.ts
@@ -1,19 +1,22 @@
 import {
-	Body,
-	Controller,
-	Delete,
-	Get,
-	Param,
-	ParseIntPipe,
-	Post,
-	Put
+        Body,
+        Controller,
+        Delete,
+        Get,
+        Param,
+        ParseIntPipe,
+        Post,
+        Put,
+        UseGuards
 } from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
 import { ProductService } from './product.service'
 import { ProductModel } from './product.model'
 import { CreateProductDto } from './dto/product.dto'
 import { UpdateProductDto } from './dto/update.product.dto'
 import { AddStockDto } from './dto/stock.dto'
 
+@UseGuards(AuthGuard('jwt'))
 @Controller('products')
 export class ProductController {
 	constructor(private readonly productService: ProductService) {}

--- a/server/src/report/report.controller.ts
+++ b/server/src/report/report.controller.ts
@@ -1,7 +1,17 @@
-import { Body, Controller, Get, Param, ParseIntPipe, Post } from '@nestjs/common'
+import {
+        Body,
+        Controller,
+        Get,
+        Param,
+        ParseIntPipe,
+        Post,
+        UseGuards
+} from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
 import { ReportService } from './report.service'
 import { GenerateReportDto } from './dto/generate-report.dto'
 
+@UseGuards(AuthGuard('jwt'))
 @Controller('reports')
 export class ReportController {
         constructor(private readonly reportService: ReportService) {}

--- a/server/src/sale/sale.controller.ts
+++ b/server/src/sale/sale.controller.ts
@@ -1,18 +1,21 @@
 import {
-	Body,
-	Controller,
-	Delete,
-	Get,
-	Param,
-	ParseIntPipe,
-	Post,
-	Put
+        Body,
+        Controller,
+        Delete,
+        Get,
+        Param,
+        ParseIntPipe,
+        Post,
+        Put,
+        UseGuards
 } from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
 import { SaleService } from './sale.service'
 import { SaleModel } from './sale.model'
 import { CreateSaleDto } from './dto/sale.dto'
 import { UpdateSaleDto } from './dto/update.sale.dto'
 
+@UseGuards(AuthGuard('jwt'))
 @Controller('sales')
 export class SaleController {
 	constructor(private readonly saleService: SaleService) {}

--- a/server/src/task/task.controller.ts
+++ b/server/src/task/task.controller.ts
@@ -1,18 +1,21 @@
 import {
-	Body,
-	Controller,
-	Delete,
-	Get,
-	Param,
-	ParseIntPipe,
-	Post,
-	Put
+        Body,
+        Controller,
+        Delete,
+        Get,
+        Param,
+        ParseIntPipe,
+        Post,
+        Put,
+        UseGuards
 } from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
 import { TaskService } from './task.service'
 import { TaskModel } from './task.model'
 import { CreateTaskDto } from './dto/task.dto'
 import { UpdateTaskDto } from './dto/update.task.dto'
 
+@UseGuards(AuthGuard('jwt'))
 @Controller('task')
 export class TaskController {
 	constructor(private readonly taskService: TaskService) {}

--- a/server/test/app.e2e-spec.ts
+++ b/server/test/app.e2e-spec.ts
@@ -1,25 +1,44 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
-import { App } from 'supertest/types';
-import { AppModule } from './../src/app.module';
+import { INestApplication } from '@nestjs/common'
+import { Test, TestingModule } from '@nestjs/testing'
+import { JwtModule } from '@nestjs/jwt'
+import { PassportModule, PassportStrategy } from '@nestjs/passport'
+import { ExtractJwt, Strategy } from 'passport-jwt'
+import request from 'supertest'
+import { AppController } from '../src/app.controller'
+import { AppService } from '../src/app.service'
+
+class TestJWTStrategy extends PassportStrategy(Strategy) {
+        constructor() {
+                super({
+                        jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+                        secretOrKey: 'test'
+                })
+        }
+
+        async validate(payload: any) {
+                return payload
+        }
+}
 
 describe('AppController (e2e)', () => {
-  let app: INestApplication<App>;
+        let app: INestApplication
 
-  beforeEach(async () => {
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
-    }).compile();
+        beforeAll(async () => {
+                const moduleFixture: TestingModule = await Test.createTestingModule({
+                        imports: [
+                                PassportModule.register({ defaultStrategy: 'jwt' }),
+                                JwtModule.register({ secret: 'test' })
+                        ],
+                        controllers: [AppController],
+                        providers: [AppService, TestJWTStrategy]
+                }).compile()
 
-    app = moduleFixture.createNestApplication();
-    await app.init();
-  });
+                app = moduleFixture.createNestApplication()
+                await app.init()
+        })
 
-  it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
-      .expect(200)
-      .expect('Hello World!');
-  });
-});
+        it('GET / without token returns 401', () => {
+                return request(app.getHttpServer()).get('/').expect(401)
+        })
+})
+


### PR DESCRIPTION
## Summary
- enable Passport JWT guard in app and auth modules
- protect controllers with `AuthGuard('jwt')`
- add e2e test for unauthorized requests

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689496a366b08329a617a40142f44af9