### PR TITLE
feat: add email confirmation flow

### DIFF
--- a/dashboard-ui/app/components/ui/header/login-form/LoginForm.tsx
+++ b/dashboard-ui/app/components/ui/header/login-form/LoginForm.tsx
@@ -6,7 +6,7 @@ import { SubmitHandler, useForm } from 'react-hook-form'
 import { IAuthFields } from '@/ui/header/login-form/login-form.interface'
 import { useAuth } from '@/hooks/useAuth'
 import styles from './LoginForm.module.scss'
-import { FaRegUserCircle } from 'react-icons/fa'
+import { FaRegUserCircle, FaUserCircle } from 'react-icons/fa'
 import Field from '@/ui/Field/Field'
 import Button from '@/ui/Button/Button'
 import { FADE_IN } from '@/utils/animations/fade'
@@ -19,6 +19,7 @@ const LoginForm: FC = () => {
   const { ref, isShow, setIsShow } = useOutside<HTMLDivElement>(false)
   const [type, setType] = useState<'login' | 'register'>('login')
   const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
 
   const {
     register,
@@ -46,11 +47,14 @@ const LoginForm: FC = () => {
     mutationFn: (data: IAuthFields) =>
       AuthService.register(data.email, data.password),
     onSuccess: data => {
-      if (setUser) setUser(data.user)
+      setMessage(data.message)
+      setError(null)
       reset()
-      setIsShow(false)
     },
-    onError: (e: any) => setError(e.message),
+    onError: (e: any) => {
+      setError(e.message)
+      setMessage(null)
+    },
   })
 
   const loginSync = loginMutation.mutate
@@ -64,7 +68,7 @@ const LoginForm: FC = () => {
   return (
     <div className={styles.wrapper} ref={ref}>
       <Button className={styles.button} onClick={() => setIsShow(!isShow)}>
-        <FaRegUserCircle />
+        {user ? <FaUserCircle /> : <FaRegUserCircle />}
       </Button>
 
       {isShow && (
@@ -110,6 +114,7 @@ const LoginForm: FC = () => {
               Регистрация
             </Button>
             {error && <p className="text-error text-sm mt-2">{error}</p>}
+            {message && <p className="text-success text-sm mt-2">{message}</p>}
           </form>
         </motion.div>
       )}

--- a/dashboard-ui/app/services/auth/auth.service.ts
+++ b/dashboard-ui/app/services/auth/auth.service.ts
@@ -24,16 +24,23 @@ export const AuthService = {
 
   /**
    * POST /auth/register
-   * Регистрирует нового пользователя и сохраняет токены.
+   * Регистрирует нового пользователя и отправляет письмо подтверждения.
    */
   async register(email: string, password: string) {
-    const respone = await axiosClassic.post<IAuthResponse>('/auth/register', {
+    const respone = await axiosClassic.post<{ message: string }>('/auth/register', {
       email,
       password,
     })
 
-    if (respone.data.accessToken) saveToStorage(respone.data)
+    return respone.data
+  },
 
+  /**
+   * POST /auth/resend
+   * Повторная отправка письма подтверждения.
+   */
+  async resend(email: string) {
+    const respone = await axiosClassic.post<{ message: string }>('/auth/resend', { email })
     return respone.data
   },
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -10,3 +10,11 @@ DB_USERNAME=user
 DB_PASSWORD=password
 # JWT secret for auth module
 JWT_SECRET=super-secret
+# SMTP settings for sending confirmation emails
+MAIL_HOST=localhost
+MAIL_PORT=587
+MAIL_USER=user
+MAIL_PASSWORD=password
+MAIL_FROM=example@example.com
+# Public URL of the server for confirmation links
+SERVER_URL=http://localhost:4000

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -24,6 +24,7 @@
         "class-validator": "^0.14.2",
         "dotenv": "^17.2.1",
         "luxon": "^3.7.1",
+        "nodemailer": "^6.9.15",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.16.3",
@@ -6802,6 +6803,15 @@
       "version": "2.0.19",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nopt": {
       "version": "7.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -38,6 +38,7 @@
     "class-validator": "^0.14.2",
     "dotenv": "^17.2.1",
     "luxon": "^3.7.1",
+    "nodemailer": "^6.9.15",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.16.3",

--- a/server/src/auth/auth.controller.spec.ts
+++ b/server/src/auth/auth.controller.spec.ts
@@ -12,7 +12,9 @@ describe('AuthController', () => {
   let app: INestApplication
   const service = {
     login: jest.fn(),
-    register: jest.fn()
+    register: jest.fn(),
+    confirmEmail: jest.fn(),
+    resendConfirmation: jest.fn()
   }
 
   beforeAll(async () => {
@@ -52,7 +54,7 @@ describe('AuthController', () => {
 
   it('/auth/register POST', async () => {
     const dto = { name: 'A', email: 'a@test.com', password: 'password' }
-    const result = { token: 't' }
+    const result = { message: 'ok' }
     service.register.mockResolvedValue(result)
     await request(app.getHttpServer())
       .post('/auth/register')
@@ -64,5 +66,27 @@ describe('AuthController', () => {
 
   it('/auth/register POST 400', async () => {
     await request(app.getHttpServer()).post('/auth/register').send({}).expect(400)
+  })
+
+  it('/auth/confirm GET', async () => {
+    const result = { message: 'done' }
+    service.confirmEmail.mockResolvedValue(result)
+    await request(app.getHttpServer())
+      .get('/auth/confirm/token123')
+      .expect(200)
+      .expect(result)
+    expect(service.confirmEmail).toHaveBeenCalledWith('token123')
+  })
+
+  it('/auth/resend POST', async () => {
+    const dto = { email: 'a@test.com' }
+    const result = { message: 'sent' }
+    service.resendConfirmation.mockResolvedValue(result)
+    await request(app.getHttpServer())
+      .post('/auth/resend')
+      .send(dto)
+      .expect(200)
+      .expect(result)
+    expect(service.resendConfirmation).toHaveBeenCalledWith(dto.email)
   })
 })

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -1,13 +1,16 @@
 import {
-	Body,
-	Controller,
-	HttpCode,
-	Post,
-	UsePipes,
-	ValidationPipe
+        Body,
+        Controller,
+        Get,
+        HttpCode,
+        Param,
+        Post,
+        UsePipes,
+        ValidationPipe
 } from '@nestjs/common'
 import { AuthService } from './auth.service'
 import { AuthDto } from './dto/auth.dto'
+import { EmailDto } from './dto/email.dto'
 
 /**
  * Контроллер для авторизации и регистрации пользователей.
@@ -33,8 +36,21 @@ export class AuthController {
 	 */
 	@UsePipes(new ValidationPipe())
 	@HttpCode(200)
-	@Post('register')
-	async register(@Body() dto: AuthDto) {
-		return this.authService.register(dto)
-	}
+        @Post('register')
+        async register(@Body() dto: AuthDto) {
+                return this.authService.register(dto)
+        }
+
+        @HttpCode(200)
+        @Get('confirm/:token')
+        async confirm(@Param('token') token: string) {
+                return this.authService.confirmEmail(token)
+        }
+
+        @UsePipes(new ValidationPipe())
+        @HttpCode(200)
+        @Post('resend')
+        async resend(@Body() dto: EmailDto) {
+                return this.authService.resendConfirmation(dto.email)
+        }
 }

--- a/server/src/auth/auth.service.spec.ts
+++ b/server/src/auth/auth.service.spec.ts
@@ -14,6 +14,7 @@ const mockUser = {
   email: 'test@example.com',
   password: 'hashed',
   name: 'Test',
+  isConfirmed: true,
   get: function() { return this }
 }
 
@@ -72,13 +73,12 @@ describe('AuthService', () => {
   it('register success', async () => {
     userModel.findOne.mockResolvedValue(null)
     userModel.create.mockResolvedValue(mockUser)
+    ;(service as any).sendConfirmationEmail = jest.fn()
     const dto: AuthDto = { email: 'test@example.com', password: '12345678' }
     const res = await service.register(dto)
-    expect(res).toEqual({
-      user: { id: 1, email: 'test@example.com', name: 'Test' },
-      accessToken: 'token'
-    })
+    expect(res).toEqual({ message: 'Письмо для подтверждения отправлено' })
     expect(hash).toHaveBeenCalled()
+    expect((service as any).sendConfirmationEmail).toHaveBeenCalled()
   })
 
   it('register conflict', async () => {
@@ -86,6 +86,30 @@ describe('AuthService', () => {
     await expect(
       service.register({ email: 'test@example.com', password: '12345678' })
     ).rejects.toBeInstanceOf(BadRequestException)
+  })
+
+  it('resendConfirmation', async () => {
+    const user = { ...mockUser, isConfirmed: false, save: jest.fn().mockResolvedValue(null) }
+    userModel.findOne.mockResolvedValue(user)
+    ;(service as any).sendConfirmationEmail = jest.fn()
+    const res = await service.resendConfirmation('test@example.com')
+    expect(res).toEqual({ message: 'Письмо отправлено повторно' })
+    expect((service as any).sendConfirmationEmail).toHaveBeenCalled()
+    expect(user.save).toHaveBeenCalled()
+  })
+
+  it('confirmEmail success', async () => {
+    const user = {
+      ...mockUser,
+      isConfirmed: false,
+      confirmationToken: 't',
+      confirmationTokenExpires: new Date(Date.now() + 1000),
+      save: jest.fn().mockResolvedValue(null)
+    }
+    userModel.findOne.mockResolvedValue(user)
+    const res = await service.confirmEmail('t')
+    expect(res).toEqual({ message: 'Email подтверждён' })
+    expect(user.save).toHaveBeenCalled()
   })
 
   it('issueAccessToken', async () => {

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -1,13 +1,15 @@
 import {
-	BadRequestException,
-	Injectable,
-	UnauthorizedException
+        BadRequestException,
+        Injectable,
+        UnauthorizedException
 } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
 import { UserModel } from './user.model'
 import { JwtService } from '@nestjs/jwt'
 import { AuthDto } from './dto/auth.dto'
 import { compare, genSalt, hash } from 'bcryptjs'
+import { randomUUID } from 'crypto'
+import * as nodemailer from 'nodemailer'
 
 @Injectable()
 export class AuthService {
@@ -21,59 +23,98 @@ export class AuthService {
 	 * Авторизация пользователя.
 	 * Проверяет данные, возвращает пользователя и токен доступа.
 	 */
-	async login(dto: AuthDto) {
-		const user = await this.validateUser(dto)
+        async login(dto: AuthDto) {
+                const user = await this.validateUser(dto)
 
-		return {
-			user: this.returnUserFields(user),
-			accessToken: await this.issueAccessToken(user.id)
-		}
-	}
+                return {
+                        user: this.returnUserFields(user),
+                        accessToken: await this.issueAccessToken(user.id)
+                }
+        }
 
 	/**
 	 * Регистрация нового пользователя.
 	 * Создаёт запись в БД и возвращает пользователя и токен.
 	 */
-	async register(dto: AuthDto) {
-		const oldUser = await this.userModel.findOne({
-			where: { email: dto.email }
-		})
+        async register(dto: AuthDto) {
+                const oldUser = await this.userModel.findOne({
+                        where: { email: dto.email }
+                })
 
-		if (oldUser) throw new BadRequestException('Некорректные email или пароль')
+                if (oldUser) throw new BadRequestException('Некорректные email или пароль')
 
-		const salt = await genSalt(10)
+                const salt = await genSalt(10)
+                const token = randomUUID()
 
-		const user = await this.userModel.create({
-			email: dto.email,
-			name: dto.name ? dto.name : '',
-			password: await hash(dto.password, salt)
-		})
+                await this.userModel.create({
+                        email: dto.email,
+                        name: dto.name ? dto.name : '',
+                        password: await hash(dto.password, salt),
+                        isConfirmed: false,
+                        confirmationToken: token,
+                        confirmationTokenExpires: new Date(Date.now() + 48 * 60 * 60 * 1000)
+                })
 
-		return {
-			user: this.returnUserFields(user),
-			accessToken: await this.issueAccessToken(user.id)
-		}
-	}
+                await this.sendConfirmationEmail(dto.email, token)
+
+                return { message: 'Письмо для подтверждения отправлено' }
+        }
+
+        async confirmEmail(token: string) {
+                const user = await this.userModel.findOne({
+                        where: { confirmationToken: token }
+                })
+
+                if (!user || !user.confirmationTokenExpires || user.confirmationTokenExpires < new Date()) {
+                        throw new BadRequestException('Токен недействителен или просрочен')
+                }
+
+                user.isConfirmed = true
+                user.confirmationToken = null
+                user.confirmationTokenExpires = null
+                await user.save()
+
+                return { message: 'Email подтверждён' }
+        }
+
+        async resendConfirmation(email: string) {
+                const user = await this.userModel.findOne({ where: { email } })
+
+                if (!user) throw new BadRequestException('Пользователь не найден')
+                if (user.isConfirmed) throw new BadRequestException('Email уже подтверждён')
+
+                const token = randomUUID()
+                user.confirmationToken = token
+                user.confirmationTokenExpires = new Date(Date.now() + 48 * 60 * 60 * 1000)
+                await user.save()
+
+                await this.sendConfirmationEmail(email, token)
+
+                return { message: 'Письмо отправлено повторно' }
+        }
 
 	/**
 	 * Проверяет существование пользователя и корректность пароля.
 	 * Возвращает пользователя при успешной проверке.
 	 */
-	async validateUser(dto: AuthDto) {
-		const user = await this.userModel.findOne({
-			where: { email: dto.email },
-			attributes: ['id', 'email', 'password', 'name']
-		})
+        async validateUser(dto: AuthDto) {
+                const user = await this.userModel.findOne({
+                        where: { email: dto.email },
+                        attributes: ['id', 'email', 'password', 'name', 'isConfirmed']
+                })
 
-		if (!user) throw new UnauthorizedException('Пользователь не найден')
+                if (!user) throw new UnauthorizedException('Пользователь не найден')
 
-		const isValidPassword = await compare(dto.password, user.get().password)
+                const isValidPassword = await compare(dto.password, user.get().password)
 
-		if (!isValidPassword)
-			throw new UnauthorizedException('Некорректные email или пароль')
+                if (!isValidPassword)
+                        throw new UnauthorizedException('Некорректные email или пароль')
 
-		return user
-	}
+                if (!user.isConfirmed)
+                        throw new UnauthorizedException('Email не подтверждён')
+
+                return user
+        }
 
 	/**
 	 * Генерирует JWT-токен для указанного пользователя.
@@ -89,12 +130,33 @@ export class AuthService {
 	/**
 	 * Возвращает только нужные поля пользователя (без пароля).
 	 */
-	returnUserFields(user: UserModel) {
-		const userData = user.get({ plain: true })
-		return {
-			id: userData.id,
-			name: userData.name,
-			email: userData.email
-		}
-	}
+        returnUserFields(user: UserModel) {
+                const userData = user.get({ plain: true })
+                return {
+                        id: userData.id,
+                        name: userData.name,
+                        email: userData.email
+                }
+        }
+
+        private async sendConfirmationEmail(email: string, token: string) {
+                const transporter = nodemailer.createTransport({
+                        host: process.env.MAIL_HOST,
+                        port: Number(process.env.MAIL_PORT) || 587,
+                        secure: false,
+                        auth: {
+                                user: process.env.MAIL_USER,
+                                pass: process.env.MAIL_PASSWORD
+                        }
+                })
+
+                const confirmUrl = `${process.env.SERVER_URL || 'http://localhost:4000'}/auth/confirm/${token}`
+
+                await transporter.sendMail({
+                        to: email,
+                        from: process.env.MAIL_FROM,
+                        subject: 'Подтверждение регистрации',
+                        html: `<a href="${confirmUrl}">Подтвердить email</a>`
+                })
+        }
 }

--- a/server/src/auth/dto/email.dto.ts
+++ b/server/src/auth/dto/email.dto.ts
@@ -1,0 +1,6 @@
+import { IsEmail } from 'class-validator'
+
+export class EmailDto {
+        @IsEmail()
+        email: string
+}

--- a/server/src/auth/user.model.ts
+++ b/server/src/auth/user.model.ts
@@ -9,9 +9,18 @@ export class UserModel extends Model {
 	@Column({ type: DataType.STRING, allowNull: true })
 	name?: string
 
-	@Column({ type: DataType.STRING, allowNull: false, unique: true })
-	email: string
+        @Column({ type: DataType.STRING, allowNull: false, unique: true })
+        email: string
 
-	@Column({ type: DataType.STRING, allowNull: false })
-	password: string
+        @Column({ type: DataType.STRING, allowNull: false })
+        password: string
+
+        @Column({ type: DataType.BOOLEAN, allowNull: false, defaultValue: false })
+        isConfirmed: boolean
+
+        @Column({ type: DataType.STRING, allowNull: true })
+        confirmationToken?: string | null
+
+        @Column({ type: DataType.DATE, allowNull: true })
+        confirmationTokenExpires?: Date | null
 }

--- a/server/test/auth.e2e-spec.ts
+++ b/server/test/auth.e2e-spec.ts
@@ -13,7 +13,9 @@ describe('Auth (e2e)', () => {
   let app: INestApplication
   const service = {
     login: jest.fn(),
-    register: jest.fn()
+    register: jest.fn(),
+    confirmEmail: jest.fn(),
+    resendConfirmation: jest.fn()
   }
 
   beforeAll(async () => {
@@ -58,12 +60,12 @@ describe('Auth (e2e)', () => {
   })
 
   it('/auth/register (POST)', async () => {
-    service.register.mockResolvedValue({ id: 1 })
+    service.register.mockResolvedValue({ message: 'ok' })
     await request(app.getHttpServer())
       .post('/auth/register')
       .send({ email: 'a@a.com', password: '12345678' })
       .expect(200)
-      .expect({ id: 1 })
+      .expect({ message: 'ok' })
     expect(service.register).toHaveBeenCalledWith({ email: 'a@a.com', password: '12345678' })
   })
 
@@ -73,6 +75,25 @@ describe('Auth (e2e)', () => {
       .post('/auth/register')
       .send({ email: 'a@a.com', password: '12345678' })
       .expect(400)
+  })
+
+  it('/auth/confirm (GET)', async () => {
+    service.confirmEmail.mockResolvedValue({ message: 'done' })
+    await request(app.getHttpServer())
+      .get('/auth/confirm/token123')
+      .expect(200)
+      .expect({ message: 'done' })
+    expect(service.confirmEmail).toHaveBeenCalledWith('token123')
+  })
+
+  it('/auth/resend (POST)', async () => {
+    service.resendConfirmation.mockResolvedValue({ message: 'sent' })
+    await request(app.getHttpServer())
+      .post('/auth/resend')
+      .send({ email: 'a@a.com' })
+      .expect(200)
+      .expect({ message: 'sent' })
+    expect(service.resendConfirmation).toHaveBeenCalledWith('a@a.com')
   })
 })
 


### PR DESCRIPTION
## Summary
- add server-side email confirmation with token generation, resend and confirm endpoints
- update frontend auth service and login form to handle registration flow and show logged-in profile icon
- document mail environment variables

## Testing
- `npm test --prefix server`
- `npm test --prefix dashboard-ui`
- `npm run lint --prefix server` *(fails: Unexpected property "allowEmptyCase" in ESLint config)*
- `npm run lint --prefix dashboard-ui`


------
https://chatgpt.com/codex/tasks/task_e_689ae90b87e88329846fb355dc9cb0fa