### PR TITLE
Add controller unit tests across modules

### DIFF
--- a/server/src/auth/auth.controller.spec.ts
+++ b/server/src/auth/auth.controller.spec.ts
@@ -1,0 +1,68 @@
+import { Test } from '@nestjs/testing'
+import {
+  INestApplication,
+  ValidationPipe,
+  UnauthorizedException
+} from '@nestjs/common'
+import request from 'supertest'
+import { AuthController } from './auth.controller'
+import { AuthService } from './auth.service'
+
+describe('AuthController', () => {
+  let app: INestApplication
+  const service = {
+    login: jest.fn(),
+    register: jest.fn()
+  }
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [AuthService]
+    })
+      .overrideProvider(AuthService)
+      .useValue(service)
+      .compile()
+
+    app = moduleRef.createNestApplication()
+    app.useGlobalPipes(new ValidationPipe({ transform: true }))
+    await app.init()
+  })
+
+  afterEach(() => jest.clearAllMocks())
+  afterAll(async () => app.close())
+
+  it('/auth/login POST', async () => {
+    const dto = { email: 'a@test.com', password: 'password' }
+    const result = { token: 't' }
+    service.login.mockResolvedValue(result)
+    await request(app.getHttpServer())
+      .post('/auth/login')
+      .send(dto)
+      .expect(200)
+      .expect(result)
+    expect(service.login).toHaveBeenCalledWith(dto)
+  })
+
+  it('/auth/login POST 401', async () => {
+    const dto = { email: 'a@test.com', password: 'badpass1' }
+    service.login.mockRejectedValue(new UnauthorizedException())
+    await request(app.getHttpServer()).post('/auth/login').send(dto).expect(401)
+  })
+
+  it('/auth/register POST', async () => {
+    const dto = { name: 'A', email: 'a@test.com', password: 'password' }
+    const result = { token: 't' }
+    service.register.mockResolvedValue(result)
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send(dto)
+      .expect(200)
+      .expect(result)
+    expect(service.register).toHaveBeenCalledWith(dto)
+  })
+
+  it('/auth/register POST 400', async () => {
+    await request(app.getHttpServer()).post('/auth/register').send({}).expect(400)
+  })
+})

--- a/server/src/category/category.controller.spec.ts
+++ b/server/src/category/category.controller.spec.ts
@@ -1,0 +1,93 @@
+import { Test } from '@nestjs/testing'
+import {
+  INestApplication,
+  ValidationPipe,
+  NotFoundException
+} from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+import request from 'supertest'
+import { CategoryController } from './category.controller'
+import { CategoryService } from './category.service'
+
+describe('CategoryController', () => {
+  let app: INestApplication
+  const service = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn()
+  }
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [CategoryController],
+      providers: [CategoryService]
+    })
+      .overrideProvider(CategoryService)
+      .useValue(service)
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: () => true })
+      .compile()
+
+    app = moduleRef.createNestApplication()
+    app.useGlobalPipes(new ValidationPipe({ transform: true }))
+    await app.init()
+  })
+
+  afterEach(() => jest.clearAllMocks())
+  afterAll(async () => app.close())
+
+  it('/category POST', async () => {
+    const dto = { name: 'Cat' }
+    const result = { id: 1, ...dto }
+    service.create.mockResolvedValue(result)
+    await request(app.getHttpServer())
+      .post('/category')
+      .send(dto)
+      .expect(201)
+      .expect(result)
+    expect(service.create).toHaveBeenCalledWith(dto)
+  })
+
+  it('/category GET', async () => {
+    const data = [{ id: 1, name: 'A' }]
+    service.findAll.mockResolvedValue(data)
+    await request(app.getHttpServer()).get('/category').expect(200).expect(data)
+    expect(service.findAll).toHaveBeenCalled()
+  })
+
+  it('/category/:id GET', async () => {
+    const data = { id: 1, name: 'A' }
+    service.findOne.mockResolvedValue(data)
+    await request(app.getHttpServer()).get('/category/1').expect(200).expect(data)
+    expect(service.findOne).toHaveBeenCalledWith(1)
+  })
+
+  it('/category/:id GET 404', async () => {
+    service.findOne.mockRejectedValue(new NotFoundException())
+    await request(app.getHttpServer()).get('/category/999').expect(404)
+  })
+
+  it('/category/:id GET 400', async () => {
+    await request(app.getHttpServer()).get('/category/abc').expect(400)
+  })
+
+  it('/category/:id PUT', async () => {
+    const dto = { name: 'B' }
+    const result = { id: 1, name: 'B' }
+    service.update.mockResolvedValue(result)
+    await request(app.getHttpServer())
+      .put('/category/1')
+      .send(dto)
+      .expect(200)
+      .expect(result)
+    expect(service.update).toHaveBeenCalledWith(1, dto)
+  })
+
+  it('/category/:id DELETE', async () => {
+    service.remove.mockResolvedValue(undefined)
+    await request(app.getHttpServer()).delete('/category/1').expect(200)
+    expect(service.remove).toHaveBeenCalledWith(1)
+  })
+})

