### PR TITLE
feat: add authentication route guard

### DIFF
--- a/dashboard-ui/app/components/ui/Layout.tsx
+++ b/dashboard-ui/app/components/ui/Layout.tsx
@@ -1,14 +1,18 @@
+'use client'
 import { FC, PropsWithChildren } from 'react'
 import Header from './header/Header'
+import ProtectedRoute from '@/providers/auth-provider/ProtectedRoute'
+import { motion } from 'framer-motion'
+import { FADE_IN } from '@/utils/animations/fade'
 
 const Layout: FC<PropsWithChildren> = ({ children }) => {
   return (
-    <>
-      <div>
+    <ProtectedRoute>
+      <motion.div {...FADE_IN}>
         <Header />
         <main className='p-4'>{children}</main>
-      </div>
-    </>
+      </motion.div>
+    </ProtectedRoute>
   )
 }
 

--- a/dashboard-ui/app/components/ui/header/Header.tsx
+++ b/dashboard-ui/app/components/ui/header/Header.tsx
@@ -1,18 +1,36 @@
-import {FC} from "react"
-import Logo from "@/ui/header/Logo";
-import LoginForm from "@/ui/header/login-form/LoginForm";
+'use client'
+import { FC } from 'react'
+import Logo from '@/ui/header/Logo'
+import LoginForm from '@/ui/header/login-form/LoginForm'
 import styles from './Header.module.scss'
-import Link from "next/link";
+import Link from 'next/link'
+import { useAuth } from '@/hooks/useAuth'
 
 const Header: FC = () => {
-    return <header className={styles.header}>
-        <Logo/>
-        <Link href="/" className={styles.link}> Главная </Link>
-        <Link href="/products" className={styles.link}> Склад   </Link>
-        <Link href="/tasks" className={styles.link}> Задачи  </Link>
-        <Link href="/reports" className={styles.link}> Отчёты  </Link>
-        <LoginForm/>
+  const { user } = useAuth()
+
+  return (
+    <header className={styles.header}>
+      <Logo />
+      {user && (
+        <>
+          <Link href='/' className={styles.link}>
+            Главная
+          </Link>
+          <Link href='/products' className={styles.link}>
+            Склад
+          </Link>
+          <Link href='/tasks' className={styles.link}>
+            Задачи
+          </Link>
+          <Link href='/reports' className={styles.link}>
+            Отчёты
+          </Link>
+        </>
+      )}
+      <LoginForm />
     </header>
+  )
 }
 
 export default Header

--- a/dashboard-ui/app/login/page.tsx
+++ b/dashboard-ui/app/login/page.tsx
@@ -1,0 +1,25 @@
+'use client'
+import LoginForm from '@/ui/header/login-form/LoginForm'
+import { FADE_IN } from '@/utils/animations/fade'
+import { motion } from 'framer-motion'
+import { useAuth } from '@/hooks/useAuth'
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+
+export default function LoginPage() {
+  const { user } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (user) router.replace('/')
+  }, [user, router])
+
+  return (
+    <motion.div
+      {...FADE_IN}
+      className='flex h-screen items-center justify-center'
+    >
+      <LoginForm inPage />
+    </motion.div>
+  )
+}

--- a/dashboard-ui/app/providers/auth-provider/ProtectedRoute.tsx
+++ b/dashboard-ui/app/providers/auth-provider/ProtectedRoute.tsx
@@ -1,0 +1,22 @@
+'use client'
+import { FC, PropsWithChildren, useEffect } from 'react'
+import { useAuth } from '@/hooks/useAuth'
+import { usePathname, useRouter } from 'next/navigation'
+
+const ProtectedRoute: FC<PropsWithChildren> = ({ children }) => {
+  const { user } = useAuth()
+  const router = useRouter()
+  const pathname = usePathname()
+
+  useEffect(() => {
+    if (!user) {
+      router.replace(`/login?redirect=${pathname}`)
+    }
+  }, [user, pathname, router])
+
+  if (!user) return null
+
+  return <>{children}</>
+}
+
+export default ProtectedRoute


### PR DESCRIPTION
## Summary
- add protected route component to enforce authentication
- redirect unauthenticated users to login page
- show navigation only for signed-in users and provide logout
- animate transitions between login and content

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aed2e52748329b4a242b935259d3a