### PR TITLE
feat(report): persist reports with sequelize

### DIFF
--- a/server/src/report/report.migration.ts
+++ b/server/src/report/report.migration.ts
@@ -1,0 +1,38 @@
+import { QueryInterface, DataTypes } from 'sequelize'
+
+export async function up(queryInterface: QueryInterface): Promise<void> {
+        await queryInterface.createTable('Report', {
+                id: {
+                        type: DataTypes.INTEGER,
+                        autoIncrement: true,
+                        primaryKey: true
+                },
+                type: {
+                        type: DataTypes.STRING,
+                        allowNull: false
+                },
+                params: {
+                        type: DataTypes.JSONB,
+                        allowNull: true
+                },
+                data: {
+                        type: DataTypes.JSONB,
+                        allowNull: true
+                },
+                created_at: {
+                        type: DataTypes.DATE,
+                        allowNull: false,
+                        defaultValue: DataTypes.NOW
+                },
+                updated_at: {
+                        type: DataTypes.DATE,
+                        allowNull: false,
+                        defaultValue: DataTypes.NOW
+                }
+        })
+}
+
+export async function down(queryInterface: QueryInterface): Promise<void> {
+        await queryInterface.dropTable('Report')
+}
+

--- a/server/src/report/report.model.ts
+++ b/server/src/report/report.model.ts
@@ -1,0 +1,14 @@
+import { Column, DataType, Model, Table } from 'sequelize-typescript'
+
+@Table({ tableName: 'Report', deletedAt: false, version: false })
+export class ReportModel extends Model {
+        @Column({ type: DataType.STRING })
+        type: string
+
+        @Column({ type: DataType.JSONB })
+        params: any
+
+        @Column({ type: DataType.JSONB })
+        data: any
+}
+

--- a/server/src/report/report.module.ts
+++ b/server/src/report/report.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
 import { ReportController } from './report.controller'
 import { ReportService } from './report.service'
+import { ReportModel } from './report.model'
 
 @Module({
+        imports: [SequelizeModule.forFeature([ReportModel])],
         controllers: [ReportController],
         providers: [ReportService]
 })
 export class ReportModule {}
+

--- a/server/src/report/report.service.ts
+++ b/server/src/report/report.service.ts
@@ -1,17 +1,13 @@
 import { Injectable } from '@nestjs/common'
-
-interface GeneratedReport {
-        id: number
-        type: string
-        params: any
-        data: any
-        createdAt: Date
-}
+import { InjectModel } from '@nestjs/sequelize'
+import { ReportModel } from './report.model'
 
 @Injectable()
 export class ReportService {
-        private reports: GeneratedReport[] = []
-        private counter = 1
+        constructor(
+                @InjectModel(ReportModel)
+                private reportRepo: typeof ReportModel
+        ) {}
 
         getAvailable() {
                 return [
@@ -21,23 +17,24 @@ export class ReportService {
                 ]
         }
 
-        generate(type: string, params: any) {
-                const report: GeneratedReport = {
-                        id: this.counter++,
+        async generate(type: string, params: any) {
+                return this.reportRepo.create({
                         type,
                         params,
-                        data: { message: `data for ${type}` },
-                        createdAt: new Date()
-                }
-                this.reports.push(report)
-                return report
+                        data: { message: `data for ${type}` }
+                })
         }
 
         getHistory() {
-                return this.reports
+                return this.reportRepo.findAll()
         }
 
-        export(id: number, format: string) {
+        async export(id: number, format: string) {
+                const report = await this.reportRepo.findByPk(id)
+                if (!report) {
+                        return { message: `Report ${id} not found` }
+                }
                 return { message: `Report ${id} exported to ${format}` }
         }
 }
+


### PR DESCRIPTION
## Summary
- add Sequelize model and migration for Report
- wire Report module with Sequelize and store generated reports in DB

## Testing
- `npm test --prefix server`
- `npm run lint --prefix server` *(fails: Key "rules": Key "@typescript-eslint/no-extraneous-class"...)*


------
https://chatgpt.com/codex/tasks/task_e_689496f5dfb08329ac6991b7db246229