### PR TITLE
refactor: drop unused report category

### DIFF
--- a/dashboard-ui/app/shared/interfaces/reports.interface.ts
+++ b/dashboard-ui/app/shared/interfaces/reports.interface.ts
@@ -1,7 +1,6 @@
 export interface IReports {
   id: number
   name: string
-  category: string
 }
 
 export interface IReportHistory {


### PR DESCRIPTION
## Summary
- remove `category` field from reports interface

## Testing
- `npm run build --prefix dashboard-ui` *(fails: Module not found, TextArea css, missing interceptors, client hooks)*
- `npm run build --prefix server` *(fails: TS4053 cannot name GeneratedReport in controller)*

------
https://chatgpt.com/codex/tasks/task_e_689496d4f59083299b2acd5af7644bf5