### PR TITLE
feat: add category filtering and warehouse movement table

### DIFF
--- a/dashboard-ui/app/reports/WarehouseTab.tsx
+++ b/dashboard-ui/app/reports/WarehouseTab.tsx
@@ -11,16 +11,19 @@ interface Stats {
 
 interface MovementItem {
   date: string
-  arrival: number
-  departure: number
+  direction: 'arrival' | 'departure'
+  product: string
+  article: string
+  quantity: number
+  reason: string
 }
 
 interface WarehouseTabProps {
   stats: Stats
-  movement: MovementItem[]
+  movements: MovementItem[]
 }
 
-const WarehouseTab: FC<WarehouseTabProps> = ({ stats, movement }) => {
+const WarehouseTab: FC<WarehouseTabProps> = ({ stats, movements }) => {
   return (
     <div className='space-y-6'>
       <div className='grid grid-cols-2 md:grid-cols-4 gap-4'>
@@ -54,20 +57,36 @@ const WarehouseTab: FC<WarehouseTabProps> = ({ stats, movement }) => {
         </div>
       </div>
 
-      <div
-        className='p-4 bg-white rounded shadow cursor-pointer'
-        onClick={() => alert('Открыть движение товара')}
-      >
+      <div className='p-4 bg-white rounded shadow overflow-x-auto'>
         <div className='font-medium mb-2'>Движение товара</div>
-        <div className='flex items-end space-x-2 h-32'>
-          {movement.map(m => (
-            <div key={m.date} className='flex-1 flex flex-col justify-end'>
-              <div className='bg-green-500' style={{ height: `${m.arrival}px` }} />
-              <div className='bg-red-500' style={{ height: `${m.departure}px` }} />
-              <span className='text-xs text-center'>{new Date(m.date).getDate()}</span>
-            </div>
-          ))}
-        </div>
+        <table className='w-full text-sm'>
+          <thead>
+            <tr className='text-left'>
+              <th className='py-1 pr-2'>Дата</th>
+              <th className='py-1 pr-2'>Товар</th>
+              <th className='py-1 pr-2'>Артикул</th>
+              <th className='py-1 pr-2 text-right'>Приход</th>
+              <th className='py-1 pr-2 text-right'>Расход</th>
+              <th className='py-1 pr-2'>Причина</th>
+            </tr>
+          </thead>
+          <tbody>
+            {movements.map(m => (
+              <tr key={`${m.date}-${m.article}`} className='border-t'>
+                <td className='py-1 pr-2'>{m.date}</td>
+                <td className='py-1 pr-2'>{m.product}</td>
+                <td className='py-1 pr-2'>{m.article}</td>
+                <td className='py-1 pr-2 text-right text-green-600'>
+                  {m.direction === 'arrival' ? m.quantity : ''}
+                </td>
+                <td className='py-1 pr-2 text-right text-red-600'>
+                  {m.direction === 'departure' ? m.quantity : ''}
+                </td>
+                <td className='py-1 pr-2'>{m.reason}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
     </div>
   )

--- a/dashboard-ui/app/services/analytics/analytics.service.ts
+++ b/dashboard-ui/app/services/analytics/analytics.service.ts
@@ -4,10 +4,32 @@ import { ISalesStat } from '@/shared/interfaces/sales-stat.interface'
 import { ITurnover } from '@/shared/interfaces/turnover.interface'
 
 export const AnalyticsService = {
-  async getTopProducts(limit?: number) {
+  async getTopProducts(
+    limit?: number,
+    startDate?: string,
+    endDate?: string,
+    categories?: number[]
+  ) {
     const params: any = {}
     if (limit) params.limit = limit
+    if (startDate) params.startDate = startDate
+    if (endDate) params.endDate = endDate
+    if (categories && categories.length) params.categories = categories.join(',')
     const res = await axios.get<ITopProduct[]>('/analytics/top-products', { params })
+    return res.data
+  },
+  async getDailyRevenue(
+    startDate?: string,
+    endDate?: string,
+    categories?: number[]
+  ) {
+    const params: any = {}
+    if (startDate) params.startDate = startDate
+    if (endDate) params.endDate = endDate
+    if (categories && categories.length) params.categories = categories.join(',')
+    const res = await axios.get<ISalesStat[]>(`/analytics/daily-revenue`, {
+      params,
+    })
     return res.data
   },
   async getSales(period: number) {

--- a/server/src/analytics/analytics.controller.ts
+++ b/server/src/analytics/analytics.controller.ts
@@ -30,6 +30,18 @@ export class AnalyticsController {
         }
 
         /**
+         * Возвращает суммы продаж по дням за выбранный диапазон.
+         */
+        @Get('daily-revenue')
+        getDailyRevenue(
+                @Query(new ValidationPipe({ transform: true }))
+                query: AnalyticsQueryDto
+        ) {
+                const { startDate, endDate, categories } = query
+                return this.analyticsService.getDailyRevenue(startDate, endDate, categories)
+        }
+
+        /**
          * Возвращает оборот за день, неделю, месяц, год и всё время.
          */
         @Get('turnover')


### PR DESCRIPTION
## Summary
- load categories from API and filter reports via multi-select
- fetch revenue and top products from backend based on period and categories
- show detailed warehouse movement table with direction and reasons

## Testing
- `npm test` (fails: Missing script)
- `npm test --prefix server`
- `npm test --prefix dashboard-ui`


------
https://chatgpt.com/codex/tasks/task_e_6899e5f276b48329b39b1878bb4d15ec