### PR TITLE
Remove Orders card from metrics grid

### DIFF
--- a/dashboard-ui/app/components/home/Metrics.tsx
+++ b/dashboard-ui/app/components/home/Metrics.tsx
@@ -37,7 +37,7 @@ const Metrics = () => {
   const value = turnover ? turnover[period] : 0
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
       <div className="bg-neutral-100 p-4 rounded-card shadow-card">
         <h3 className="text-lg font-semibold mb-2">Оборот</h3>
         <select
@@ -53,11 +53,6 @@ const Metrics = () => {
         </select>
         {turnoverError && <p className="text-error text-sm mb-1">{turnoverError}</p>}
         <p className="text-2xl font-bold">{format(value)} ₽</p>
-      </div>
-      <div className="bg-neutral-100 p-4 rounded-card shadow-card">
-        <h3 className="text-lg font-semibold mb-2">Заказы</h3>
-        <p className="text-2xl font-bold">32 сегодня</p>
-        <p className="text-sm text-neutral-700 mt-1">За неделю: 210</p>
       </div>
       <div className="bg-neutral-100 p-4 rounded-card shadow-card">
         <h3 className="text-lg font-semibold mb-2">Товары на складе</h3>


### PR DESCRIPTION
## Summary
- remove obsolete Orders card from the home metrics section
- adjust metrics grid to three columns to avoid empty space

## Testing
- `npm test` (dashboard-ui)
- `npm test` (server)


------
https://chatgpt.com/codex/tasks/task_e_6899c20f0b188329aec0a5893b492515