### PR TITLE
feat: localize report pages to Russian

### DIFF
--- a/dashboard-ui/app/reports/SalesTab.tsx
+++ b/dashboard-ui/app/reports/SalesTab.tsx
@@ -36,9 +36,9 @@ const SalesTab: FC<SalesTabProps> = ({ revenueData, topProducts, totalRevenue })
     <div className='space-y-6'>
       <div
         className='p-4 bg-white rounded shadow cursor-pointer'
-        onClick={() => alert('Open revenue details')}
+        onClick={() => alert('Открыть детали выручки')}
       >
-        <div className='font-medium mb-2'>Revenue by day</div>
+        <div className='font-medium mb-2'>Выручка по дням</div>
         <svg viewBox='0 0 100 100' className='w-full h-24'>
           <polyline
             fill='none'
@@ -51,12 +51,12 @@ const SalesTab: FC<SalesTabProps> = ({ revenueData, topProducts, totalRevenue })
       </div>
 
       <div className='p-4 bg-white rounded shadow space-y-2'>
-        <div className='font-medium'>Top-10 products by revenue</div>
+        <div className='font-medium'>Топ-10 товаров по выручке</div>
         {topProducts.map(p => (
           <div
             key={p.name}
             className='flex items-center cursor-pointer'
-            onClick={() => alert(`Open ${p.name} details`)}
+            onClick={() => alert(`Открыть детали ${p.name}`)}
           >
             <span className='w-32 text-sm'>{p.name}</span>
             <div className='flex-1 bg-neutral-200 h-2 mr-2'>
@@ -70,9 +70,9 @@ const SalesTab: FC<SalesTabProps> = ({ revenueData, topProducts, totalRevenue })
         ))}
         <div
           className='text-sm mt-2 cursor-pointer'
-          onClick={() => alert('Open top products share details')}
+          onClick={() => alert('Открыть долю топовых товаров')}
         >
-          Share of top-10 products: {share.toFixed(1)}%
+          Доля топ-10 товаров: {share.toFixed(1)}%
         </div>
       </div>
     </div>

