### PR TITLE
fix: update category selection handling

### DIFF
--- a/dashboard-ui/app/reports/new/page.tsx
+++ b/dashboard-ui/app/reports/new/page.tsx
@@ -55,7 +55,10 @@ export default function NewReportPage() {
   const handleCategoryChange = (
     e: React.ChangeEvent<HTMLSelectElement>,
   ) => {
-    const values = Array.from(e.target.selectedOptions).map(o => Number(o.value))
+    const values = Array.from(
+      e.target.selectedOptions,
+      option => Number(option.value),
+    )
     setSelectedCategories(values)
   }
 

--- a/dashboard-ui/app/reports/page.tsx
+++ b/dashboard-ui/app/reports/page.tsx
@@ -130,7 +130,10 @@ export default function ReportsPage() {
   )
 
   const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const values = Array.from(e.target.selectedOptions).map(o => Number(o.value))
+    const values = Array.from(
+      e.target.selectedOptions,
+      option => Number(option.value),
+    )
     setSelectedCategories(values)
   }
 


### PR DESCRIPTION
## Summary
- properly map selected options to numeric category IDs on reports pages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a44be50188329a29eac097554cb45