### PR TITLE
Add comprehensive unit tests for missing modules and transaction handling

### DIFF
--- a/server/src/app.service.spec.ts
+++ b/server/src/app.service.spec.ts
@@ -1,0 +1,8 @@
+import { AppService } from './app.service'
+
+describe('AppService', () => {
+  it('getHello returns greeting', () => {
+    const service = new AppService()
+    expect(service.getHello()).toBe('Hello World!')
+  })
+})

--- a/server/src/config/db.config.spec.ts
+++ b/server/src/config/db.config.spec.ts
@@ -1,0 +1,37 @@
+import { getSequelizeConfig } from './db.config'
+
+const makeConfigService = (values: Record<string, any>) => ({
+  get: jest.fn((key: string, def?: any) =>
+    key in values ? values[key] : def
+  ),
+}) as any
+
+describe('getSequelizeConfig', () => {
+  it('returns config when env vars set', () => {
+    const configService = makeConfigService({
+      DB_HOST: 'localhost',
+      DB_PORT: 5433,
+      DB_DATABASE: 'db',
+      DB_USERNAME: 'user',
+      DB_PASSWORD: 'pass',
+      NODE_ENV: 'development',
+    })
+
+    const cfg = getSequelizeConfig(configService)
+    expect(cfg).toMatchObject({
+      host: 'localhost',
+      port: 5433,
+      database: 'db',
+      username: 'user',
+      password: 'pass',
+      synchronize: true,
+    })
+  })
+
+  it('throws when required vars missing', () => {
+    const configService = makeConfigService({})
+    expect(() => getSequelizeConfig(configService)).toThrow(
+      /DB_DATABASE, DB_USERNAME или DB_PASSWORD/
+    )
+  })
+})

--- a/server/src/config/jwt.config.spec.ts
+++ b/server/src/config/jwt.config.spec.ts
@@ -1,0 +1,14 @@
+import { getJWTConfig } from './jwt.config'
+
+describe('getJWTConfig', () => {
+  it('returns secret from config', async () => {
+    const configService = { get: jest.fn().mockReturnValue('secret') } as any
+    await expect(getJWTConfig(configService)).resolves.toEqual({ secret: 'secret' })
+    expect(configService.get).toHaveBeenCalledWith('JWT_SECRET')
+  })
+
+  it('handles missing secret', async () => {
+    const configService = { get: jest.fn().mockReturnValue(undefined) } as any
+    await expect(getJWTConfig(configService)).resolves.toEqual({ secret: undefined })
+  })
+})

--- a/server/src/product/product.service.spec.ts
+++ b/server/src/product/product.service.spec.ts
@@ -33,15 +33,58 @@ describe('ProductService.decreaseRemains', () => {
 		expect(productRepo.decrement).not.toHaveBeenCalled()
 	})
 
-	it('decrements when enough remains', async () => {
-		jest
-			.spyOn(service, 'findOne')
-			.mockResolvedValue({ id: 1, remains: 10 } as any)
-		const trx = {} as any
-		await service.decreaseRemains(1, 5, trx)
-		expect(productRepo.decrement).toHaveBeenCalledWith(
-			{ remains: 5 },
-			{ where: { id: 1 }, transaction: trx }
-		)
-	})
+        it('decrements when enough remains', async () => {
+                jest
+                        .spyOn(service, 'findOne')
+                        .mockResolvedValue({ id: 1, remains: 10 } as any)
+                const trx = {} as any
+                await service.decreaseRemains(1, 5, trx)
+                expect(productRepo.decrement).toHaveBeenCalledWith(
+                        { remains: 5 },
+                        { where: { id: 1 }, transaction: trx }
+                )
+        })
+
+        it('uses transaction and commits when trx not provided', async () => {
+                jest
+                        .spyOn(service, 'findOne')
+                        .mockResolvedValue({ id: 1, remains: 10 } as any)
+                const commit = jest.fn()
+                const rollback = jest.fn()
+                sequelize.transaction.mockImplementation(async (cb) => {
+                        const trx = { commit, rollback }
+                        const res = await cb(trx)
+                        await commit()
+                        return res
+                })
+                await service.decreaseRemains(1, 5)
+                expect(sequelize.transaction).toHaveBeenCalled()
+                expect(productRepo.decrement).toHaveBeenCalled()
+                expect(commit).toHaveBeenCalled()
+                expect(rollback).not.toHaveBeenCalled()
+        })
+
+        it('rolls back transaction on error', async () => {
+                jest
+                        .spyOn(service, 'findOne')
+                        .mockResolvedValue({ id: 1, remains: 1 } as any)
+                const commit = jest.fn()
+                const rollback = jest.fn()
+                sequelize.transaction.mockImplementation(async (cb) => {
+                        const trx = { commit, rollback }
+                        try {
+                                const res = await cb(trx)
+                                await commit()
+                                return res
+                        } catch (e) {
+                                await rollback()
+                                throw e
+                        }
+                })
+                await expect(service.decreaseRemains(1, 5)).rejects.toThrow(
+                        BadRequestException
+                )
+                expect(commit).not.toHaveBeenCalled()
+                expect(rollback).toHaveBeenCalled()
+        })
 })

