### PR TITLE
test: add analytics module tests

### DIFF
--- a/server/src/analytics/analytics.controller.spec.ts
+++ b/server/src/analytics/analytics.controller.spec.ts
@@ -1,0 +1,61 @@
+import { Test } from '@nestjs/testing'
+import {
+  INestApplication,
+  ValidationPipe,
+  NotFoundException
+} from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+import request from 'supertest'
+import { AnalyticsController } from './analytics.controller'
+import { AnalyticsService } from './analytics.service'
+
+describe('AnalyticsController', () => {
+  let app: INestApplication
+  const service = {
+    getRevenue: jest.fn(),
+    getTurnover: jest.fn()
+  }
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AnalyticsController],
+      providers: [AnalyticsService]
+    })
+      .overrideProvider(AnalyticsService)
+      .useValue(service)
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: () => true })
+      .compile()
+
+    app = moduleRef.createNestApplication()
+    app.useGlobalPipes(new ValidationPipe({ transform: true }))
+    await app.init()
+  })
+
+  afterAll(async () => app.close())
+
+  it('/analytics/revenue GET', async () => {
+    service.getRevenue.mockResolvedValue(123)
+    await request(app.getHttpServer())
+      .get('/analytics/revenue?startDate=2024-01-01&endDate=2024-01-31&categories=1,2')
+      .expect(200)
+      .expect('123')
+    expect(service.getRevenue).toHaveBeenCalledWith('2024-01-01', '2024-01-31', [1, 2])
+  })
+
+  it('/analytics/turnover GET', async () => {
+    const data = { day: 1, week: 2, month: 3, year: 4, allTime: 5 }
+    service.getTurnover.mockResolvedValue(data)
+    await request(app.getHttpServer())
+      .get('/analytics/turnover')
+      .expect(200)
+      .expect(data)
+    expect(service.getTurnover).toHaveBeenCalled()
+  })
+
+  it('/analytics/revenue GET 404', async () => {
+    service.getRevenue.mockRejectedValue(new NotFoundException())
+    await request(app.getHttpServer()).get('/analytics/revenue').expect(404)
+  })
+})
+

--- a/server/src/analytics/analytics.service.spec.ts
+++ b/server/src/analytics/analytics.service.spec.ts
@@ -1,0 +1,138 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getModelToken } from '@nestjs/sequelize'
+import { Op } from 'sequelize'
+import { DateTime } from 'luxon'
+import { AnalyticsService } from './analytics.service'
+import { SaleModel } from '../sale/sale.model'
+import { ProductModel } from '../product/product.model'
+import { TaskModel } from '../task/task.model'
+
+describe('AnalyticsService', () => {
+  let service: AnalyticsService
+  const saleRepo = { sum: jest.fn(), findAll: jest.fn(), findOne: jest.fn() }
+  const productRepo = { findAll: jest.fn(), sum: jest.fn() }
+  const taskRepo = { count: jest.fn() }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalyticsService,
+        { provide: getModelToken(SaleModel), useValue: saleRepo },
+        { provide: getModelToken(ProductModel), useValue: productRepo },
+        { provide: getModelToken(TaskModel), useValue: taskRepo }
+      ]
+    }).compile()
+
+    service = module.get<AnalyticsService>(AnalyticsService)
+    jest.clearAllMocks()
+  })
+
+  describe('getRevenue', () => {
+    it('calculates revenue with filters', async () => {
+      saleRepo.sum.mockResolvedValue('100')
+      const result = await service.getRevenue('2024-01-01', '2024-01-31', [1, 2])
+      expect(saleRepo.sum).toHaveBeenCalledWith('totalPrice', expect.objectContaining({
+        where: expect.objectContaining({
+          saleDate: { [Op.between]: ['2024-01-01', '2024-01-31'] },
+          '$product.category_id$': { [Op.in]: [1, 2] }
+        }),
+        include: [{ model: ProductModel, attributes: [] }]
+      }))
+      expect(result).toBe(100)
+    })
+
+    it('returns 0 when repository returns null', async () => {
+      saleRepo.sum.mockResolvedValue(null)
+      const result = await service.getRevenue()
+      expect(result).toBe(0)
+    })
+  })
+
+  describe('getDailyRevenue', () => {
+    it('maps results correctly', async () => {
+      saleRepo.findAll.mockResolvedValue([
+        { date: '2024-01-01', total: '50' },
+        { date: '2024-01-02', total: '70' }
+      ])
+      const result = await service.getDailyRevenue('2024-01-01', '2024-01-02')
+      expect(saleRepo.findAll).toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({
+          saleDate: { [Op.between]: ['2024-01-01', '2024-01-02'] }
+        }),
+        group: [expect.anything()],
+        order: [[expect.anything(), 'ASC']],
+        raw: true
+      }))
+      expect(result).toEqual([
+        { date: '2024-01-01', total: 50 },
+        { date: '2024-01-02', total: 70 }
+      ])
+    })
+  })
+
+  describe('getTurnover', () => {
+    it('aggregates revenues for different periods', async () => {
+      jest.spyOn(DateTime, 'now').mockReturnValue(DateTime.fromISO('2024-03-15T12:00:00'))
+      const spy = jest
+        .spyOn(service, 'getRevenue')
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(2)
+        .mockResolvedValueOnce(3)
+        .mockResolvedValueOnce(4)
+        .mockResolvedValueOnce(5)
+
+      const result = await service.getTurnover()
+      expect(spy).toHaveBeenNthCalledWith(1, '2024-03-15', '2024-03-15')
+      expect(spy).toHaveBeenNthCalledWith(2, '2024-03-11', '2024-03-15')
+      expect(spy).toHaveBeenNthCalledWith(3, '2024-03-01', '2024-03-15')
+      expect(spy).toHaveBeenNthCalledWith(4, '2024-01-01', '2024-03-15')
+      expect(spy.mock.calls[4]).toEqual([])
+      expect(result).toEqual({ day: 1, week: 2, month: 3, year: 4, allTime: 5 })
+    })
+  })
+
+  describe('getKpis', () => {
+    it('returns calculated kpis', async () => {
+      saleRepo.findOne.mockResolvedValue({
+        revenue: '100',
+        orders: '5',
+        unitsSold: '20',
+        margin: '30'
+      })
+      taskRepo.count.mockResolvedValue(2)
+
+      const result = await service.getKpis('2024-01-01', '2024-01-31', [1])
+
+      expect(saleRepo.findOne).toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({
+          saleDate: { [Op.between]: ['2024-01-01', '2024-01-31'] }
+        }),
+        include: [expect.objectContaining({ where: { categoryId: { [Op.in]: [1] } } })],
+        raw: true
+      }))
+      expect(taskRepo.count).toHaveBeenCalled()
+      expect(result).toEqual({
+        revenue: 100,
+        orders: 5,
+        unitsSold: 20,
+        avgCheck: 20,
+        margin: 30,
+        completedTasks: 2
+      })
+    })
+  })
+
+  describe('getSales', () => {
+    it('builds date range and maps result', async () => {
+      saleRepo.findAll.mockResolvedValue([{ date: '2024-01-01', total: '40' }])
+      const result = await service.getSales(7)
+      expect(saleRepo.findAll).toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({
+          saleDate: { [Op.between]: [expect.any(String), expect.any(String)] }
+        })
+      }))
+      expect(result).toEqual([{ date: '2024-01-01', total: 40 }])
+    })
+  })
+})
+

