### PR TITLE
fix: add providers path alias

### DIFF
--- a/dashboard-ui/tsconfig.json
+++ b/dashboard-ui/tsconfig.json
@@ -30,7 +30,8 @@
       "@/services/*": ["services/*"],
       "@/utils/*": ["utils/*"],
       "@/store/*": ["store/*"],
-      "@/assets/*": ["assets/*"]
+      "@/assets/*": ["assets/*"],
+      "@/providers/*": ["providers/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- add providers path alias

## Testing
- `npm test`
- `npm run build` *(fails: ESLint invalid options; TypeScript type mismatch in app/tasks/[id]/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689a1a9695748329a8991cbf139bdf7c