--- a/server/src/product/product.controller.spec.ts
+++ b/server/src/product/product.controller.spec.ts
@@ -1,0 +1,118 @@
+import { Test } from '@nestjs/testing'
+import {
+  INestApplication,
+  ValidationPipe,
+  NotFoundException
+} from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+import request from 'supertest'
+import { ProductController } from './product.controller'
+import { ProductService } from './product.service'
+
+describe('ProductController', () => {
+  let app: INestApplication
+  const service = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+    getStats: jest.fn(),
+    increaseRemains: jest.fn()
+  }
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [ProductController],
+      providers: [ProductService]
+    })
+      .overrideProvider(ProductService)
+      .useValue(service)
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: () => true })
+      .compile()
+
+    app = moduleRef.createNestApplication()
+    app.useGlobalPipes(new ValidationPipe({ transform: true }))
+    await app.init()
+  })
+
+  afterEach(() => jest.clearAllMocks())
+  afterAll(async () => app.close())
+
+  it('/products POST', async () => {
+    const dto = {
+      name: 'P',
+      articleNumber: 'A1',
+      purchasePrice: 1,
+      salePrice: 2,
+      categoryId: 1
+    }
+    const result = { id: 1, ...dto }
+    service.create.mockResolvedValue(result)
+    await request(app.getHttpServer())
+      .post('/products')
+      .send(dto)
+      .expect(201)
+      .expect(result)
+    expect(service.create).toHaveBeenCalledWith(dto)
+  })
+
+  it('/products GET', async () => {
+    const data = [{ id: 1 }]
+    service.findAll.mockResolvedValue(data)
+    await request(app.getHttpServer()).get('/products').expect(200).expect(data)
+    expect(service.findAll).toHaveBeenCalled()
+  })
+
+  it('/products/:id GET', async () => {
+    const data = { id: 1 }
+    service.findOne.mockResolvedValue(data)
+    await request(app.getHttpServer()).get('/products/1').expect(200).expect(data)
+    expect(service.findOne).toHaveBeenCalledWith(1)
+  })
+
+  it('/products/:id GET 404', async () => {
+    service.findOne.mockRejectedValue(new NotFoundException())
+    await request(app.getHttpServer()).get('/products/999').expect(404)
+  })
+
+  it('/products/:id GET 400', async () => {
+    await request(app.getHttpServer()).get('/products/abc').expect(400)
+  })
+
+  it('/products/:id PUT', async () => {
+    const dto = { name: 'B' }
+    const result = { id: 1, name: 'B' }
+    service.update.mockResolvedValue(result)
+    await request(app.getHttpServer())
+      .put('/products/1')
+      .send(dto)
+      .expect(200)
+      .expect(result)
+    expect(service.update).toHaveBeenCalledWith(1, dto)
+  })
+
+  it('/products/:id DELETE', async () => {
+    service.remove.mockResolvedValue(undefined)
+    await request(app.getHttpServer()).delete('/products/1').expect(200)
+    expect(service.remove).toHaveBeenCalledWith(1)
+  })
+
+  it('/products/:id/stats GET', async () => {
+    const data = { totalUnits: 1, totalRevenue: 2 }
+    service.getStats.mockResolvedValue(data)
+    await request(app.getHttpServer()).get('/products/1/stats').expect(200).expect(data)
+    expect(service.getStats).toHaveBeenCalledWith(1)
+  })
+
+  it('/products/:id/stock POST', async () => {
+    service.increaseRemains.mockResolvedValue(undefined)
+    await request(app.getHttpServer())
+      .post('/products/1/stock')
+      .send({ qty: 5 })
+      .expect(201)
+      .expect({ message: 'Количество единиц товара 1 увеличено на 5' })
+    expect(service.increaseRemains).toHaveBeenCalledWith(1, 5)
+  })
+})