--- a/dashboard-ui/app/reports/TasksTab.tsx
+++ b/dashboard-ui/app/reports/TasksTab.tsx
@@ -14,12 +14,12 @@ const TasksTab: FC<TasksTabProps> = ({ completed, prevCompleted }) => {
   return (
     <div
       className='p-4 bg-white rounded shadow cursor-pointer'
-      onClick={() => alert('Open tasks details')}
+      onClick={() => alert('Открыть задачи')}
     >
-      <div className='font-medium'>Completed tasks</div>
+      <div className='font-medium'>Выполненные задачи</div>
       <div className='text-3xl font-semibold'>{completed}</div>
       <div className={`text-sm ${isGrowth ? 'text-green-600' : 'text-red-600'}`}>
-        {isGrowth ? '+' : ''}{diff} from previous period
+        {isGrowth ? '+' : ''}{diff} от предыдущего периода
       </div>
     </div>
   )

--- a/dashboard-ui/app/reports/WarehouseTab.tsx
+++ b/dashboard-ui/app/reports/WarehouseTab.tsx
@@ -26,39 +26,39 @@ const WarehouseTab: FC<WarehouseTabProps> = ({ stats, movement }) => {
       <div className='grid grid-cols-2 md:grid-cols-4 gap-4'>
         <div
           className='p-4 bg-white rounded shadow cursor-pointer'
-          onClick={() => alert('Open initial balance')}
+          onClick={() => alert('Открыть начальный остаток')}
         >
-          <div className='text-sm'>Initial stock balance</div>
+          <div className='text-sm'>Начальный остаток на складе</div>
           <div className='text-xl font-semibold'>{stats.initial}</div>
         </div>
         <div
           className='p-4 bg-white rounded shadow cursor-pointer'
-          onClick={() => alert('Open arrivals')}
+          onClick={() => alert('Открыть поступления')}
         >
-          <div className='text-sm'>Stock arrival</div>
+          <div className='text-sm'>Поступление товара</div>
           <div className='text-xl font-semibold text-green-600'>{stats.arrival}</div>
         </div>
         <div
           className='p-4 bg-white rounded shadow cursor-pointer'
-          onClick={() => alert('Open departures')}
+          onClick={() => alert('Открыть расход')}
         >
-          <div className='text-sm'>Stock departure</div>
+          <div className='text-sm'>Списание товара</div>
           <div className='text-xl font-semibold text-red-600'>{stats.departure}</div>
         </div>
         <div
           className='p-4 bg-white rounded shadow cursor-pointer'
-          onClick={() => alert('Open final balance')}
+          onClick={() => alert('Открыть конечный остаток')}
         >
-          <div className='text-sm'>Final stock balance</div>
+          <div className='text-sm'>Конечный остаток на складе</div>
           <div className='text-xl font-semibold'>{stats.final}</div>
         </div>
       </div>
 
       <div
         className='p-4 bg-white rounded shadow cursor-pointer'
-        onClick={() => alert('Open stock movement details')}
+        onClick={() => alert('Открыть движение товара')}
       >
-        <div className='font-medium mb-2'>Stock movement</div>
+        <div className='font-medium mb-2'>Движение товара</div>
         <div className='flex items-end space-x-2 h-32'>
           {movement.map(m => (
             <div key={m.date} className='flex-1 flex flex-col justify-end'>

--- a/dashboard-ui/app/reports/new/page.tsx
+++ b/dashboard-ui/app/reports/new/page.tsx
@@ -5,14 +5,14 @@ import { useState } from 'react'
 import Layout from '@/ui/Layout'
 
 const periodPresets = [
-  { label: 'Today', value: 'today' },
-  { label: '7 days', value: '7d' },
-  { label: '30 days', value: '30d' },
-  { label: 'This month', value: 'month' },
-  { label: 'Any range', value: 'custom' },
+  { label: 'Сегодня', value: 'today' },
+  { label: '7 дней', value: '7d' },
+  { label: '30 дней', value: '30d' },
+  { label: 'Этот месяц', value: 'month' },
+  { label: 'Произвольный диапазон', value: 'custom' },
 ]
 
-const categories = ['Electronics', 'Clothing', 'Home']
+const categories = ['Электроника', 'Одежда', 'Дом']
 
 interface KPI {
   title: string
@@ -25,18 +25,21 @@ export default function NewReportPage() {
   const [period, setPeriod] = useState('today')
   const [start, setStart] = useState('')
   const [end, setEnd] = useState('')
-  const [activeTab, setActiveTab] = useState<'sales' | 'warehouse' | 'tasks'>(
-    'sales'
-  )
+  const tabs = [
+    { key: 'sales', label: 'Продажи' },
+    { key: 'warehouse', label: 'Склад' },
+    { key: 'tasks', label: 'Задачи' },
+  ]
+  const [activeTab, setActiveTab] = useState<'sales' | 'warehouse' | 'tasks'>('sales')
   const [selected, setSelected] = useState<string[]>([...categories])
 
   const kpis: KPI[] = [
-    { title: 'Revenue', value: 150000, change: 5.2, currency: true },
-    { title: 'Number of orders', value: 320, change: -1.3 },
-    { title: 'Units sold', value: 845, change: 2.1 },
-    { title: 'Average receipt', value: 4700, change: 0.4, currency: true },
-    { title: 'Margin', value: 23000, change: -0.8, currency: true },
-    { title: 'Completed tasks', value: 42, change: 3.5 },
+    { title: 'Выручка', value: 150000, change: 5.2, currency: true },
+    { title: 'Количество заказов', value: 320, change: -1.3 },
+    { title: 'Проданные единицы', value: 845, change: 2.1 },
+    { title: 'Средний чек', value: 4700, change: 0.4, currency: true },
+    { title: 'Маржа', value: 23000, change: -0.8, currency: true },
+    { title: 'Выполненные задачи', value: 42, change: 3.5 },
   ]
 
   const toggleCategory = (cat: string) => {
@@ -46,7 +49,7 @@ export default function NewReportPage() {
   }
 
   const exportCSV = () => {
-    const rows = ['Metric,Value']
+    const rows = ['Показатель,Значение']
     kpis.forEach(k => rows.push(`${k.title},${k.value}`))
     const blob = new Blob([rows.join('\n')], {
       type: 'text/csv;charset=utf-8;',
@@ -114,22 +117,22 @@ export default function NewReportPage() {
             className="bg-primary-500 text-white px-4 py-1 rounded"
             onClick={exportCSV}
           >
-            Export CSV
+            Экспорт CSV
           </button>
         </div>
 
         <div className="flex gap-4 border-b">
-          {['sales', 'warehouse', 'tasks'].map(tab => (
+          {tabs.map(t => (
             <button
-              key={tab}
+              key={t.key}
               className={`pb-2 ${
-                activeTab === tab
+                activeTab === t.key
                   ? 'border-b-2 border-primary-500 font-semibold'
                   : 'text-neutral-500'
               }`}
-              onClick={() => setActiveTab(tab as any)}
+              onClick={() => setActiveTab(t.key)}
             >
-              {tab.charAt(0).toUpperCase() + tab.slice(1)}
+              {t.label}
             </button>
           ))}
         </div>

--- a/dashboard-ui/app/reports/page.tsx
+++ b/dashboard-ui/app/reports/page.tsx
@@ -8,17 +8,17 @@ import WarehouseTab from './WarehouseTab'
 import TasksTab from './TasksTab'
 
 const tabs = [
-  { key: 'sales', label: 'Sales' },
-  { key: 'warehouse', label: 'Warehouse' },
-  { key: 'tasks', label: 'Tasks' },
+  { key: 'sales', label: 'Продажи' },
+  { key: 'warehouse', label: 'Склад' },
+  { key: 'tasks', label: 'Задачи' },
 ] as const
 
 type TabKey = (typeof tabs)[number]['key']
 
 const categories = [
-  { id: 1, name: 'Electronics' },
-  { id: 2, name: 'Clothing' },
-  { id: 3, name: 'Home' },
+  { id: 1, name: 'Электроника' },
+  { id: 2, name: 'Одежда' },
+  { id: 3, name: 'Дом' },
 ]
 
 interface SaleRecord {
@@ -59,16 +59,16 @@ const salesRecordsPrev: SaleRecord[] = [
 ]
 
 const productSales = [
-  { name: 'Laptop', categoryId: 1, revenue: 3000 },
-  { name: 'Phone', categoryId: 1, revenue: 2500 },
-  { name: 'Jeans', categoryId: 2, revenue: 1800 },
-  { name: 'Shirt', categoryId: 2, revenue: 1600 },
-  { name: 'Sofa', categoryId: 3, revenue: 1400 },
-  { name: 'Lamp', categoryId: 3, revenue: 1200 },
-  { name: 'Headphones', categoryId: 1, revenue: 1100 },
-  { name: 'Jacket', categoryId: 2, revenue: 1000 },
-  { name: 'Table', categoryId: 3, revenue: 900 },
-  { name: 'Watch', categoryId: 1, revenue: 800 },
+  { name: 'Ноутбук', categoryId: 1, revenue: 3000 },
+  { name: 'Телефон', categoryId: 1, revenue: 2500 },
+  { name: 'Джинсы', categoryId: 2, revenue: 1800 },
+  { name: 'Рубашка', categoryId: 2, revenue: 1600 },
+  { name: 'Диван', categoryId: 3, revenue: 1400 },
+  { name: 'Лампа', categoryId: 3, revenue: 1200 },
+  { name: 'Наушники', categoryId: 1, revenue: 1100 },
+  { name: 'Куртка', categoryId: 2, revenue: 1000 },
+  { name: 'Стол', categoryId: 3, revenue: 900 },
+  { name: 'Часы', categoryId: 1, revenue: 800 },
 ]
 
 const warehouseStats = { initial: 1200, arrival: 300, departure: 200, final: 1300 }
@@ -245,22 +245,26 @@ export default function ReportsPage() {
   }
 
   const kpis = [
-    { label: 'Revenue (₽)', value: metrics.revenue, change: metrics.revenueChange },
-    { label: 'Number of orders', value: metrics.orders, change: metrics.ordersChange },
-    { label: 'Units sold', value: metrics.units, change: metrics.unitsChange },
+    { label: 'Выручка (₽)', value: metrics.revenue, change: metrics.revenueChange },
     {
-      label: 'Average receipt (₽)',
+      label: 'Количество заказов',
+      value: metrics.orders,
+      change: metrics.ordersChange,
+    },
+    { label: 'Проданные единицы', value: metrics.units, change: metrics.unitsChange },
+    {
+      label: 'Средний чек (₽)',
       value: metrics.avgReceipt,
       change: metrics.avgReceiptChange,
     },
     {
-      label: 'Margin (₽)',
+      label: 'Маржа (₽)',
       value: metrics.marginValue,
       change: metrics.marginChange,
       extra: `${metrics.marginPercent.toFixed(1)}%`,
     },
     {
-      label: 'Completed tasks (pcs.)',
+      label: 'Выполненные задачи (шт.)',
       value: tasksStats.current,
       change: tasksStats.previous
         ? ((tasksStats.current - tasksStats.previous) / tasksStats.previous) * 100
@@ -273,23 +277,23 @@ export default function ReportsPage() {
       <div className='space-y-6'>
         <div className='flex flex-wrap items-end gap-4'>
           <div className='flex flex-col'>
-            <span className='text-sm'>Period</span>
+            <span className='text-sm'>Период</span>
             <select
               value={period}
               onChange={e => setPeriod(e.target.value as any)}
               className='border border-neutral-300 rounded px-2 py-1'
             >
-              <option value='today'>Today</option>
-              <option value='7d'>7 days</option>
-              <option value='30d'>30 days</option>
-              <option value='month'>This month</option>
-              <option value='custom'>Custom</option>
+              <option value='today'>Сегодня</option>
+              <option value='7d'>7 дней</option>
+              <option value='30d'>30 дней</option>
+              <option value='month'>Этот месяц</option>
+              <option value='custom'>Произвольный</option>
             </select>
           </div>
           {period === 'custom' && (
             <>
               <label className='flex flex-col'>
-                <span className='text-sm'>Start date</span>
+                <span className='text-sm'>Дата начала</span>
                 <input
                   type='date'
                   value={start}
@@ -298,7 +302,7 @@ export default function ReportsPage() {
                 />
               </label>
               <label className='flex flex-col'>
-                <span className='text-sm'>End date</span>
+                <span className='text-sm'>Дата окончания</span>
                 <input
                   type='date'
                   value={end}
@@ -309,7 +313,7 @@ export default function ReportsPage() {
             </>
           )}
           <div className='flex flex-col'>
-            <span className='text-sm'>Categories</span>
+            <span className='text-sm'>Категории</span>
             <div className='flex flex-wrap gap-2'>
               {categories.map(c => (
                 <label key={c.id} className='flex items-center space-x-1'>
@@ -327,7 +331,7 @@ export default function ReportsPage() {
             onClick={handleExport}
             className='ml-auto px-4 py-2 bg-primary-500 text-white rounded'
           >
-            Export CSV
+            Экспорт CSV
           </button>
         </div>
 


### PR DESCRIPTION
## Summary
- translate report tabs and filters to Russian
- localize sales, warehouse, tasks, and new report pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899e24ddee083299bc1edf40aaf1e84