### PR TITLE
test: add category dto validation tests

### DIFF
--- a/server/src/category/dto/category.dto.spec.ts
+++ b/server/src/category/dto/category.dto.spec.ts
@@ -1,0 +1,23 @@
+import { plainToInstance } from 'class-transformer'
+import { validateSync } from 'class-validator'
+import { CreateCategoryDto } from './category.dto'
+
+describe('CreateCategoryDto', () => {
+  it('should validate successfully with name', () => {
+    const dto = plainToInstance(CreateCategoryDto, { name: 'Food' })
+    const errors = validateSync(dto)
+    expect(errors.length).toBe(0)
+  })
+
+  it('should fail validation with empty name', () => {
+    const dto = plainToInstance(CreateCategoryDto, { name: '' })
+    const errors = validateSync(dto)
+    expect(errors.length).toBeGreaterThan(0)
+  })
+
+  it('should fail validation when name is missing', () => {
+    const dto = plainToInstance(CreateCategoryDto, {})
+    const errors = validateSync(dto)
+    expect(errors.length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for CreateCategoryDto validating successful and failing cases

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a2673b4e48329bd44742af31e3798