--- a/server/src/report/report.controller.spec.ts
+++ b/server/src/report/report.controller.spec.ts
@@ -1,0 +1,84 @@
+import { Test } from '@nestjs/testing'
+import {
+  INestApplication,
+  ValidationPipe,
+  NotFoundException
+} from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+import request from 'supertest'
+import { ReportController } from './report.controller'
+import { ReportService } from './report.service'
+
+describe('ReportController', () => {
+  let app: INestApplication
+  const service = {
+    getAvailable: jest.fn(),
+    generate: jest.fn(),
+    getHistory: jest.fn(),
+    export: jest.fn()
+  }
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [ReportController],
+      providers: [ReportService]
+    })
+      .overrideProvider(ReportService)
+      .useValue(service)
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: () => true })
+      .compile()
+
+    app = moduleRef.createNestApplication()
+    app.useGlobalPipes(new ValidationPipe({ transform: true }))
+    await app.init()
+  })
+
+  afterEach(() => jest.clearAllMocks())
+  afterAll(async () => app.close())
+
+  it('/reports GET', async () => {
+    const data = ['a']
+    service.getAvailable.mockResolvedValue(data)
+    await request(app.getHttpServer()).get('/reports').expect(200).expect(data)
+    expect(service.getAvailable).toHaveBeenCalled()
+  })
+
+  it('/reports/generate POST', async () => {
+    const dto = { type: 'sales', params: {} }
+    const result = { id: 1 }
+    service.generate.mockResolvedValue(result)
+    await request(app.getHttpServer())
+      .post('/reports/generate')
+      .send(dto)
+      .expect(201)
+      .expect(result)
+    expect(service.generate).toHaveBeenCalledWith(dto)
+  })
+
+  it('/reports/history GET', async () => {
+    const data = [{ id: 1 }]
+    service.getHistory.mockResolvedValue(data)
+    await request(app.getHttpServer()).get('/reports/history').expect(200).expect(data)
+    expect(service.getHistory).toHaveBeenCalled()
+  })
+
+  it('/reports/:id/export/:format GET', async () => {
+    const result = { ok: true }
+    service.export.mockResolvedValue(result)
+    await request(app.getHttpServer())
+      .get('/reports/1/export/pdf')
+      .expect(200)
+      .expect(result)
+    expect(service.export).toHaveBeenCalledWith(1, 'pdf')
+  })
+
+  it('/reports/:id/export/:format GET 404', async () => {
+    service.export.mockRejectedValue(new NotFoundException())
+    await request(app.getHttpServer()).get('/reports/999/export/pdf').expect(404)
+  })
+
+  it('/reports/:id/export/:format GET 400', async () => {
+    await request(app.getHttpServer()).get('/reports/abc/export/pdf').expect(400)
+  })
+})

--- a/server/src/sale/sale.controller.spec.ts
+++ b/server/src/sale/sale.controller.spec.ts
@@ -1,0 +1,98 @@
+import { Test } from '@nestjs/testing'
+import {
+  INestApplication,
+  ValidationPipe,
+  NotFoundException
+} from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+import request from 'supertest'
+import { SaleController } from './sale.controller'
+import { SaleService } from './sale.service'
+
+describe('SaleController', () => {
+  let app: INestApplication
+  const service = {
+    createSale: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn()
+  }
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [SaleController],
+      providers: [SaleService]
+    })
+      .overrideProvider(SaleService)
+      .useValue(service)
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: () => true })
+      .compile()
+
+    app = moduleRef.createNestApplication()
+    app.useGlobalPipes(new ValidationPipe({ transform: true }))
+    await app.init()
+  })
+
+  afterEach(() => jest.clearAllMocks())
+  afterAll(async () => app.close())
+
+  it('/sales POST', async () => {
+    const dto = {
+      productId: 1,
+      quantitySold: 1,
+      totalPrice: 10,
+      saleDate: '2024-01-01'
+    }
+    const result = { id: 1, ...dto }
+    service.createSale.mockResolvedValue(result)
+    await request(app.getHttpServer())
+      .post('/sales')
+      .send(dto)
+      .expect(201)
+      .expect(result)
+    expect(service.createSale).toHaveBeenCalledWith(dto)
+  })
+
+  it('/sales GET', async () => {
+    const data = [{ id: 1 }]
+    service.findAll.mockResolvedValue(data)
+    await request(app.getHttpServer()).get('/sales').expect(200).expect(data)
+    expect(service.findAll).toHaveBeenCalled()
+  })
+
+  it('/sales/:id GET', async () => {
+    const data = { id: 1 }
+    service.findOne.mockResolvedValue(data)
+    await request(app.getHttpServer()).get('/sales/1').expect(200).expect(data)
+    expect(service.findOne).toHaveBeenCalledWith(1)
+  })
+
+  it('/sales/:id GET 404', async () => {
+    service.findOne.mockRejectedValue(new NotFoundException())
+    await request(app.getHttpServer()).get('/sales/999').expect(404)
+  })
+
+  it('/sales/:id GET 400', async () => {
+    await request(app.getHttpServer()).get('/sales/abc').expect(400)
+  })
+
+  it('/sales/:id PUT', async () => {
+    const dto = { quantity: 2 }
+    const result = { id: 1 }
+    service.update.mockResolvedValue(result)
+    await request(app.getHttpServer())
+      .put('/sales/1')
+      .send(dto)
+      .expect(200)
+      .expect(result)
+    expect(service.update).toHaveBeenCalledWith(1, dto)
+  })
+
+  it('/sales/:id DELETE', async () => {
+    service.remove.mockResolvedValue(undefined)
+    await request(app.getHttpServer()).delete('/sales/1').expect(200)
+    expect(service.remove).toHaveBeenCalledWith(1)
+  })
+})

