### PR TITLE
Add tests for auth, task and report modules

### DIFF
--- a/server/src/auth/auth.service.spec.ts
+++ b/server/src/auth/auth.service.spec.ts
@@ -1,0 +1,105 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { AuthService } from './auth.service'
+import { JwtService } from '@nestjs/jwt'
+import { getModelToken } from '@nestjs/sequelize'
+import { UserModel } from './user.model'
+import { BadRequestException, UnauthorizedException } from '@nestjs/common'
+import { AuthDto } from './dto/auth.dto'
+import { compare, genSalt, hash } from 'bcryptjs'
+
+jest.mock('bcryptjs')
+
+const mockUser = {
+  id: 1,
+  email: 'test@example.com',
+  password: 'hashed',
+  name: 'Test',
+  get: function() { return this }
+}
+
+describe('AuthService', () => {
+  let service: AuthService
+  let userModel: { findOne: jest.Mock; create: jest.Mock }
+  let jwt: { signAsync: jest.Mock }
+
+  beforeEach(async () => {
+    userModel = {
+      findOne: jest.fn(),
+      create: jest.fn()
+    }
+    jwt = { signAsync: jest.fn().mockResolvedValue('token') }
+    ;(genSalt as jest.Mock).mockResolvedValue('salt')
+    ;(hash as jest.Mock).mockResolvedValue('hashed')
+    ;(compare as jest.Mock).mockResolvedValue(true)
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: getModelToken(UserModel), useValue: userModel },
+        { provide: JwtService, useValue: jwt }
+      ]
+    }).compile()
+
+    service = module.get<AuthService>(AuthService)
+  })
+
+  it('login success', async () => {
+    userModel.findOne.mockResolvedValue(mockUser)
+    const dto: AuthDto = { email: 'test@example.com', password: '12345678' }
+    const res = await service.login(dto)
+    expect(res).toEqual({
+      user: { id: 1, email: 'test@example.com', name: 'Test' },
+      accessToken: 'token'
+    })
+    expect(compare).toHaveBeenCalledWith('12345678', 'hashed')
+    expect(jwt.signAsync).toHaveBeenCalledWith({ id: 1 }, { expiresIn: '31d' })
+  })
+
+  it('login user not found', async () => {
+    userModel.findOne.mockResolvedValue(null)
+    await expect(
+      service.login({ email: 'a@a.com', password: '12345678' })
+    ).rejects.toBeInstanceOf(UnauthorizedException)
+  })
+
+  it('login invalid password', async () => {
+    userModel.findOne.mockResolvedValue(mockUser)
+    ;(compare as jest.Mock).mockResolvedValue(false)
+    await expect(
+      service.login({ email: 'test@example.com', password: 'wrong' })
+    ).rejects.toBeInstanceOf(UnauthorizedException)
+  })
+
+  it('register success', async () => {
+    userModel.findOne.mockResolvedValue(null)
+    userModel.create.mockResolvedValue(mockUser)
+    const dto: AuthDto = { email: 'test@example.com', password: '12345678' }
+    const res = await service.register(dto)
+    expect(res).toEqual({
+      user: { id: 1, email: 'test@example.com', name: 'Test' },
+      accessToken: 'token'
+    })
+    expect(hash).toHaveBeenCalled()
+  })
+
+  it('register conflict', async () => {
+    userModel.findOne.mockResolvedValue(mockUser)
+    await expect(
+      service.register({ email: 'test@example.com', password: '12345678' })
+    ).rejects.toBeInstanceOf(BadRequestException)
+  })
+
+  it('issueAccessToken', async () => {
+    const token = await service.issueAccessToken('1')
+    expect(token).toBe('token')
+    expect(jwt.signAsync).toHaveBeenCalledWith({ id: '1' }, { expiresIn: '31d' })
+  })
+
+  it('returnUserFields', () => {
+    expect(service.returnUserFields(mockUser as any)).toEqual({
+      id: 1,
+      email: 'test@example.com',
+      name: 'Test'
+    })
+  })
+})
+

