### PR TITLE
fix: translate report page and textarea styling

### DIFF
--- a/dashboard-ui/app/components/ui/TextArea/TextArea.module.scss
+++ b/dashboard-ui/app/components/ui/TextArea/TextArea.module.scss
@@ -1,0 +1,27 @@
+@use "../../../assets/styles/mixins" as *;
+
+.editor {
+  @apply py-2;
+
+  .textarea {
+    @apply bg-neutral-50 font-medium text-lg rounded-lg w-full;
+    @include shadow('md');
+    height: 6rem;
+    padding: 1rem;
+    outline: none;
+
+    &::placeholder {
+      color: #b8b09e;
+    }
+
+    &:focus {
+      @apply focus:border-neutral-600 focus:ring-2 focus:ring-inset focus:ring-neutral-600;
+    }
+  }
+
+  .error {
+    @apply p-1 text-neutral-900;
+    font-size: 0.75rem;
+  }
+}
+

--- a/dashboard-ui/app/components/ui/TextArea/TextArea.tsx
+++ b/dashboard-ui/app/components/ui/TextArea/TextArea.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from "react";
-import styles from "./text-area.module.css";
+import styles from "./TextArea.module.scss";
 import {ITextArea} from "@/ui/TextArea/text-area-interface";
 
 
 const TextArea = forwardRef<HTMLTextAreaElement, ITextArea>(
     ({ error, style, ...rest }, ref) => {
         return (
-            <div className={styles['editor']}  style={style}>
-                <textarea ref={ref} {...rest}/>
+            <div className={styles.editor} style={style}>
+                <textarea className={styles.textarea} ref={ref} {...rest} />
                 {error && <div className={styles.error}>{error}</div>}
             </div>
         )

--- a/dashboard-ui/app/reports/page.tsx
+++ b/dashboard-ui/app/reports/page.tsx
@@ -61,10 +61,11 @@ export default function ReportsPage() {
             ))}
           </ul>
           <Button
+            type="button"
             className="mt-2 bg-primary-500 text-white px-4 py-1"
             onClick={generate}
           >
-            Generate a new report
+            Создать отчёт
           </Button>
         </div>
 
@@ -72,7 +73,7 @@ export default function ReportsPage() {
           <h3 className="text-lg font-medium">Параметры</h3>
           <div className="flex flex-wrap gap-2">
             <label className="flex flex-col">
-              <span className="text-sm">Start date</span>
+              <span className="text-sm">Дата начала</span>
               <input
                 type="date"
                 value={start}
@@ -81,7 +82,7 @@ export default function ReportsPage() {
               />
             </label>
             <label className="flex flex-col">
-              <span className="text-sm">End date</span>
+              <span className="text-sm">Дата окончания</span>
               <input
                 type="date"
                 value={end}
@@ -89,18 +90,22 @@ export default function ReportsPage() {
                 className="border border-neutral-300 rounded px-2 py-1"
               />
             </label>
-            <input
-              placeholder="Product"
-              value={product}
-              onChange={e => setProduct(e.target.value)}
-              className="border border-neutral-300 rounded px-2 py-1"
-            />
-            <input
-              placeholder="Employee"
-              value={employee}
-              onChange={e => setEmployee(e.target.value)}
-              className="border border-neutral-300 rounded px-2 py-1"
-            />
+            <label className="flex flex-col">
+              <span className="text-sm">Продукт</span>
+              <input
+                value={product}
+                onChange={e => setProduct(e.target.value)}
+                className="border border-neutral-300 rounded px-2 py-1"
+              />
+            </label>
+            <label className="flex flex-col">
+              <span className="text-sm">Сотрудник</span>
+              <input
+                value={employee}
+                onChange={e => setEmployee(e.target.value)}
+                className="border border-neutral-300 rounded px-2 py-1"
+              />
+            </label>
           </div>
         </div>
 
@@ -117,16 +122,18 @@ export default function ReportsPage() {
             </table>
             <div className="flex space-x-2">
               <Button
+                type="button"
                 className="bg-primary-500 text-white px-4 py-1"
                 onClick={() => exportReport('pdf')}
               >
-                Export to PDF
+                Экспорт в PDF
               </Button>
               <Button
+                type="button"
                 className="bg-primary-500 text-white px-4 py-1"
                 onClick={() => exportReport('excel')}
               >
-                Export to Excel
+                Экспорт в Excel
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- translate report generation page to Russian and align form fields
- style textarea to match other inputs

## Testing
- `cd dashboard-ui && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899999e17c48329aa41628c16572358