### PR TITLE
Align frontend models with backend and clarify forms

### DIFF
--- a/dashboard-ui/app/components/tasks/TaskForm.tsx
+++ b/dashboard-ui/app/components/tasks/TaskForm.tsx
@@ -60,27 +60,36 @@ const TaskForm = ({ task }: Props) => {
         {...register('executor')}
         placeholder="Исполнитель"
       />
-      <Field type="date" {...register('deadline', { required: true })} />
-      <select
-        {...register('priority')}
-        className="border border-neutral-300 rounded px-2 py-1 w-full"
-      >
-        {Object.values(TaskPriority).map(p => (
-          <option key={p} value={p}>
-            {p}
-          </option>
-        ))}
-      </select>
-      <select
-        {...register('status')}
-        className="border border-neutral-300 rounded px-2 py-1 w-full"
-      >
-        {Object.values(TaskStatus).map(s => (
-          <option key={s} value={s}>
-            {s}
-          </option>
-        ))}
-      </select>
+      <div>
+        <label className="block mb-1">Дедлайн</label>
+        <Field type="date" {...register('deadline', { required: true })} />
+      </div>
+      <div>
+        <label className="block mb-1">Приоритет</label>
+        <select
+          {...register('priority')}
+          className="border border-neutral-300 rounded px-2 py-1 w-full"
+        >
+          {Object.values(TaskPriority).map(p => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="block mb-1">Статус</label>
+        <select
+          {...register('status')}
+          className="border border-neutral-300 rounded px-2 py-1 w-full"
+        >
+          {Object.values(TaskStatus).map(s => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
       <Button
         type="submit"
         className="bg-primary-500 text-white px-4 py-1"

--- a/dashboard-ui/app/reports/page.tsx
+++ b/dashboard-ui/app/reports/page.tsx
@@ -71,18 +71,24 @@ export default function ReportsPage() {
         <div className="space-y-2">
           <h3 className="text-lg font-medium">Параметры</h3>
           <div className="flex flex-wrap gap-2">
-            <input
-              type="date"
-              value={start}
-              onChange={e => setStart(e.target.value)}
-              className="border border-neutral-300 rounded px-2 py-1"
-            />
-            <input
-              type="date"
-              value={end}
-              onChange={e => setEnd(e.target.value)}
-              className="border border-neutral-300 rounded px-2 py-1"
-            />
+            <label className="flex flex-col">
+              <span className="text-sm">Start date</span>
+              <input
+                type="date"
+                value={start}
+                onChange={e => setStart(e.target.value)}
+                className="border border-neutral-300 rounded px-2 py-1"
+              />
+            </label>
+            <label className="flex flex-col">
+              <span className="text-sm">End date</span>
+              <input
+                type="date"
+                value={end}
+                onChange={e => setEnd(e.target.value)}
+                className="border border-neutral-300 rounded px-2 py-1"
+              />
+            </label>
             <input
               placeholder="Product"
               value={product}

--- a/dashboard-ui/app/shared/interfaces/sale.interface.ts
+++ b/dashboard-ui/app/shared/interfaces/sale.interface.ts
@@ -2,16 +2,17 @@ import { IProduct } from '@/shared/interfaces/product.interface'
 
 /*
 Модель продажи
-saleDate - дата продажи
+saleDate - дата продажи в формате строки
 productId - id продукта
+product - связанный продукт (может быть опционален)
 quantitySold - количество проданного
 totalPrice - сумма продажи
-* */
+*/
 export interface ISale {
   id: number
-  saleDate: Date
+  saleDate: string
   productId: number
-  product: IProduct
+  product?: IProduct
   quantitySold: number
   totalPrice: number
 }

--- a/dashboard-ui/app/shared/interfaces/task.interface.ts
+++ b/dashboard-ui/app/shared/interfaces/task.interface.ts
@@ -1,9 +1,12 @@
 /*
 Модель задачи
-deadline - срок выполнения
+title - заголовок задачи
 description - описание задачи
+executor - исполнитель задачи
+deadline - срок выполнения
 status - статус задачи
-* */
+priority - приоритет выполнения
+*/
 export enum TaskStatus {
   Pending = 'Ожидает',
   InProgress = 'Выполняется',


### PR DESCRIPTION
## Summary
- Match sale interface to backend by using string sale dates and optional related product
- Document task interface fields and show labels for deadline, priority, and status in task form
- Add labels for report date filters to clarify their purpose

## Testing
- `npm test --prefix server`
- `npm run lint --prefix dashboard-ui` *(fails: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_6895bb3ac8d883299eb7b825be575fb8