### PR TITLE
Center auth forms for guests

### DIFF
--- a/dashboard-ui/app/components/ui/header/login-form/LoginForm.module.scss
+++ b/dashboard-ui/app/components/ui/header/login-form/LoginForm.module.scss
@@ -25,3 +25,11 @@
     @apply shadow-icon;
   }
 }
+
+.wrapperPage {
+  @apply relative flex;
+}
+
+.formPage {
+  @apply p-3 w-full max-w-sm z-20 rounded-lg bg-neutral-500 shadow-md;
+}

--- a/dashboard-ui/app/components/ui/header/login-form/LoginForm.tsx
+++ b/dashboard-ui/app/components/ui/header/login-form/LoginForm.tsx
@@ -10,6 +10,7 @@ import { FaRegUserCircle, FaUserCircle } from 'react-icons/fa'
 import Field from '@/ui/Field/Field'
 import Button from '@/ui/Button/Button'
 import { FADE_IN } from '@/utils/animations/fade'
+import cn from 'classnames'
 
 import { motion } from 'framer-motion'
 import { useMutation } from '@tanstack/react-query'
@@ -83,7 +84,10 @@ const LoginForm: FC<Props> = ({ inPage = false }) => {
   const isVisible = inPage || isShow
 
   return (
-    <div className={styles.wrapper} ref={ref}>
+    <div
+      className={cn(inPage ? styles.wrapperPage : styles.wrapper)}
+      ref={ref}
+    >
       {!inPage && (
         <Button className={styles.button} onClick={() => setIsShow(!isShow)}>
           {user ? <FaUserCircle /> : <FaRegUserCircle />}
@@ -97,7 +101,10 @@ const LoginForm: FC<Props> = ({ inPage = false }) => {
               Выйти
             </Button>
           ) : (
-            <form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
+            <form
+              className={cn(inPage ? styles.formPage : styles.form)}
+              onSubmit={handleSubmit(onSubmit)}
+            >
               <Field
                 {...register('email', {
                   required: 'Введите email',


### PR DESCRIPTION
## Summary
- Center login/register form on standalone auth page
- Keep auth form responsive across screen sizes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689af40b1aac8329b3bc504a3d4ecbff