--- a/server/src/report/report.service.spec.ts
+++ b/server/src/report/report.service.spec.ts
@@ -1,0 +1,74 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { ReportService } from './report.service'
+import { getModelToken } from '@nestjs/sequelize'
+import { ReportModel } from './report.model'
+import { AnalyticsService } from '../analytics/analytics.service'
+
+const mockReport = { id: 1 }
+
+describe('ReportService', () => {
+  let service: ReportService
+  let repo: { create: jest.Mock; findAll: jest.Mock; findByPk: jest.Mock }
+  let analytics: { getKpis: jest.Mock }
+
+  beforeEach(async () => {
+    repo = {
+      create: jest.fn().mockResolvedValue(mockReport),
+      findAll: jest.fn().mockResolvedValue([mockReport]),
+      findByPk: jest.fn()
+    }
+    analytics = { getKpis: jest.fn().mockResolvedValue([]) }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReportService,
+        { provide: getModelToken(ReportModel), useValue: repo },
+        { provide: AnalyticsService, useValue: analytics }
+      ]
+    }).compile()
+
+    service = module.get<ReportService>(ReportService)
+  })
+
+  it('getAvailable', () => {
+    const list = service.getAvailable()
+    expect(list).toHaveLength(3)
+  })
+
+  it('generate', async () => {
+    const dto = {
+      type: 'sales',
+      params: { startDate: '2024-01-01', endDate: '2024-02-01', categories: [] }
+    }
+    await service.generate(dto as any)
+    expect(analytics.getKpis).toHaveBeenCalledWith(
+      dto.params.startDate,
+      dto.params.endDate,
+      dto.params.categories
+    )
+    expect(repo.create).toHaveBeenCalledWith({
+      type: 'sales',
+      params: dto.params,
+      data: []
+    })
+  })
+
+  it('getHistory', async () => {
+    const res = await service.getHistory()
+    expect(res).toEqual([mockReport])
+    expect(repo.findAll).toHaveBeenCalled()
+  })
+
+  it('export not found', async () => {
+    repo.findByPk.mockResolvedValue(null)
+    const res = await service.export(1, 'pdf')
+    expect(res).toEqual({ message: 'Report 1 not found' })
+  })
+
+  it('export success', async () => {
+    repo.findByPk.mockResolvedValue({})
+    const res = await service.export(1, 'pdf')
+    expect(res).toEqual({ message: 'Report 1 exported to pdf' })
+  })
+})
+

--- a/server/src/task/task.service.spec.ts
+++ b/server/src/task/task.service.spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { TaskService } from './task.service'
+import { getModelToken } from '@nestjs/sequelize'
+import { TaskModel } from './task.model'
+import { NotFoundException } from '@nestjs/common'
+
+const mockTask = { id: 1, title: 'Test', update: jest.fn(), destroy: jest.fn() }
+
+describe('TaskService', () => {
+  let service: TaskService
+  let repo: {
+    create: jest.Mock
+    findAll: jest.Mock
+    findByPk: jest.Mock
+  }
+
+  beforeEach(async () => {
+    repo = {
+      create: jest.fn().mockResolvedValue(mockTask),
+      findAll: jest.fn().mockResolvedValue([mockTask]),
+      findByPk: jest.fn().mockResolvedValue(mockTask)
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TaskService,
+        { provide: getModelToken(TaskModel), useValue: repo }
+      ]
+    }).compile()
+
+    service = module.get<TaskService>(TaskService)
+    mockTask.update.mockResolvedValue({ ...mockTask, title: 'Updated' })
+  })
+
+  it('create', async () => {
+    const dto = { title: 'Test' }
+    await service.create(dto as any)
+    expect(repo.create).toHaveBeenCalledWith({ ...dto })
+  })
+
+  it('findAll', async () => {
+    const res = await service.findAll()
+    expect(res).toEqual([mockTask])
+    expect(repo.findAll).toHaveBeenCalled()
+  })
+
+  it('findOne success', async () => {
+    const res = await service.findOne(1)
+    expect(res).toBe(mockTask)
+  })
+
+  it('findOne not found', async () => {
+    repo.findByPk.mockResolvedValue(null)
+    await expect(service.findOne(1)).rejects.toBeInstanceOf(NotFoundException)
+  })
+
+  it('update', async () => {
+    const dto = { title: 'New' }
+    const res = await service.update(1, dto as any)
+    expect(repo.findByPk).toHaveBeenCalledWith(1)
+    expect(mockTask.update).toHaveBeenCalledWith(dto)
+    expect(res).toEqual({ ...mockTask, title: 'Updated' })
+  })
+
+  it('remove', async () => {
+    await service.remove(1)
+    expect(repo.findByPk).toHaveBeenCalledWith(1)
+    expect(mockTask.destroy).toHaveBeenCalled()
+  })
+})
+

