### PR TITLE
feat: add category selection by name

### DIFF
--- a/dashboard-ui/app/components/products/ProductDetails.tsx
+++ b/dashboard-ui/app/components/products/ProductDetails.tsx
@@ -21,7 +21,7 @@ const ProductDetails: FC<Props> = ({ product, onClose }) => {
       </div>
       <div className="space-y-1 text-sm">
         <p>Артикул: {product.articleNumber}</p>
-        <p>ID категории: {product.categoryId}</p>
+        <p>Категория: {product.category?.name || '-'}</p>
         <p>Закупочная цена: ${product.purchasePrice}</p>
         <p>Цена продажи: ${product.salePrice}</p>
         <p>Остаток: {product.remains}</p>

--- a/dashboard-ui/app/services/category/category.service.ts
+++ b/dashboard-ui/app/services/category/category.service.ts
@@ -1,0 +1,14 @@
+import axios from '../../api/interceptor'
+import { ICategory } from '@/shared/interfaces/category.interface'
+
+// Сервис для взаимодействия с категориями
+export const CategoryService = {
+  /**
+   * GET /category
+   * Получение всех категорий.
+   */
+  async getAll() {
+    const response = await axios.get<ICategory[]>('/category')
+    return response.data
+  },
+}

--- a/dashboard-ui/app/services/product/product.service.ts
+++ b/dashboard-ui/app/services/product/product.service.ts
@@ -1,5 +1,8 @@
 import axios from '../../api/interceptor'
-import { IProduct } from '@/shared/interfaces/product.interface'
+import {
+  IProduct,
+  IProductCreate,
+} from '@/shared/interfaces/product.interface'
 
 // Сервис для взаимодействия с продуктами склада
 export const ProductService = {
@@ -25,7 +28,7 @@ export const ProductService = {
    * POST /products
    * Создание нового продукта.
    */
-  async create(data: Omit<IProduct, 'id'>) {
+  async create(data: IProductCreate) {
     const response = await axios.post<IProduct>('/products', data)
     return response.data
   },
@@ -34,7 +37,7 @@ export const ProductService = {
    * PUT /products/:id
    * Обновление данных продукта.
    */
-  async update(id: number, data: Partial<IProduct>) {
+  async update(id: number, data: Partial<IProductCreate>) {
     const response = await axios.put<IProduct>(`/products/${id}`, data)
     return response.data
   },

--- a/dashboard-ui/app/shared/interfaces/product.interface.ts
+++ b/dashboard-ui/app/shared/interfaces/product.interface.ts
@@ -13,11 +13,20 @@ import { ICategory } from './category.interface'
 export interface IProduct {
   id: number
   name: string
-  categoryId: number
   articleNumber: string
   purchasePrice: number
   salePrice: number
   remains: number
   // Связанная категория может приходить из бэкенда
   category?: ICategory
+}
+
+// Данные для создания или обновления продукта
+export interface IProductCreate {
+  name: string
+  categoryName: string
+  articleNumber: string
+  purchasePrice: number
+  salePrice: number
+  remains: number
 }


### PR DESCRIPTION
## Summary
- allow products to choose category by name with suggestions
- fetch available categories and show in form
- support updating product category by name on backend

## Testing
- `npm test` in dashboard-ui
- `npm test` in server

------
https://chatgpt.com/codex/tasks/task_e_6899b41d237483299e572931ad29c240