--- a/server/test/analytics.e2e-spec.ts
+++ b/server/test/analytics.e2e-spec.ts
@@ -1,0 +1,61 @@
+import { Test } from '@nestjs/testing'
+import {
+  INestApplication,
+  ValidationPipe,
+  NotFoundException
+} from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+import request from 'supertest'
+import { getConnectionToken, getModelToken } from '@nestjs/sequelize'
+import { AnalyticsModule } from '../src/analytics/analytics.module'
+import { AnalyticsService } from '../src/analytics/analytics.service'
+import { SaleModel } from '../src/sale/sale.model'
+import { ProductModel } from '../src/product/product.model'
+import { CategoryModel } from '../src/category/category.model'
+import { TaskModel } from '../src/task/task.model'
+
+describe('Analytics (e2e)', () => {
+  let app: INestApplication
+  const service = { getRevenue: jest.fn() }
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AnalyticsModule]
+    })
+      .overrideProvider(AnalyticsService)
+      .useValue(service)
+      .overrideProvider(getModelToken(SaleModel))
+      .useValue({})
+      .overrideProvider(getModelToken(ProductModel))
+      .useValue({})
+      .overrideProvider(getModelToken(CategoryModel))
+      .useValue({})
+      .overrideProvider(getModelToken(TaskModel))
+      .useValue({})
+      .overrideProvider(getConnectionToken())
+      .useValue({})
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: () => true })
+      .compile()
+
+    app = moduleRef.createNestApplication()
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }))
+    await app.init()
+  })
+
+  afterAll(async () => app.close())
+
+  it('/analytics/revenue (GET)', async () => {
+    service.getRevenue.mockResolvedValue(200)
+    await request(app.getHttpServer())
+      .get('/analytics/revenue')
+      .expect(200)
+      .expect('200')
+  })
+
+  it('/analytics/revenue (GET) 404', async () => {
+    service.getRevenue.mockRejectedValue(new NotFoundException())
+    await request(app.getHttpServer()).get('/analytics/revenue').expect(404)
+  })
+})
+


### PR DESCRIPTION
## Summary
- add unit tests for analytics service covering revenue, daily revenue, turnover aggregation, KPIs and sales mapping
- add analytics controller tests for parameter forwarding, status codes and error handling
- introduce analytics e2e tests for revenue route success and failure scenarios

## Testing
- `cd server && npm test`
- `cd server && npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689a2a28d76c83298e477b8851db80f2