### PR TITLE
refactor: use authenticated axios instance in services

### DIFF
--- a/dashboard-ui/app/services/product/product.service.ts
+++ b/dashboard-ui/app/services/product/product.service.ts
@@ -1,4 +1,4 @@
-import { axiosClassic } from '@/api/interceptor'
+import axios from '../../api/interceptor'
 import { IProduct } from '@/shared/interfaces/product.interface'
 
 // Сервис для взаимодействия с продуктами склада
@@ -8,7 +8,7 @@ export const ProductService = {
    * Получение всех продуктов со склада.
    */
   async getAll() {
-    const response = await axiosClassic.get<IProduct[]>('/products')
+    const response = await axios.get<IProduct[]>('/products')
     return response.data
   },
 
@@ -17,7 +17,7 @@ export const ProductService = {
    * Получение одного продукта по ID.
    */
   async getById(id: number) {
-    const response = await axiosClassic.get<IProduct>(`/products/${id}`)
+    const response = await axios.get<IProduct>(`/products/${id}`)
     return response.data
   },
 
@@ -26,7 +26,7 @@ export const ProductService = {
    * Создание нового продукта.
    */
   async create(data: Omit<IProduct, 'id'>) {
-    const response = await axiosClassic.post<IProduct>('/products', data)
+    const response = await axios.post<IProduct>('/products', data)
     return response.data
   },
 
@@ -35,7 +35,7 @@ export const ProductService = {
    * Обновление данных продукта.
    */
   async update(id: number, data: Partial<IProduct>) {
-    const response = await axiosClassic.put<IProduct>(`/products/${id}`, data)
+    const response = await axios.put<IProduct>(`/products/${id}`, data)
     return response.data
   },
 
@@ -44,7 +44,7 @@ export const ProductService = {
    * Удаление продукта.
    */
   async delete(id: number) {
-    await axiosClassic.delete(`/products/${id}`)
+    await axios.delete(`/products/${id}`)
   },
 
   /**
@@ -52,7 +52,7 @@ export const ProductService = {
    * Увеличение остатка (приход на склад).
    */
   async addStock(id: number, qty: number) {
-    const response = await axiosClassic.post(`/products/${id}/stock`, { qty })
+    const response = await axios.post(`/products/${id}/stock`, { qty })
     return response.data
   },
 }

--- a/dashboard-ui/app/services/report/report.service.ts
+++ b/dashboard-ui/app/services/report/report.service.ts
@@ -1,4 +1,4 @@
-import { axiosClassic } from '@/api/interceptor'
+import axios from '../../api/interceptor'
 
 export const ReportService = {
   /**
@@ -6,7 +6,7 @@ export const ReportService = {
    * Список доступных отчётов.
    */
   async getAvailable() {
-    const response = await axiosClassic.get('/reports')
+    const response = await axios.get('/reports')
     return response.data
   },
 
@@ -15,7 +15,7 @@ export const ReportService = {
    * Генерация отчёта по переданным параметрам.
    */
   async generate(data: any) {
-    const response = await axiosClassic.post('/reports/generate', data)
+    const response = await axios.post('/reports/generate', data)
     return response.data
   },
 
@@ -24,7 +24,7 @@ export const ReportService = {
    * История сгенерированных отчётов.
    */
   async getHistory() {
-    const response = await axiosClassic.get('/reports/history')
+    const response = await axios.get('/reports/history')
     return response.data
   },
 
@@ -33,7 +33,7 @@ export const ReportService = {
    * Выгрузка отчёта в указанном формате (pdf, excel).
    */
   async export(id: number, format: string) {
-    const response = await axiosClassic.get(`/reports/${id}/export/${format}`, {
+    const response = await axios.get(`/reports/${id}/export/${format}`, {
       responseType: 'blob',
     })
     return response.data

--- a/dashboard-ui/app/services/task/task.service.ts
+++ b/dashboard-ui/app/services/task/task.service.ts
@@ -1,4 +1,4 @@
-import { axiosClassic } from '@/api/interceptor'
+import axios from '../../api/interceptor'
 import { ITask } from '@/shared/interfaces/task.interface'
 
 export const TaskService = {
@@ -7,7 +7,7 @@ export const TaskService = {
    * Получение всех задач.
    */
   async getAll() {
-    const response = await axiosClassic.get<ITask[]>('/task')
+    const response = await axios.get<ITask[]>('/task')
     return response.data
   },
 
@@ -16,7 +16,7 @@ export const TaskService = {
    * Получение одной задачи по идентификатору.
    */
   async getById(id: string | number) {
-    const response = await axiosClassic.get<ITask>(`/task/${id}`)
+    const response = await axios.get<ITask>(`/task/${id}`)
     return response.data
   },
 
@@ -25,7 +25,7 @@ export const TaskService = {
    * Создание новой задачи.
    */
   async create(data: Omit<ITask, 'id'>) {
-    const response = await axiosClassic.post<ITask>('/task', data)
+    const response = await axios.post<ITask>('/task', data)
     return response.data
   },
 
@@ -34,7 +34,7 @@ export const TaskService = {
    * Обновление существующей задачи.
    */
   async update(id: string | number, data: Partial<ITask>) {
-    const response = await axiosClassic.put<ITask>(`/task/${id}`, data)
+    const response = await axios.put<ITask>(`/task/${id}`, data)
     return response.data
   },
 
@@ -43,6 +43,6 @@ export const TaskService = {
    * Удаление задачи.
    */
   async delete(id: number) {
-    await axiosClassic.delete(`/task/${id}`)
+    await axios.delete(`/task/${id}`)
   },
 }


### PR DESCRIPTION
## Summary
- use default axios instance with interceptor for product, report, and task services

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint --prefix dashboard-ui` (fails: Invalid Options - Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)
- `npm run build --prefix dashboard-ui` (fails: Module not found: Can't resolve './text-area.module.css')

------
https://chatgpt.com/codex/tasks/task_e_6894a1bf00c083298994e36c384c91e4