### PR TITLE
feat: fetch dashboard metrics from server

### DIFF
--- a/dashboard-ui/app/components/home/Metrics.tsx
+++ b/dashboard-ui/app/components/home/Metrics.tsx
@@ -14,13 +14,23 @@ const periods = [
 
 const Metrics = () => {
   const [turnover, setTurnover] = useState<ITurnover | null>(null)
-  const [error, setError] = useState<string | null>(null)
+  const [turnoverError, setTurnoverError] = useState<string | null>(null)
+  const [stock, setStock] = useState<number | null>(null)
+  const [stockError, setStockError] = useState<string | null>(null)
+  const [openTasks, setOpenTasks] = useState<number | null>(null)
+  const [tasksError, setTasksError] = useState<string | null>(null)
   const [period, setPeriod] = useState<typeof periods[number]['key']>('day')
 
   useEffect(() => {
     AnalyticsService.getTurnover()
       .then(setTurnover)
-      .catch(e => setError(e.message))
+      .catch(e => setTurnoverError(e.message))
+    AnalyticsService.getProductRemains()
+      .then(setStock)
+      .catch(e => setStockError(e.message))
+    AnalyticsService.getOpenTasks()
+      .then(setOpenTasks)
+      .catch(e => setTasksError(e.message))
   }, [])
 
   const format = (val: number) => val.toLocaleString('ru-RU')
@@ -30,20 +40,18 @@ const Metrics = () => {
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
       <div className="bg-neutral-100 p-4 rounded-card shadow-card">
         <h3 className="text-lg font-semibold mb-2">Оборот</h3>
-        <div className="flex flex-wrap gap-2 mb-2">
+        <select
+          value={period}
+          onChange={e => setPeriod(e.target.value as typeof periods[number]['key'])}
+          className="mb-2 border border-neutral-300 rounded px-2 py-1 text-sm"
+        >
           {periods.map(p => (
-            <button
-              key={p.key}
-              onClick={() => setPeriod(p.key)}
-              className={`text-xs px-2 py-1 rounded ${
-                period === p.key ? 'bg-primary-600 text-white' : 'bg-neutral-200'
-              }`}
-            >
+            <option key={p.key} value={p.key}>
               {p.label}
-            </button>
+            </option>
           ))}
-        </div>
-        {error && <p className="text-error text-sm mb-1">{error}</p>}
+        </select>
+        {turnoverError && <p className="text-error text-sm mb-1">{turnoverError}</p>}
         <p className="text-2xl font-bold">{format(value)} ₽</p>
       </div>
       <div className="bg-neutral-100 p-4 rounded-card shadow-card">
@@ -53,11 +61,15 @@ const Metrics = () => {
       </div>
       <div className="bg-neutral-100 p-4 rounded-card shadow-card">
         <h3 className="text-lg font-semibold mb-2">Товары на складе</h3>
-        <p className="text-2xl font-bold">1 200 шт.</p>
+        {stockError && <p className="text-error text-sm mb-1">{stockError}</p>}
+        <p className="text-2xl font-bold">
+          {stock !== null ? `${format(stock)} шт.` : '-'}
+        </p>
       </div>
       <div className="bg-neutral-100 p-4 rounded-card shadow-card">
         <h3 className="text-lg font-semibold mb-2">Открытые задачи</h3>
-        <p className="text-2xl font-bold">8</p>
+        {tasksError && <p className="text-error text-sm mb-1">{tasksError}</p>}
+        <p className="text-2xl font-bold">{openTasks !== null ? openTasks : '-'}</p>
       </div>
     </div>
   )

--- a/dashboard-ui/app/services/analytics/analytics.service.ts
+++ b/dashboard-ui/app/services/analytics/analytics.service.ts
@@ -18,4 +18,12 @@ export const AnalyticsService = {
     const res = await axios.get<ITurnover>(`/analytics/turnover`)
     return res.data
   },
+  async getProductRemains() {
+    const res = await axios.get<number>(`/analytics/product-remains`)
+    return res.data
+  },
+  async getOpenTasks() {
+    const res = await axios.get<number>(`/analytics/open-tasks`)
+    return res.data
+  },
 }

--- a/server/src/analytics/analytics.controller.ts
+++ b/server/src/analytics/analytics.controller.ts
@@ -37,6 +37,22 @@ export class AnalyticsController {
                 return this.analyticsService.getTurnover()
         }
 
+        /**
+         * Возвращает общее количество товаров на складе.
+         */
+        @Get('product-remains')
+        getProductRemains() {
+                return this.analyticsService.getProductRemains()
+        }
+
+        /**
+         * Возвращает количество открытых задач.
+         */
+        @Get('open-tasks')
+        getOpenTasks() {
+                return this.analyticsService.getOpenTasksCount()
+        }
+
 	/**
 	 * Получает данные о продажах по категориям за определённый период.
 	 *

--- a/server/src/analytics/analytics.module.ts
+++ b/server/src/analytics/analytics.module.ts
@@ -5,14 +5,15 @@ import { AnalyticsController } from './analytics.controller'
 import { SaleModel } from '../sale/sale.model'
 import { ProductModel } from '../product/product.model'
 import { CategoryModel } from '../category/category.model'
+import { TaskModel } from '../task/task.model'
 
 /**
  * Модуль аналитики, отвечающий за маршруты и логику получения аналитических данных.
  */
 @Module({
 	imports: [
-		// Регистрация моделей, используемых в сервисе аналитики
-		SequelizeModule.forFeature([SaleModel, ProductModel, CategoryModel])
+                // Регистрация моделей, используемых в сервисе аналитики
+                SequelizeModule.forFeature([SaleModel, ProductModel, CategoryModel, TaskModel])
 	],
 	controllers: [AnalyticsController], // Регистрация контроллера аналитики
 	providers: [AnalyticsService] // Регистрация сервиса аналитики

--- a/server/src/analytics/analytics.service.ts
+++ b/server/src/analytics/analytics.service.ts
@@ -5,15 +5,18 @@ import { DateTime } from 'luxon'
 import { SaleModel } from '../sale/sale.model'
 import { ProductModel } from '../product/product.model'
 import { CategoryModel } from '../category/category.model'
+import { TaskModel, TaskStatus } from '../task/task.model'
 
 @Injectable()
 export class AnalyticsService {
-	constructor(
-		@InjectModel(SaleModel)
-		private readonly saleRepo: typeof SaleModel,
-		@InjectModel(ProductModel)
-		private readonly productRepo: typeof ProductModel
-	) {}
+        constructor(
+                @InjectModel(SaleModel)
+                private readonly saleRepo: typeof SaleModel,
+                @InjectModel(ProductModel)
+                private readonly productRepo: typeof ProductModel,
+                @InjectModel(TaskModel)
+                private readonly taskRepo: typeof TaskModel
+        ) {}
 
 	/**
 	 * Получает общую выручку за определённый период.
@@ -211,6 +214,23 @@ export class AnalyticsService {
                 ])
 
                 return { day, week, month, year, allTime }
+        }
+
+        /**
+         * Возвращает общее количество товаров на складе.
+         */
+        async getProductRemains(): Promise<number> {
+                const total = await this.productRepo.sum('remains')
+                return parseInt(String(total)) || 0
+        }
+
+        /**
+         * Возвращает количество открытых задач.
+         */
+        async getOpenTasksCount(): Promise<number> {
+                return this.taskRepo.count({
+                        where: { status: { [Op.ne]: TaskStatus.Completed } },
+                })
         }
 
         /**


### PR DESCRIPTION
## Summary
- switch turnover period selection to dropdown
- load product stock and open task metrics from backend
- expose new analytics endpoints for stock and task counts

## Testing
- `cd server && npm test`
- `cd ../dashboard-ui && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899bf0972208329be31b5a80c1eb37b