--- a/server/test/auth.e2e-spec.ts
+++ b/server/test/auth.e2e-spec.ts
@@ -1,0 +1,78 @@
+import { Test } from '@nestjs/testing'
+import {
+  INestApplication,
+  ValidationPipe,
+  BadRequestException,
+  UnauthorizedException
+} from '@nestjs/common'
+import request from 'supertest'
+import { AuthController } from '../src/auth/auth.controller'
+import { AuthService } from '../src/auth/auth.service'
+
+describe('Auth (e2e)', () => {
+  let app: INestApplication
+  const service = {
+    login: jest.fn(),
+    register: jest.fn()
+  }
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [AuthService]
+    })
+      .overrideProvider(AuthService)
+      .useValue(service)
+      .compile()
+
+    app = moduleRef.createNestApplication()
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }))
+    await app.init()
+  })
+
+  afterAll(async () => app.close())
+
+  it('/auth/login (POST)', async () => {
+    service.login.mockResolvedValue({ ok: true })
+    await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'a@a.com', password: '12345678' })
+      .expect(200)
+      .expect({ ok: true })
+    expect(service.login).toHaveBeenCalledWith({ email: 'a@a.com', password: '12345678' })
+  })
+
+  it('/auth/login (POST) 401', async () => {
+    service.login.mockRejectedValue(new UnauthorizedException())
+    await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'a@a.com', password: '12345678' })
+      .expect(401)
+  })
+
+  it('/auth/register (POST) validation error', async () => {
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({ email: 'bad', password: '1' })
+      .expect(400)
+  })
+
+  it('/auth/register (POST)', async () => {
+    service.register.mockResolvedValue({ id: 1 })
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({ email: 'a@a.com', password: '12345678' })
+      .expect(200)
+      .expect({ id: 1 })
+    expect(service.register).toHaveBeenCalledWith({ email: 'a@a.com', password: '12345678' })
+  })
+
+  it('/auth/register (POST) 400', async () => {
+    service.register.mockRejectedValue(new BadRequestException())
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({ email: 'a@a.com', password: '12345678' })
+      .expect(400)
+  })
+})
+

--- a/server/test/report.e2e-spec.ts
+++ b/server/test/report.e2e-spec.ts
@@ -1,0 +1,82 @@
+import { Test } from '@nestjs/testing'
+import {
+  INestApplication,
+  ValidationPipe,
+  NotFoundException
+} from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+import request from 'supertest'
+import { ReportController } from '../src/report/report.controller'
+import { ReportService } from '../src/report/report.service'
+
+describe('Report (e2e)', () => {
+  let app: INestApplication
+  const service = {
+    getAvailable: jest.fn(),
+    generate: jest.fn(),
+    getHistory: jest.fn(),
+    export: jest.fn()
+  }
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [ReportController],
+      providers: [ReportService]
+    })
+      .overrideProvider(ReportService)
+      .useValue(service)
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: () => true })
+      .compile()
+
+    app = moduleRef.createNestApplication()
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }))
+    await app.init()
+  })
+
+  afterAll(async () => app.close())
+
+  it('/reports (GET)', async () => {
+    service.getAvailable.mockReturnValue([{ id: 1 }])
+    await request(app.getHttpServer())
+      .get('/reports')
+      .expect(200)
+      .expect([{ id: 1 }])
+  })
+
+  it('/reports/generate (POST)', async () => {
+    service.generate.mockResolvedValue({ id: 1 })
+    await request(app.getHttpServer())
+      .post('/reports/generate')
+      .send({ type: 'sales', params: {} })
+      .expect(201)
+      .expect({ id: 1 })
+    expect(service.generate).toHaveBeenCalledWith({ type: 'sales', params: {} })
+  })
+
+  it('/reports/generate (POST) 404', async () => {
+    service.generate.mockRejectedValue(new NotFoundException())
+    await request(app.getHttpServer())
+      .post('/reports/generate')
+      .send({ type: 'sales', params: {} })
+      .expect(404)
+  })
+
+  it('/reports/history (GET)', async () => {
+    service.getHistory.mockResolvedValue([{ id: 1 }])
+    await request(app.getHttpServer())
+      .get('/reports/history')
+      .expect(200)
+      .expect([{ id: 1 }])
+  })
+
+  it('/reports/:id/export/:format (GET)', async () => {
+    service.export.mockResolvedValue({ message: 'ok' })
+    await request(app.getHttpServer())
+      .get('/reports/1/export/pdf')
+      .expect(200)
+      .expect({ message: 'ok' })
+    expect(service.export).toHaveBeenCalledWith(1, 'pdf')
+  })
+})
+

