### PR TITLE
feat: disallow past task deadlines

### DIFF
--- a/dashboard-ui/app/components/tasks/TaskForm.tsx
+++ b/dashboard-ui/app/components/tasks/TaskForm.tsx
@@ -62,7 +62,19 @@ const TaskForm = ({ task }: Props) => {
       />
       <div>
         <label className="block mb-1">Дедлайн</label>
-        <Field type="date" {...register('deadline', { required: true })} />
+        <Field
+          type="date"
+          min={new Date().toISOString().split('T')[0]}
+          {...register('deadline', {
+            required: 'Укажите дату',
+            validate: value => {
+              const today = new Date()
+              today.setHours(0, 0, 0, 0)
+              return new Date(value) >= today || 'Дата не может быть в прошлом'
+            },
+          })}
+          error={errors.deadline}
+        />
       </div>
       <div>
         <label className="block mb-1">Приоритет</label>

--- a/server/src/task/dto/task.dto.ts
+++ b/server/src/task/dto/task.dto.ts
@@ -6,6 +6,7 @@ import {
         IsString
 } from 'class-validator'
 import { TaskStatus, TaskPriority } from '../task.model'
+import { IsFutureDate } from '../../validators/is-future-date.decorator'
 
 export class CreateTaskDto {
 	@IsString()
@@ -16,8 +17,9 @@ export class CreateTaskDto {
 	@IsOptional()
 	description?: string
 
-	@IsDateString()
-	deadline: string
+        @IsDateString()
+        @IsFutureDate()
+        deadline: string
 
         @IsEnum(TaskStatus)
         @IsOptional()

--- a/server/src/validators/is-future-date.decorator.ts
+++ b/server/src/validators/is-future-date.decorator.ts
@@ -1,0 +1,24 @@
+import { registerDecorator, ValidationArguments, ValidationOptions } from 'class-validator'
+
+export function IsFutureDate(validationOptions?: ValidationOptions) {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'IsFutureDate',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: any) {
+          if (!value) return false
+          const date = new Date(value)
+          const today = new Date()
+          today.setHours(0, 0, 0, 0)
+          return date >= today
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} не может быть в прошлом`
+        },
+      },
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- prevent setting task deadline in the past on server
- validate and restrict past dates in the task form

## Testing
- `npm test` (server)
- `npm run lint` (server) *(fails: Key "@typescript-eslint/no-extraneous-class" Unexpected property "allowEmptyCase")*
- `npm test` (dashboard-ui)


------
https://chatgpt.com/codex/tasks/task_e_6899ad395f0c8329b3aa0dcb916a52e9