### PR TITLE
test: add e2e tests for product and sale modules

### DIFF
--- a/server/test/product.e2e-spec.ts
+++ b/server/test/product.e2e-spec.ts
@@ -1,0 +1,131 @@
+import { Test } from '@nestjs/testing'
+import {
+  INestApplication,
+  ValidationPipe,
+  NotFoundException
+} from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+import request from 'supertest'
+import { getConnectionToken, getModelToken } from '@nestjs/sequelize'
+import { ProductModule } from '../src/product/product.module'
+import { ProductService } from '../src/product/product.service'
+import { ProductModel } from '../src/product/product.model'
+import { CategoryModel } from '../src/category/category.model'
+
+describe('Product (e2e)', () => {
+  let app: INestApplication
+  const service = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+    getStats: jest.fn(),
+    increaseRemains: jest.fn()
+  }
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [ProductModule]
+    })
+      .overrideProvider(ProductService)
+      .useValue(service)
+      .overrideProvider(getModelToken(ProductModel))
+      .useValue({})
+      .overrideProvider(getModelToken(CategoryModel))
+      .useValue({})
+      .overrideProvider(getConnectionToken())
+      .useValue({})
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: () => true })
+      .compile()
+
+    app = moduleRef.createNestApplication()
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }))
+    await app.init()
+  })
+
+  afterAll(async () => app.close())
+  afterEach(() => jest.clearAllMocks())
+
+  it('/products (POST)', async () => {
+    const dto = {
+      name: 'P',
+      articleNumber: 'A',
+      purchasePrice: 10,
+      salePrice: 20,
+      categoryName: 'C',
+      remains: 5
+    }
+    const result = { id: 1, ...dto }
+    service.create.mockResolvedValue(result)
+    await request(app.getHttpServer())
+      .post('/products')
+      .send(dto)
+      .expect(201)
+      .expect(result)
+    expect(service.create).toHaveBeenCalledWith(dto)
+  })
+
+  it('/products (GET)', async () => {
+    const data = [{ id: 1 }]
+    service.findAll.mockResolvedValue(data)
+    await request(app.getHttpServer()).get('/products').expect(200).expect(data)
+    expect(service.findAll).toHaveBeenCalled()
+  })
+
+  it('/products/:id (GET)', async () => {
+    const data = { id: 1 }
+    service.findOne.mockResolvedValue(data)
+    await request(app.getHttpServer()).get('/products/1').expect(200).expect(data)
+    expect(service.findOne).toHaveBeenCalledWith(1)
+  })
+
+  it('/products/:id (GET) 404', async () => {
+    service.findOne.mockRejectedValue(new NotFoundException())
+    await request(app.getHttpServer()).get('/products/999').expect(404)
+  })
+
+  it('/products/:id (GET) 400', async () => {
+    await request(app.getHttpServer()).get('/products/abc').expect(400)
+  })
+
+  it('/products/:id (PUT)', async () => {
+    const dto = { name: 'N' }
+    const result = { id: 1, name: 'N' }
+    service.update.mockResolvedValue(result)
+    await request(app.getHttpServer())
+      .put('/products/1')
+      .send(dto)
+      .expect(200)
+      .expect(result)
+    expect(service.update).toHaveBeenCalledWith(1, dto)
+  })
+
+  it('/products/:id (DELETE)', async () => {
+    service.remove.mockResolvedValue(undefined)
+    await request(app.getHttpServer()).delete('/products/1').expect(200)
+    expect(service.remove).toHaveBeenCalledWith(1)
+  })
+
+  it('/products/:id/stats (GET)', async () => {
+    const stats = { totalUnits: 5, totalRevenue: 100 }
+    service.getStats.mockResolvedValue(stats)
+    await request(app.getHttpServer())
+      .get('/products/1/stats')
+      .expect(200)
+      .expect(stats)
+    expect(service.getStats).toHaveBeenCalledWith(1)
+  })
+
+  it('/products/:id/stock (POST)', async () => {
+    service.increaseRemains.mockResolvedValue(undefined)
+    await request(app.getHttpServer())
+      .post('/products/1/stock')
+      .send({ qty: 2 })
+      .expect(201)
+      .expect({ message: 'Количество единиц товара 1 увеличено на 2' })
+    expect(service.increaseRemains).toHaveBeenCalledWith(1, 2)
+  })
+})
+