--- a/server/test/task.e2e-spec.ts
+++ b/server/test/task.e2e-spec.ts
@@ -1,0 +1,84 @@
+import { Test } from '@nestjs/testing'
+import {
+  INestApplication,
+  ValidationPipe,
+  NotFoundException
+} from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+import request from 'supertest'
+import { getConnectionToken, getModelToken } from '@nestjs/sequelize'
+import { TaskModule } from '../src/task/task.module'
+import { TaskService } from '../src/task/task.service'
+import { TaskModel } from '../src/task/task.model'
+
+describe('Task (e2e)', () => {
+  let app: INestApplication
+  const service = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn()
+  }
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [TaskModule]
+    })
+      .overrideProvider(TaskService)
+      .useValue(service)
+      .overrideProvider(getModelToken(TaskModel))
+      .useValue({})
+      .overrideProvider(getConnectionToken())
+      .useValue({})
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: () => true })
+      .compile()
+
+    app = moduleRef.createNestApplication()
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }))
+    await app.init()
+  })
+
+  afterAll(async () => app.close())
+
+  it('/task (POST)', async () => {
+    service.create.mockResolvedValue({ id: 1, title: 'Test', deadline: '2099-01-01' })
+    await request(app.getHttpServer())
+      .post('/task')
+      .send({ title: 'Test', deadline: '2099-01-01' })
+      .expect(201)
+      .expect({ id: 1, title: 'Test', deadline: '2099-01-01' })
+    expect(service.create).toHaveBeenCalledWith({ title: 'Test', deadline: '2099-01-01' })
+  })
+
+  it('/task (GET)', async () => {
+    service.findAll.mockResolvedValue([{ id: 1, title: 'A' }])
+    await request(app.getHttpServer())
+      .get('/task')
+      .expect(200)
+      .expect([{ id: 1, title: 'A' }])
+  })
+
+  it('/task/:id (GET) 404', async () => {
+    service.findOne.mockRejectedValue(new NotFoundException())
+    await request(app.getHttpServer()).get('/task/1').expect(404)
+  })
+
+  it('/task/:id (PUT)', async () => {
+    service.update.mockResolvedValue({ id: 1, title: 'New' })
+    await request(app.getHttpServer())
+      .put('/task/1')
+      .send({ title: 'New' })
+      .expect(200)
+      .expect({ id: 1, title: 'New' })
+    expect(service.update).toHaveBeenCalledWith(1, { title: 'New' })
+  })
+
+  it('/task/:id (DELETE)', async () => {
+    service.remove.mockResolvedValue(undefined)
+    await request(app.getHttpServer()).delete('/task/1').expect(200)
+    expect(service.remove).toHaveBeenCalledWith(1)
+  })
+})
+


### PR DESCRIPTION
## Summary
- add unit tests for AuthService covering login, registration and token issuance
- cover TaskService CRUD logic and error handling
- cover ReportService generation, history and export flows
- add e2e tests for auth, task and report controllers

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689a2ecc7a508329be920a97864f9f3d