### PR TITLE
Add KPI analytics and report generation

### DIFF
--- a/server/src/analytics/analytics.controller.ts
+++ b/server/src/analytics/analytics.controller.ts
@@ -65,6 +65,18 @@ export class AnalyticsController {
                 return this.analyticsService.getOpenTasksCount()
         }
 
+        /**
+         * Рассчитывает KPI продаж за период.
+         */
+        @Get('kpis')
+        getKpis(
+                @Query(new ValidationPipe({ transform: true }))
+                query: AnalyticsQueryDto
+        ) {
+                const { startDate, endDate, categories } = query
+                return this.analyticsService.getKpis(startDate, endDate, categories)
+        }
+
 	/**
 	 * Получает данные о продажах по категориям за определённый период.
 	 *

--- a/server/src/analytics/analytics.module.ts
+++ b/server/src/analytics/analytics.module.ts
@@ -15,7 +15,8 @@ import { TaskModel } from '../task/task.model'
                 // Регистрация моделей, используемых в сервисе аналитики
                 SequelizeModule.forFeature([SaleModel, ProductModel, CategoryModel, TaskModel])
 	],
-	controllers: [AnalyticsController], // Регистрация контроллера аналитики
-	providers: [AnalyticsService] // Регистрация сервиса аналитики
+        controllers: [AnalyticsController], // Регистрация контроллера аналитики
+        providers: [AnalyticsService], // Регистрация сервиса аналитики
+        exports: [AnalyticsService]
 })
 export class AnalyticsModule {}

--- a/server/src/report/dto/generate-report.dto.ts
+++ b/server/src/report/dto/generate-report.dto.ts
@@ -1,5 +1,13 @@
-import { IsDateString, IsEnum, IsOptional, ValidateNested } from 'class-validator'
-import { Type } from 'class-transformer'
+import {
+        IsArray,
+        IsDateString,
+        IsEnum,
+        IsInt,
+        IsOptional,
+        IsString,
+        ValidateNested
+} from 'class-validator'
+import { Type, Transform } from 'class-transformer'
 
 export enum ReportType {
         SALES = 'sales',
@@ -15,6 +23,38 @@ export class ReportParamsDto {
         @IsOptional()
         @IsDateString()
         endDate?: string
+
+        @IsOptional()
+        @Transform(({ value }) => {
+                if (typeof value === 'string') {
+                        return value
+                                .split(',')
+                                .map((id) => parseInt(id, 10))
+                                .filter((n) => !isNaN(n))
+                }
+                if (Array.isArray(value)) {
+                        return value
+                                .map((id) => parseInt(id, 10))
+                                .filter((n) => !isNaN(n))
+                }
+                return undefined
+        })
+        @IsInt({ each: true })
+        categories?: number[]
+
+        @IsOptional()
+        @Transform(({ value }) => {
+                if (typeof value === 'string') {
+                        return value.split(',')
+                }
+                if (Array.isArray(value)) {
+                        return value
+                }
+                return undefined
+        })
+        @IsString({ each: true })
+        @IsArray()
+        metrics?: string[]
 }
 
 export class GenerateReportDto {

--- a/server/src/report/report.module.ts
+++ b/server/src/report/report.module.ts
@@ -3,9 +3,10 @@ import { SequelizeModule } from '@nestjs/sequelize'
 import { ReportController } from './report.controller'
 import { ReportService } from './report.service'
 import { ReportModel } from './report.model'
+import { AnalyticsModule } from '../analytics/analytics.module'
 
 @Module({
-        imports: [SequelizeModule.forFeature([ReportModel])],
+        imports: [SequelizeModule.forFeature([ReportModel]), AnalyticsModule],
         controllers: [ReportController],
         providers: [ReportService]
 })

--- a/server/src/report/report.service.ts
+++ b/server/src/report/report.service.ts
@@ -2,12 +2,14 @@ import { Injectable } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
 import { ReportModel } from './report.model'
 import { GenerateReportDto } from './dto/generate-report.dto'
+import { AnalyticsService } from '../analytics/analytics.service'
 
 @Injectable()
 export class ReportService {
         constructor(
                 @InjectModel(ReportModel)
-                private reportRepo: typeof ReportModel
+                private reportRepo: typeof ReportModel,
+                private readonly analyticsService: AnalyticsService
         ) {}
 
         getAvailable() {
@@ -19,10 +21,15 @@ export class ReportService {
         }
 
         async generate({ type, params }: GenerateReportDto) {
+                const data = await this.analyticsService.getKpis(
+                        params.startDate,
+                        params.endDate,
+                        params.categories
+                )
                 return this.reportRepo.create({
                         type,
                         params,
-                        data: { message: `data for ${type}` }
+                        data
                 })
         }
 


### PR DESCRIPTION
## Summary
- expose a new `/analytics/kpis` endpoint for server-side KPI calculation
- allow reports to accept category and metric filters and store generated KPI data
- export AnalyticsService for reuse in reports module

## Testing
- `npm test`
- `npm run lint` *(fails: Key "rules": Key "@typescript-eslint/no-extraneous-class": Unexpected property "allowEmptyCase")*

------
https://chatgpt.com/codex/tasks/task_e_6899ee59983083298d56d7b542b480b2