### PR TITLE
fix: assign category id when updating product

### DIFF
--- a/server/src/product/product.service.ts
+++ b/server/src/product/product.service.ts
@@ -94,22 +94,19 @@ export class ProductService {
                 const updateData: any = { ...dto }
 
                 if (dto.categoryId || dto.categoryName) {
-                        let categoryId: number
-
                         if (dto.categoryId) {
                                 const cat = await this.categoryRepo.findByPk(dto.categoryId)
                                 if (!cat)
                                         throw new NotFoundException('Категория с таким ID не найдена')
-                                categoryId = dto.categoryId
+                                updateData.categoryId = dto.categoryId
                         } else if (dto.categoryName) {
                                 const [cat] = await this.categoryRepo.findOrCreate({
                                         where: { name: dto.categoryName.trim() },
                                         defaults: { name: dto.categoryName.trim() }
                                 })
-                                categoryId = cat.id
+                                updateData.categoryId = cat.id
                         }
 
-                        updateData.categoryId = categoryId
                         delete updateData.categoryName
                 }
 


### PR DESCRIPTION
## Summary
- ensure product update assigns category id directly from request or created category

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a07b5ae548329a1ba9e4f85e90cde