### PR TITLE
Ensure frontend connects to backend and label product fields

### DIFF
--- a/dashboard-ui/app/api/interceptor.ts
+++ b/dashboard-ui/app/api/interceptor.ts
@@ -17,7 +17,7 @@ export const getContentType = () => ({
  * знал адрес бекенда при сборке.
  * Пример: http://localhost:4000/api
  */
-export const API_URL = `${process.env.NEXT_PUBLIC_API_URL}/api`
+export const API_URL = `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000'}/api`
 
 /**
  * Экземпляр Axios без авторизации.

--- a/dashboard-ui/app/components/products/ProductForm.tsx
+++ b/dashboard-ui/app/components/products/ProductForm.tsx
@@ -53,35 +53,41 @@ const ProductForm = ({ product, onSuccess, onCancel }: Props) => {
       <Field
         {...register('name', { required: 'Enter name' })}
         placeholder="Name"
+        label="Name"
         error={errors.name}
       />
       <Field
         type="number"
         {...register('categoryId', { valueAsNumber: true })}
         placeholder="Category ID"
+        label="Category ID"
         error={errors.categoryId}
       />
       <Field
         {...register('articleNumber', { required: 'Enter article number' })}
         placeholder="Article number"
+        label="Article number"
         error={errors.articleNumber}
       />
       <Field
         type="number"
         {...register('purchasePrice', { valueAsNumber: true })}
         placeholder="Purchase price"
+        label="Purchase price"
         error={errors.purchasePrice}
       />
       <Field
         type="number"
         {...register('salePrice', { valueAsNumber: true })}
         placeholder="Sale price"
+        label="Sale price"
         error={errors.salePrice}
       />
       <Field
         type="number"
         {...register('remains', { valueAsNumber: true })}
         placeholder="Remains"
+        label="Remains"
         error={errors.remains}
       />
       <div className="flex space-x-2">

--- a/dashboard-ui/app/components/ui/Field/Field.module.scss
+++ b/dashboard-ui/app/components/ui/Field/Field.module.scss
@@ -3,6 +3,10 @@
 .field {
   @apply py-2;
 
+  .label {
+    @apply block mb-1 text-sm font-medium text-neutral-700;
+  }
+
   input {
     @apply bg-neutral-50 font-medium text-lg rounded-lg;
     @include shadow('md');

--- a/dashboard-ui/app/components/ui/Field/Field.tsx
+++ b/dashboard-ui/app/components/ui/Field/Field.tsx
@@ -5,9 +5,10 @@ import {IField} from "@/ui/Field/field.interface";
 
 
 const Field = forwardRef<HTMLInputElement, IField>(
-    ({error, type = 'text', style, ...rest}, ref) => {
+    ({ error, label, type = 'text', style, ...rest }, ref) => {
         return (
             <div className={styles.field} style={style}>
+                {label && <label className={styles.label}>{label}</label>}
                 <input className={styles.input} ref={ref} type={type} {...rest} />
                 {error && <div className={styles.error}>{error.message}</div>}
             </div>

--- a/dashboard-ui/app/components/ui/Field/field.interface.ts
+++ b/dashboard-ui/app/components/ui/Field/field.interface.ts
@@ -4,6 +4,7 @@ import {InputHTMLAttributes} from "react";
 
 export interface IFieldProps {
     error?: FieldError | undefined
+    label?: string
 }
 
 type TypeInputPropsField = InputHTMLAttributes<HTMLInputElement> & IFieldProps


### PR DESCRIPTION
## Summary
- Provide a default API base URL so the frontend can talk to the backend when `NEXT_PUBLIC_API_URL` is not set
- Add labels to product form fields via an enhanced reusable Field component

## Testing
- `cd dashboard-ui && npm test`
- `cd ../server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895e7df30088329acd47742ba47e20a