### PR TITLE
style: enhance auth form styling

### DIFF
--- a/dashboard-ui/app/components/ui/Button/Button.module.scss
+++ b/dashboard-ui/app/components/ui/Button/Button.module.scss
@@ -1,3 +1,3 @@
 .button {
-
+  @apply rounded-button transition-colors duration-200;
 }

--- a/dashboard-ui/app/components/ui/Field/Field.module.scss
+++ b/dashboard-ui/app/components/ui/Field/Field.module.scss
@@ -2,36 +2,35 @@
 
 .field {
   @apply py-2;
+}
 
-  .label {
-    @apply block mb-1 text-sm font-medium text-neutral-700;
+.label {
+  @apply block mb-1 text-sm font-medium text-neutral-700;
+}
+
+.input {
+  @apply bg-neutral-50 font-medium text-lg rounded-lg border border-neutral-300 transition-colors duration-200;
+  @include shadow('md');
+  width: 100%;
+  height: 3rem;
+  padding-left: 1rem;
+  outline: none;
+
+  &::placeholder {
+    color: #b8b09e;
   }
 
-  input {
-    @apply bg-neutral-50 font-medium text-lg rounded-lg;
-    @include shadow('md');
-    width: 100%;
-    height: 3rem;
-    padding-left: 1rem;
-    outline: none;
-
-    &::placeholder {
-      color: #b8b09e;
-    }
-
-    &:focus {
-      @apply
-      focus:border-neutral-600
-      focus:ring-2
-      focus:ring-inset
-      focus:ring-neutral-600;
-    }
+  &:focus {
+    @apply border-primary-500 ring-2 ring-inset ring-primary-500;
   }
+}
 
-  .error {
-    @apply p-1 text-neutral-900;
-    font-size: 0.75rem;
-  }
+.inputError {
+  @apply border-error ring-error;
+}
 
+.error {
+  @apply p-1 text-error;
+  font-size: 0.75rem;
 }
 

--- a/dashboard-ui/app/components/ui/Field/Field.tsx
+++ b/dashboard-ui/app/components/ui/Field/Field.tsx
@@ -1,4 +1,5 @@
-import {forwardRef} from "react"
+import { forwardRef } from 'react'
+import cn from 'classnames'
 
 import styles from "./Field.module.scss"
 import {IField} from "@/ui/Field/field.interface";
@@ -9,7 +10,12 @@ const Field = forwardRef<HTMLInputElement, IField>(
         return (
             <div className={styles.field} style={style}>
                 {label && <label className={styles.label}>{label}</label>}
-                <input className={styles.input} ref={ref} type={type} {...rest} />
+                <input
+                    className={cn(styles.input, { [styles.inputError]: error })}
+                    ref={ref}
+                    type={type}
+                    {...rest}
+                />
                 {error && <div className={styles.error}>{error.message}</div>}
             </div>
         )

--- a/dashboard-ui/app/components/ui/header/login-form/LoginForm.module.scss
+++ b/dashboard-ui/app/components/ui/header/login-form/LoginForm.module.scss
@@ -4,22 +4,19 @@
   @apply relative inline-flex;
 
   .form {
-    @apply p-3 absolute right-0.5 w-88 z-20 rounded-lg bg-neutral-500 shadow-md;
+    @apply absolute right-0.5 w-88 z-20 p-6 bg-neutral-50 rounded-lg shadow-lg;
     top: calc(100% + 1.1rem);
   }
 
   .login {
-    @apply p-2 mt-6 mb-2 text-xl font-medium text-white bg-primary-500 rounded-lg text-center;
+    @apply p-2 mt-6 mb-2 text-xl font-medium text-white bg-primary-500 rounded-lg text-center transition-colors duration-200 hover:bg-primary-400;
     @include shadow('md');
   }
-
 
   .register {
-    @apply p-2 text-secondary-700 text-xl font-medium bg-primary-100 rounded-lg text-center w-full;
+    @apply p-2 text-secondary-700 text-xl font-medium bg-primary-100 rounded-lg text-center w-full transition-colors duration-200 hover:bg-primary-200;
     @include shadow('md');
   }
-
-
 
   .button {
     @apply shadow-icon;
@@ -31,5 +28,5 @@
 }
 
 .formPage {
-  @apply p-3 w-full max-w-sm z-20 rounded-lg bg-neutral-500 shadow-md;
+  @apply w-full max-w-sm z-20 p-8 bg-neutral-50 rounded-lg shadow-lg;
 }

--- a/dashboard-ui/app/login/page.tsx
+++ b/dashboard-ui/app/login/page.tsx
@@ -17,7 +17,7 @@ export default function LoginPage() {
   return (
     <motion.div
       {...FADE_IN}
-      className='flex h-screen items-center justify-center'
+      className='flex h-screen items-center justify-center bg-gradient-to-br from-primary-100 to-secondary-100'
     >
       <LoginForm inPage />
     </motion.div>


### PR DESCRIPTION
## Summary
- center auth page on soft gradient background
- polish login/register container with rounded corners and hoverable buttons
- add bordered inputs with focus and error states

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689af73945f48329981ef7005fde87f6