### PR TITLE
test: add frontend test setup and examples

### DIFF
--- a/dashboard-ui/app/components/tasks/TaskForm.test.tsx
+++ b/dashboard-ui/app/components/tasks/TaskForm.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import TaskForm from './TaskForm'
+import { vi } from 'vitest'
+
+vi.mock('@/services/task/task.service', () => ({
+  TaskService: {
+    create: vi.fn(() => Promise.resolve({})),
+    update: vi.fn(() => Promise.resolve({})),
+  },
+}))
+
+const push = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}))
+
+describe('TaskForm', () => {
+  it('submits new task (happy path)', async () => {
+    render(<TaskForm />)
+    await userEvent.type(screen.getByPlaceholderText('Заголовок'), 'Test')
+    const dateInput = document.querySelector('input[type="date"]') as HTMLInputElement
+    await userEvent.type(dateInput, '2099-01-01')
+    await userEvent.click(screen.getByRole('button', { name: 'Сохранить' }))
+
+    const { TaskService } = await import('@/services/task/task.service')
+    expect(TaskService.create).toHaveBeenCalled()
+    expect(push).toHaveBeenCalledWith('/tasks')
+  })
+
+  it('shows validation error', async () => {
+    render(<TaskForm />)
+    await userEvent.click(screen.getByRole('button', { name: 'Сохранить' }))
+    expect(await screen.findByText('Введите заголовок')).toBeInTheDocument()
+  })
+
+  it('handles submit error', async () => {
+    const { TaskService } = await import('@/services/task/task.service')
+    ;(TaskService.create as any).mockRejectedValueOnce(new Error('fail'))
+
+    render(<TaskForm />)
+    await userEvent.type(screen.getByPlaceholderText('Заголовок'), 'Test')
+    const dateInput = document.querySelector('input[type="date"]') as HTMLInputElement
+    await userEvent.type(dateInput, '2099-01-01')
+    await userEvent.click(screen.getByRole('button', { name: 'Сохранить' }))
+
+    expect(await screen.findByText('fail')).toBeInTheDocument()
+  })
+})

