### PR TITLE
feat(report): add typed dto for report generation

### DIFF
--- a/server/src/report/dto/generate-report.dto.ts
+++ b/server/src/report/dto/generate-report.dto.ts
@@ -1,4 +1,27 @@
+import { IsDateString, IsEnum, IsOptional, ValidateNested } from 'class-validator'
+import { Type } from 'class-transformer'
+
+export enum ReportType {
+        SALES = 'sales',
+        INVENTORY_BALANCES = 'inventory balances',
+        TASK_EFFICIENCY = 'task efficiency'
+}
+
+export class ReportParamsDto {
+        @IsOptional()
+        @IsDateString()
+        startDate?: string
+
+        @IsOptional()
+        @IsDateString()
+        endDate?: string
+}
+
 export class GenerateReportDto {
-        type: string
-        params: any
+        @IsEnum(ReportType)
+        type: ReportType
+
+        @ValidateNested()
+        @Type(() => ReportParamsDto)
+        params: ReportParamsDto
 }

--- a/server/src/report/report.controller.ts
+++ b/server/src/report/report.controller.ts
@@ -5,7 +5,8 @@ import {
         Param,
         ParseIntPipe,
         Post,
-        UseGuards
+        UseGuards,
+        ValidationPipe
 } from '@nestjs/common'
 import { AuthGuard } from '@nestjs/passport'
 import { ReportService } from './report.service'
@@ -22,8 +23,8 @@ export class ReportController {
         }
 
         @Post('generate')
-        generate(@Body() dto: GenerateReportDto) {
-                return this.reportService.generate(dto.type, dto.params)
+        generate(@Body(new ValidationPipe()) dto: GenerateReportDto) {
+                return this.reportService.generate(dto)
         }
 
         @Get('history')

--- a/server/src/report/report.service.ts
+++ b/server/src/report/report.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
 import { ReportModel } from './report.model'
+import { GenerateReportDto } from './dto/generate-report.dto'
 
 @Injectable()
 export class ReportService {
@@ -17,7 +18,7 @@ export class ReportService {
                 ]
         }
 
-        async generate(type: string, params: any) {
+        async generate({ type, params }: GenerateReportDto) {
                 return this.reportRepo.create({
                         type,
                         params,
@@ -37,4 +38,3 @@ export class ReportService {
                 return { message: `Report ${id} exported to ${format}` }
         }
 }
-


### PR DESCRIPTION
## Summary
- add ReportType enum and params schema for generating reports
- validate report generation body with DTO and ValidationPipe
- accept GenerateReportDto in report service

## Testing
- `npm test`
- `npm run lint` *(fails: Key "@typescript-eslint/no-extraneous-class" should NOT have additional properties)*


------
https://chatgpt.com/codex/tasks/task_e_6894a1f4beb48329b5bc05a7bcdaad75