### PR TITLE
feat: support category name

### DIFF
--- a/dashboard-ui/app/components/products/ProductDetails.tsx
+++ b/dashboard-ui/app/components/products/ProductDetails.tsx
@@ -21,7 +21,12 @@ const ProductDetails: FC<Props> = ({ product, onClose }) => {
       </div>
       <div className="space-y-1 text-sm">
         <p>Article: {product.articleNumber}</p>
-        <p>Category ID: {product.categoryId}</p>
+        <p>
+          Category:{' '}
+          {product.category?.name ||
+            product.categoryName ||
+            (product.categoryId !== undefined ? product.categoryId : 'N/A')}
+        </p>
         <p>Purchase price: ${product.purchasePrice}</p>
         <p>Sale price: ${product.salePrice}</p>
         <p>Remains: {product.remains}</p>

--- a/dashboard-ui/app/components/products/ProductForm.tsx
+++ b/dashboard-ui/app/components/products/ProductForm.tsx
@@ -26,7 +26,8 @@ const ProductForm = ({ product, onSuccess, onCancel }: Props) => {
   } = useForm<ProductFormData>({
     defaultValues: {
       name: product?.name || '',
-      categoryId: product?.categoryId ?? 0,
+      categoryId: product?.categoryId,
+      categoryName: product?.category?.name || '',
       articleNumber: product?.articleNumber || '',
       purchasePrice: product?.purchasePrice ?? 0,
       salePrice: product?.salePrice ?? 0,
@@ -57,9 +58,18 @@ const ProductForm = ({ product, onSuccess, onCancel }: Props) => {
       />
       <Field
         type="number"
-        {...register('categoryId', { valueAsNumber: true })}
+        {...register('categoryId', {
+          setValueAs: v => (v === '' ? undefined : Number(v)),
+        })}
         placeholder="Category ID"
         error={errors.categoryId}
+      />
+      <Field
+        {...register('categoryName', {
+          setValueAs: v => (v === '' ? undefined : v),
+        })}
+        placeholder="Category name"
+        error={errors.categoryName}
       />
       <Field
         {...register('articleNumber', { required: 'Enter article number' })}

--- a/dashboard-ui/app/components/products/ProductsTable.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.tsx
@@ -21,12 +21,12 @@ const ProductsTable = () => {
   }, [])
 
   const categories = Array.from(
-    new Set(products.map(p => p.category?.name || ''))
+    new Set(products.map(p => p.category?.name || p.categoryName || ''))
   )
 
   const filtered = products.filter(p =>
     p.name.toLowerCase().includes(search.toLowerCase()) &&
-    (!category || p.category?.name === category)
+    (!category || (p.category?.name || p.categoryName) === category)
   )
 
   const isLow = (balance: number) => balance <= 5
@@ -102,7 +102,7 @@ const ProductsTable = () => {
               className={`cursor-pointer border-b border-neutral-200 hover:bg-neutral-200 ${isLow(prod.remains) ? 'bg-warning/20' : ''}`}
             >
               <td className="p-2">{prod.name}</td>
-              <td className="p-2">{prod.category?.name || '-'}</td>
+              <td className="p-2">{prod.category?.name || prod.categoryName || '-'}</td>
               <td className="p-2">
                 {prod.remains}
                 {isLow(prod.remains) && (

--- a/dashboard-ui/app/services/product/product.service.ts
+++ b/dashboard-ui/app/services/product/product.service.ts
@@ -25,8 +25,22 @@ export const ProductService = {
    * POST /products
    * Создание нового продукта.
    */
-  async create(data: Omit<IProduct, 'id'>) {
-    const response = await axiosClassic.post<IProduct>('/products', data)
+  async create(
+    data: Omit<IProduct, 'id' | 'category'> & {
+      categoryId?: number
+      categoryName?: string
+    }
+  ) {
+    const payload: Record<string, any> = {
+      name: data.name,
+      articleNumber: data.articleNumber,
+      purchasePrice: data.purchasePrice,
+      salePrice: data.salePrice,
+      remains: data.remains,
+    }
+    if (data.categoryId !== undefined) payload.categoryId = data.categoryId
+    if (data.categoryName !== undefined) payload.categoryName = data.categoryName
+    const response = await axiosClassic.post<IProduct>('/products', payload)
     return response.data
   },
 

--- a/dashboard-ui/app/shared/interfaces/product.interface.ts
+++ b/dashboard-ui/app/shared/interfaces/product.interface.ts
@@ -13,7 +13,8 @@ import { ICategory } from './category.interface'
 export interface IProduct {
   id: number
   name: string
-  categoryId: number
+  categoryId?: number
+  categoryName?: string
   articleNumber: string
   purchasePrice: number
   salePrice: number


### PR DESCRIPTION
## Summary
- allow providing category by ID or name on product creation
- expose optional category name in product interfaces
- show category names in product form, table and details

## Testing
- `npm run lint --prefix dashboard-ui` *(fails: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_6894a1f04cfc832999d8f8371637a5d3