--- a/dashboard-ui/app/components/tasks/TasksTable.test.tsx
+++ b/dashboard-ui/app/components/tasks/TasksTable.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import TasksTable from './TasksTable'
+import { server } from '@/tests/mocks/server'
+
+describe('TasksTable', () => {
+  it('renders tasks from API (happy path)', async () => {
+    render(<TasksTable />)
+    expect(await screen.findByText('Task 1')).toBeInTheDocument()
+  })
+
+  it('shows error on API failure', async () => {
+    server.use(
+      http.get('http://localhost:4000/api/task', () => HttpResponse.error())
+    )
+    render(<TasksTable />)
+    await waitFor(() => expect(screen.getByText(/error/i)).toBeInTheDocument())
+  })
+
+  it('handles empty data', async () => {
+    server.use(
+      http.get('http://localhost:4000/api/task', () => HttpResponse.json([]))
+    )
+    render(<TasksTable />)
+    await waitFor(() => {
+      const rows = screen.queryAllByRole('row')
+      // header + no data
+      expect(rows).toHaveLength(1)
+    })
+  })
+
+  it('filters by priority', async () => {
+    render(<TasksTable />)
+    await screen.findByText('Task 1')
+    const select = screen.getByRole('combobox')
+    await userEvent.selectOptions(select, 'Высокий')
+    expect(screen.getByText('Task 1')).toBeInTheDocument()
+  })
+
+  it('deletes a task', async () => {
+    render(<TasksTable />)
+    const deleteBtn = await screen.findByRole('button', { name: /удалить/i })
+    await userEvent.click(deleteBtn)
+    await waitFor(() => {
+      expect(screen.queryByText('Task 1')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/dashboard-ui/app/hooks/useAuth.test.tsx
+++ b/dashboard-ui/app/hooks/useAuth.test.tsx
@@ -1,0 +1,17 @@
+import { renderHook } from '@testing-library/react'
+import React from 'react'
+import { AuthContext } from '@/providers/auth-provider/AuthProvider'
+import { useAuth } from './useAuth'
+import { vi } from 'vitest'
+
+describe('useAuth', () => {
+  it('returns context value', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthContext.Provider value={{ user: { id: 1 } as any, setUser: vi.fn() }}>
+        {children}
+      </AuthContext.Provider>
+    )
+    const { result } = renderHook(() => useAuth(), { wrapper })
+    expect(result.current.user).toEqual({ id: 1 })
+  })
+})

--- a/dashboard-ui/app/hooks/useOutside.test.ts
+++ b/dashboard-ui/app/hooks/useOutside.test.ts
@@ -1,0 +1,21 @@
+import { renderHook, act } from '@testing-library/react'
+import { useOutside } from './useOutside'
+
+describe('useOutside', () => {
+  it('toggles visibility when clicking outside', () => {
+    const { result } = renderHook(() => useOutside<HTMLDivElement>(true))
+    const div = document.createElement('div')
+    result.current.ref.current = div
+    document.body.appendChild(div)
+
+    act(() => {
+      div.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(result.current.isShow).toBe(true)
+
+    act(() => {
+      document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(result.current.isShow).toBe(false)
+  })
+})

--- a/dashboard-ui/app/utils/animations/fade.test.ts
+++ b/dashboard-ui/app/utils/animations/fade.test.ts
@@ -1,0 +1,9 @@
+import { FADE_IN } from './fade'
+
+describe('FADE_IN utility', () => {
+  it('contains fade animation config', () => {
+    expect(FADE_IN.initial).toEqual({ opacity: 0 })
+    expect(FADE_IN.whileInView).toEqual({ opacity: 1 })
+    expect(FADE_IN.transition).toEqual({ duration: 0.6 })
+  })
+})

--- a/dashboard-ui/e2e/basic.spec.ts
+++ b/dashboard-ui/e2e/basic.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test'
+
+test('home page loads', async ({ page }) => {
+  await page.goto('http://localhost:3000')
+  await expect(page).toHaveTitle(/Главная|Dashboard/i)
+})

--- a/dashboard-ui/package.json
+++ b/dashboard-ui/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "test": "npm run lint"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.84.1",
@@ -27,17 +28,26 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.54.2",
+    "@testing-library/jest-dom": "^6.6.4",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@types/node": "^20.11.24",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
+    "@vitejs/plugin-react": "^5.0.0",
     "autoprefixer": "^10.4.21",
     "eslint": "^8.56.0",
     "eslint-config-next": "14.2.0",
+    "jsdom": "^26.1.0",
+    "msw": "^2.10.4",
     "postcss": "^8.4.38",
     "prettier": "^3.6.2",
     "tailwindcss": "^3.4.3",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.2.4"
   }
 }

--- a/dashboard-ui/playwright.config.ts
+++ b/dashboard-ui/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: 'e2e',
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    timeout: 120000,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    headless: true,
+  },
+})

--- a/dashboard-ui/tests/mocks/handlers.ts
+++ b/dashboard-ui/tests/mocks/handlers.ts
@@ -1,0 +1,23 @@
+import { http, HttpResponse } from 'msw'
+import { ITask } from '@/shared/interfaces/task.interface'
+
+export const mockTasks: ITask[] = [
+  {
+    id: 1,
+    title: 'Task 1',
+    description: 'Desc',
+    executor: 'John',
+    deadline: '2024-01-01',
+    priority: 'Высокий',
+    status: 'Ожидает',
+  },
+]
+
+export const handlers = [
+  http.get('http://localhost:4000/api/task', () => {
+    return HttpResponse.json(mockTasks)
+  }),
+  http.delete('http://localhost:4000/api/task/:id', () => {
+    return HttpResponse.json({})
+  }),
+]

--- a/dashboard-ui/tests/mocks/server.ts
+++ b/dashboard-ui/tests/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from 'msw/node'
+import { handlers } from './handlers'
+
+export const server = setupServer(...handlers)

--- a/dashboard-ui/tsconfig.json
+++ b/dashboard-ui/tsconfig.json
@@ -31,7 +31,8 @@
       "@/utils/*": ["utils/*"],
       "@/store/*": ["store/*"],
       "@/assets/*": ["assets/*"],
-      "@/providers/*": ["providers/*"]
+      "@/providers/*": ["providers/*"],
+      "@/tests/*": ["../tests/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/dashboard-ui/vitest.config.ts
+++ b/dashboard-ui/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+  plugins: [react(), tsconfigPaths()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './vitest.setup.tsx',
+    exclude: ['**/node_modules/**', 'e2e/**'],
+  },
+})

--- a/dashboard-ui/vitest.setup.tsx
+++ b/dashboard-ui/vitest.setup.tsx
@@ -1,0 +1,18 @@
+import '@testing-library/jest-dom'
+import { afterEach, beforeAll, afterAll, vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { server } from './tests/mocks/server'
+import React from 'react'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+beforeAll(() => server.listen())
+afterEach(() => {
+  server.resetHandlers()
+  cleanup()
+})
+afterAll(() => server.close())


### PR DESCRIPTION
## Summary
- setup vitest and msw for frontend unit tests
- add tests for tasks table, task form, hooks and animation util
- scaffold Playwright e2e test

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browser executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_689a3b18696c8329a6dd2a1bc5cb4e8c