--- a/server/test/sale.e2e-spec.ts
+++ b/server/test/sale.e2e-spec.ts
@@ -1,0 +1,108 @@
+import { Test } from '@nestjs/testing'
+import {
+  INestApplication,
+  ValidationPipe,
+  NotFoundException
+} from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+import request from 'supertest'
+import { getConnectionToken, getModelToken } from '@nestjs/sequelize'
+import { SaleModule } from '../src/sale/sale.module'
+import { SaleService } from '../src/sale/sale.service'
+import { SaleModel } from '../src/sale/sale.model'
+import { ProductService } from '../src/product/product.service'
+import { ProductModel } from '../src/product/product.model'
+import { CategoryModel } from '../src/category/category.model'
+
+describe('Sale (e2e)', () => {
+  let app: INestApplication
+  const service = {
+    createSale: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn()
+  }
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [SaleModule]
+    })
+      .overrideProvider(SaleService)
+      .useValue(service)
+      .overrideProvider(ProductService)
+      .useValue({})
+      .overrideProvider(getModelToken(SaleModel))
+      .useValue({})
+      .overrideProvider(getModelToken(ProductModel))
+      .useValue({})
+      .overrideProvider(getModelToken(CategoryModel))
+      .useValue({})
+      .overrideProvider(getConnectionToken())
+      .useValue({})
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: () => true })
+      .compile()
+
+    app = moduleRef.createNestApplication()
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }))
+    await app.init()
+  })
+
+  afterAll(async () => app.close())
+  afterEach(() => jest.clearAllMocks())
+
+  it('/sales (POST)', async () => {
+    const dto = { productId: 1, quantitySold: 1, saleDate: '2024-01-01', totalPrice: 10 }
+    const result = { id: 1, ...dto }
+    service.createSale.mockResolvedValue(result)
+    await request(app.getHttpServer())
+      .post('/sales')
+      .send(dto)
+      .expect(201)
+      .expect(result)
+    expect(service.createSale).toHaveBeenCalledWith(dto)
+  })
+
+  it('/sales (GET)', async () => {
+    const data = [{ id: 1 }]
+    service.findAll.mockResolvedValue(data)
+    await request(app.getHttpServer()).get('/sales').expect(200).expect(data)
+    expect(service.findAll).toHaveBeenCalled()
+  })
+
+  it('/sales/:id (GET)', async () => {
+    const data = { id: 1 }
+    service.findOne.mockResolvedValue(data)
+    await request(app.getHttpServer()).get('/sales/1').expect(200).expect(data)
+    expect(service.findOne).toHaveBeenCalledWith(1)
+  })
+
+  it('/sales/:id (GET) 404', async () => {
+    service.findOne.mockRejectedValue(new NotFoundException())
+    await request(app.getHttpServer()).get('/sales/999').expect(404)
+  })
+
+  it('/sales/:id (GET) 400', async () => {
+    await request(app.getHttpServer()).get('/sales/abc').expect(400)
+  })
+
+  it('/sales/:id (PUT)', async () => {
+    const dto = { quantitySold: 2 }
+    const result = { id: 1 }
+    service.update.mockResolvedValue(result)
+    await request(app.getHttpServer())
+      .put('/sales/1')
+      .send(dto)
+      .expect(200)
+      .expect(result)
+    expect(service.update).toHaveBeenCalledWith(1, dto)
+  })
+
+  it('/sales/:id (DELETE)', async () => {
+    service.remove.mockResolvedValue(undefined)
+    await request(app.getHttpServer()).delete('/sales/1').expect(200)
+    expect(service.remove).toHaveBeenCalledWith(1)
+  })
+})
+


### PR DESCRIPTION
## Summary
- add e2e tests for product controller
- add e2e tests for sale controller

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689a3691ccf48329b3893bb2aff6787d