### PR TITLE
Show top selling products and fix quick action links

### DIFF
--- a/dashboard-ui/app/components/home/QuickActions.tsx
+++ b/dashboard-ui/app/components/home/QuickActions.tsx
@@ -1,19 +1,16 @@
+"use client";
+
 import React from "react";
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 import Button from "@/ui/Button/Button";
 
 const QuickActions = () => {
+    const router = useRouter();
     return (
         <div className="flex flex-col sm:flex-row gap-4">
-            <Link href="/tasks/new">
-                <Button className="w-full">Добавить задачу</Button>
-            </Link>
-            <Link href="/reports/new">
-                <Button className="w-full">Создать отчёт</Button>
-            </Link>
-            <Link href="/products/receipt">
-                <Button className="w-full">Приход товара</Button>
-            </Link>
+            <Button className="w-full" onClick={() => router.push("/tasks/new")}>Добавить задачу</Button>
+            <Button className="w-full" onClick={() => router.push("/reports/new")}>Создать отчёт</Button>
+            <Button className="w-full" onClick={() => router.push("/products/receipt")}>Приход товара</Button>
         </div>
     );
 };

--- a/dashboard-ui/app/components/home/TopProducts.tsx
+++ b/dashboard-ui/app/components/home/TopProducts.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { AnalyticsService } from '@/services/analytics/analytics.service'
+import { ITopProduct } from '@/shared/interfaces/top-product.interface'
+
+const TopProducts = () => {
+  const [items, setItems] = useState<ITopProduct[]>([])
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    AnalyticsService.getTopProducts(10)
+      .then(setItems)
+      .catch(e => setError(e.message))
+  }, [])
+
+  return (
+    <div className="bg-neutral-100 p-4 rounded-card shadow-card">
+      <div className="flex justify-between items-center mb-4">
+        <h3 className="text-lg font-semibold">Топ товаров</h3>
+        <Link href="/products/sales" className="text-sm text-primary-600">
+          Показать полностью
+        </Link>
+      </div>
+      {error && <div className="text-error text-sm mb-2">{error}</div>}
+      <ul className="divide-y divide-neutral-200">
+        {items.map(item => (
+          <li key={item.productId} className="py-2 flex justify-between text-sm">
+            <span>
+              {item.productName} ({item.categoryName})
+            </span>
+            <span>{item.totalUnits}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default TopProducts

--- a/dashboard-ui/app/page.tsx
+++ b/dashboard-ui/app/page.tsx
@@ -5,6 +5,7 @@ import Metrics from "@/components/home/Metrics";
 import SalesChart from "@/components/home/SalesChart";
 import Notifications from "@/components/home/Notifications";
 import QuickActions from "@/components/home/QuickActions";
+import TopProducts from "@/components/home/TopProducts";
 
 export const metadata: Metadata = {
   title: "Главная",
@@ -17,6 +18,7 @@ export default function Home() {
             <div className="space-y-8">
                 <Metrics/>
                 <SalesChart/>
+                <TopProducts/>
                 <Notifications/>
                 <QuickActions/>
             </div>

--- a/dashboard-ui/app/products/sales/page.tsx
+++ b/dashboard-ui/app/products/sales/page.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Layout from '@/ui/Layout'
+import type { Metadata } from 'next'
+import { AnalyticsService } from '@/services/analytics/analytics.service'
+import { ITopProduct } from '@/shared/interfaces/top-product.interface'
+
+export const metadata: Metadata = {
+  title: 'Статистика продаж товаров',
+}
+
+export default function ProductSalesPage() {
+  const [items, setItems] = useState<ITopProduct[]>([])
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    AnalyticsService.getTopProducts()
+      .then(setItems)
+      .catch(e => setError(e.message))
+  }, [])
+
+  return (
+    <Layout>
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold">Статистика продаж товаров</h2>
+        {error && <div className="text-error">{error}</div>}
+        <table className="min-w-full bg-neutral-100 rounded shadow-md text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="p-2">Товар</th>
+              <th className="p-2">Категория</th>
+              <th className="p-2">Продано</th>
+              <th className="p-2">Выручка</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map(item => (
+              <tr key={item.productId} className="border-t border-neutral-200">
+                <td className="p-2">{item.productName}</td>
+                <td className="p-2">{item.categoryName}</td>
+                <td className="p-2">{item.totalUnits}</td>
+                <td className="p-2">{item.totalRevenue}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Layout>
+  )
+}

--- a/dashboard-ui/app/services/analytics/analytics.service.ts
+++ b/dashboard-ui/app/services/analytics/analytics.service.ts
@@ -1,0 +1,11 @@
+import axios from '@/api/interceptor'
+import { ITopProduct } from '@/shared/interfaces/top-product.interface'
+
+export const AnalyticsService = {
+  async getTopProducts(limit?: number) {
+    const params: any = {}
+    if (limit) params.limit = limit
+    const res = await axios.get<ITopProduct[]>('/analytics/top-products', { params })
+    return res.data
+  },
+}

--- a/dashboard-ui/app/shared/interfaces/top-product.interface.ts
+++ b/dashboard-ui/app/shared/interfaces/top-product.interface.ts
@@ -1,0 +1,7 @@
+export interface ITopProduct {
+  productId: number
+  productName: string
+  categoryName: string
+  totalUnits: number
+  totalRevenue: number
+}

--- a/server/src/analytics/analytics.controller.ts
+++ b/server/src/analytics/analytics.controller.ts
@@ -4,6 +4,7 @@ import { AnalyticsService } from './analytics.service'
 import { ProductModel } from '../product/product.model'
 import { AnalyticsQueryDto } from './dto/analytics.query.dto'
 import { LowStockQueryDto } from './dto/low-stock.query.dto'
+import { TopProductsQueryDto } from './dto/top-products.query.dto'
 
 @UseGuards(AuthGuard('jwt'))
 @Controller('analytics')
@@ -42,6 +43,21 @@ export class AnalyticsController {
         ): Promise<any[]> {
                 const { startDate, endDate, categories } = query
                 return this.analyticsService.getSalesByCategories(startDate, endDate, categories)
+        }
+
+        /**
+         * Получает топ товаров по продажам.
+         *
+         * @param limit - Сколько товаров вернуть (по умолчанию 10)
+         * @param categories - Строка с ID категорий через запятую
+         */
+        @Get('top-products')
+        getTopProducts(
+                @Query(new ValidationPipe({ transform: true }))
+                query: TopProductsQueryDto
+        ): Promise<any[]> {
+                const { limit, startDate, endDate, categories } = query
+                return this.analyticsService.getTopProducts(limit, startDate, endDate, categories)
         }
 
 	/**

--- a/server/src/analytics/dto/top-products.query.dto.ts
+++ b/server/src/analytics/dto/top-products.query.dto.ts
@@ -1,0 +1,11 @@
+import { AnalyticsQueryDto } from './analytics.query.dto'
+import { Transform } from 'class-transformer'
+import { IsInt, IsOptional, Min } from 'class-validator'
+
+export class TopProductsQueryDto extends AnalyticsQueryDto {
+  @IsOptional()
+  @Transform(({ value }) => (value !== undefined ? parseInt(value, 10) : undefined))
+  @IsInt()
+  @Min(1)
+  limit?: number
+}


### PR DESCRIPTION
## Summary
- Display top 10 selling products on the home page with link to full stats
- Add backend analytics endpoint for top product sales
- Fix Quick Actions buttons for report creation and product arrival

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68999e15f9188329941dd93b23854189