--- a/server/src/task/task.controller.spec.ts
+++ b/server/src/task/task.controller.spec.ts
@@ -1,0 +1,93 @@
+import { Test } from '@nestjs/testing'
+import {
+  INestApplication,
+  ValidationPipe,
+  NotFoundException
+} from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+import request from 'supertest'
+import { TaskController } from './task.controller'
+import { TaskService } from './task.service'
+
+describe('TaskController', () => {
+  let app: INestApplication
+  const service = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn()
+  }
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [TaskController],
+      providers: [TaskService]
+    })
+      .overrideProvider(TaskService)
+      .useValue(service)
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: () => true })
+      .compile()
+
+    app = moduleRef.createNestApplication()
+    app.useGlobalPipes(new ValidationPipe({ transform: true }))
+    await app.init()
+  })
+
+  afterEach(() => jest.clearAllMocks())
+  afterAll(async () => app.close())
+
+  it('/task POST', async () => {
+    const dto = { title: 'T', deadline: '2099-01-01' }
+    const result = { id: 1, ...dto }
+    service.create.mockResolvedValue(result)
+    await request(app.getHttpServer())
+      .post('/task')
+      .send(dto)
+      .expect(201)
+      .expect(result)
+    expect(service.create).toHaveBeenCalledWith(dto)
+  })
+
+  it('/task GET', async () => {
+    const data = [{ id: 1 }]
+    service.findAll.mockResolvedValue(data)
+    await request(app.getHttpServer()).get('/task').expect(200).expect(data)
+    expect(service.findAll).toHaveBeenCalled()
+  })
+
+  it('/task/:id GET', async () => {
+    const data = { id: 1 }
+    service.findOne.mockResolvedValue(data)
+    await request(app.getHttpServer()).get('/task/1').expect(200).expect(data)
+    expect(service.findOne).toHaveBeenCalledWith(1)
+  })
+
+  it('/task/:id GET 404', async () => {
+    service.findOne.mockRejectedValue(new NotFoundException())
+    await request(app.getHttpServer()).get('/task/999').expect(404)
+  })
+
+  it('/task/:id GET 400', async () => {
+    await request(app.getHttpServer()).get('/task/abc').expect(400)
+  })
+
+  it('/task/:id PUT', async () => {
+    const dto = { title: 'B' }
+    const result = { id: 1, title: 'B' }
+    service.update.mockResolvedValue(result)
+    await request(app.getHttpServer())
+      .put('/task/1')
+      .send(dto)
+      .expect(200)
+      .expect(result)
+    expect(service.update).toHaveBeenCalledWith(1, dto)
+  })
+
+  it('/task/:id DELETE', async () => {
+    service.remove.mockResolvedValue(undefined)
+    await request(app.getHttpServer()).delete('/task/1').expect(200)
+    expect(service.remove).toHaveBeenCalledWith(1)
+  })
+})


### PR DESCRIPTION
## Summary
- add controller tests for categories, products, sales, tasks, reports, and auth modules
- cover success paths, not found errors, and validation edge cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a31cce1a88329a7a86105db1e5dbf