### PR TITLE
fix: add placeholder pages for quick action links

### DIFF
--- a/dashboard-ui/app/products/receipt/page.tsx
+++ b/dashboard-ui/app/products/receipt/page.tsx
@@ -1,0 +1,14 @@
+import Layout from '@/ui/Layout'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Product Receipt',
+}
+
+export default function ProductReceiptPage() {
+  return (
+    <Layout>
+      <div>Приход товара</div>
+    </Layout>
+  )
+}

--- a/dashboard-ui/app/reports/new/page.tsx
+++ b/dashboard-ui/app/reports/new/page.tsx
@@ -1,0 +1,14 @@
+import Layout from '@/ui/Layout'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'New Report',
+}
+
+export default function NewReportPage() {
+  return (
+    <Layout>
+      <div>Новый отчёт</div>
+    </Layout>
+  )
+}


### PR DESCRIPTION
## Summary
- add `/reports/new` page
- add `/products/receipt` page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid Options: useEslintrc...)*
- `curl -I http://localhost:3001/reports/new`
- `curl -I http://localhost:3001/products/receipt`


------
https://chatgpt.com/codex/tasks/task_e_689496c2df948329a682540eaa1f649d