--- a/server/src/sale/sale.service.spec.ts
+++ b/server/src/sale/sale.service.spec.ts
@@ -1,5 +1,6 @@
 import { SaleService } from './sale.service'
 import { UpdateSaleDto } from './dto/update.sale.dto'
+import { CreateSaleDto } from './dto/sale.dto'
 
 describe('SaleService.update', () => {
         it('should handle product change with stock adjustments and price recalculation', async () => {
@@ -60,5 +61,84 @@ describe('SaleService.update', () => {
                         },
                         { transaction: trx }
                 )
+        })
+})
+
+describe('SaleService.createSale transactions', () => {
+        it('commits on success', async () => {
+                const saleRepo = { create: jest.fn().mockResolvedValue({}) }
+                const productService = {
+                        decreaseRemains: jest.fn().mockResolvedValue(undefined),
+                        findOne: jest.fn().mockResolvedValue({ salePrice: 10 })
+                }
+                const commit = jest.fn()
+                const rollback = jest.fn()
+                const sequelize = {
+                        transaction: jest.fn(async (cb: any) => {
+                                const trx = { commit, rollback }
+                                const res = await cb(trx)
+                                await commit()
+                                return res
+                        })
+                }
+                const service = new SaleService(
+                        saleRepo as any,
+                        sequelize as any,
+                        productService as any
+                )
+                const dto: CreateSaleDto = {
+                        productId: 1,
+                        quantitySold: 2,
+                        saleDate: '2024-01-01',
+                        totalPrice: 0 as any
+                }
+                await service.createSale(dto)
+                expect(sequelize.transaction).toHaveBeenCalled()
+                expect(productService.decreaseRemains).toHaveBeenCalledWith(
+                        1,
+                        2,
+                        expect.any(Object)
+                )
+                expect(commit).toHaveBeenCalled()
+                expect(rollback).not.toHaveBeenCalled()
+        })
+
+        it('rolls back on error', async () => {
+                const saleRepo = { create: jest.fn() }
+                const productService = {
+                        decreaseRemains: jest
+                                .fn()
+                                .mockRejectedValue(new Error('fail')),
+                        findOne: jest.fn()
+                }
+                const commit = jest.fn()
+                const rollback = jest.fn()
+                const sequelize = {
+                        transaction: jest.fn(async (cb: any) => {
+                                const trx = { commit, rollback }
+                                try {
+                                        const res = await cb(trx)
+                                        await commit()
+                                        return res
+                                } catch (e) {
+                                        await rollback()
+                                        throw e
+                                }
+                        })
+                }
+                const service = new SaleService(
+                        saleRepo as any,
+                        sequelize as any,
+                        productService as any
+                )
+                const dto: CreateSaleDto = {
+                        productId: 1,
+                        quantitySold: 2,
+                        saleDate: '2024-01-01',
+                        totalPrice: 0 as any
+                }
+                await expect(service.createSale(dto)).rejects.toThrow('fail')
+                expect(commit).not.toHaveBeenCalled()
+                expect(rollback).toHaveBeenCalled()
         })
 })

--- a/server/src/validators/is-future-date.decorator.spec.ts
+++ b/server/src/validators/is-future-date.decorator.spec.ts
@@ -1,0 +1,29 @@
+import { validate } from 'class-validator'
+import { IsFutureDate } from './is-future-date.decorator'
+
+class TestDto {
+  @IsFutureDate()
+  date!: string
+}
+
+describe('IsFutureDate', () => {
+  it('accepts today or future date', async () => {
+    const dto = new TestDto()
+    dto.date = new Date().toISOString()
+    const errors = await validate(dto)
+    expect(errors.length).toBe(0)
+  })
+
+  it('rejects past date', async () => {
+    const dto = new TestDto()
+    dto.date = new Date(Date.now() - 86400000).toISOString()
+    const errors = await validate(dto)
+    expect(errors[0].constraints?.IsFutureDate).toBe('date не может быть в прошлом')
+  })
+
+  it('rejects missing value', async () => {
+    const dto = new TestDto()
+    const errors = await validate(dto)
+    expect(errors[0].constraints?.IsFutureDate).toBe('date не может быть в прошлом')
+  })
+})


### PR DESCRIPTION
## Summary
- Add tests for AppService, configuration helpers, and custom validator
- Verify Sequelize transaction commit/rollback in ProductService and SaleService

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a33ce4d2c8329a30e92e51ec9ed58