### PR TITLE
docs: describe API integration and handle auth token expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,34 @@ access the API at `NEXT_PUBLIC_API_URL` without cross-origin issues.
 
 The root `npm run dev` command launches both the NestJS server and the Next.js
 frontend in watch mode for development.
+
+### Integration points
+
+Each UI action results in a REST call:
+
+| Module      | Frontend sends                               | Backend responds with            |
+|-------------|----------------------------------------------|----------------------------------|
+| Auth        | `POST /auth/login` `{ email, password }`     | user data + JWT tokens           |
+| Products    | `GET/POST/PUT/DELETE /products`              | list of products / updated item  |
+| Tasks       | `GET/POST/PUT/DELETE /task`                  | task entities                    |
+| Reports     | `POST /reports/generate` report params       | generated report, history list   |
+
+Errors returned by the API are converted to human readable messages inside
+`app/api/interceptor.ts`. For example, a 401 response clears stored tokens so the
+user can re-authenticate.
+
+UI components update their state after successful requests. Examples:
+
+```tsx
+// delete a task and refresh table
+await TaskService.delete(id)
+setTasks(prev => prev.filter(t => t.id !== id))
+
+// create product and reload list
+await ProductService.create(data)
+ProductService.getAll().then(setProducts)
+```
+
+Configuration values such as API base URL and allowed CORS origin are supplied
+via `.env` files. Changing `NEXT_PUBLIC_API_URL` or `CLIENT_URL` is enough to point
+the apps to a different backend or frontend without touching the code.

--- a/dashboard-ui/app/api/interceptor.ts
+++ b/dashboard-ui/app/api/interceptor.ts
@@ -1,5 +1,7 @@
 import axios from 'axios'
 import Cookies from 'js-cookie'
+// Удаляет access token из cookies при разлогине или истечении сессии
+import { removeTokenFromStorage } from '@/services/auth/auth.helper'
 
 /**
  * Функция возвращает стандартные заголовки для запросов.
@@ -59,6 +61,12 @@ instance.interceptors.request.use(config => {
 instance.interceptors.response.use(
   response => response,
   error => {
+    // Если бекенд вернул 401 — токен недействителен, удаляем его
+    if (error.response?.status === 401) {
+      removeTokenFromStorage()
+    }
+
+    // Формируем понятное сообщение об ошибке для UI
     const message = error?.response?.data?.message || error.message
     return Promise.reject(new Error(message))
   }

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -9,15 +9,18 @@ async function bootstrap() {
         console.log('> BOOTSTRAP: создан app')
 
         // Разрешаем запросы с фронтенда.
-        // URL фронта задаётся через переменную окружения CLIENT_URL
+        // URL фронта задаётся через переменную окружения CLIENT_URL,
+        // что позволяет легко менять адрес, не перекомпилируя приложение.
         const config = app.get(ConfigService)
         const clientUrl = config.get<string>('CLIENT_URL', 'http://localhost:3000')
 
-        // Настройка CORS, чтобы фронтенд мог обращаться к бекенду без ошибок
+        // Настройка CORS, чтобы фронтенд мог обращаться к бекенду без ошибок.
+        // credentials:true позволяет отправлять cookie (например, JWT токен).
         app.enableCors({
                 origin: clientUrl,
                 credentials: true
         })
+        console.log(`> BOOTSTRAP: CORS configured for ${clientUrl}`)
 
         // Устанавливаем глобальный префикс для всех маршрутов
         app.setGlobalPrefix('api')


### PR DESCRIPTION
## Summary
- document frontend↔backend integration points and configuration
- clear auth tokens on 401 responses in axios interceptor
- clarify CORS setup in NestJS bootstrap

## Testing
- `npm test --prefix server`
- `npm run lint --prefix dashboard-ui` *(fails: Unknown options in ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6895c78cb16c8329ab6add61d0e91ce2