### PR TITLE
style: enhance auth page styling

### DIFF
--- a/dashboard-ui/app/components/ui/Button/Button.module.scss
+++ b/dashboard-ui/app/components/ui/Button/Button.module.scss
@@ -1,3 +1,3 @@
 .button {
-  @apply rounded-button transition-colors duration-200;
+  @apply rounded-button shadow-md cursor-pointer transition-all duration-200 hover:scale-105 active:scale-95;
 }

--- a/dashboard-ui/app/components/ui/Field/Field.module.scss
+++ b/dashboard-ui/app/components/ui/Field/Field.module.scss
@@ -9,7 +9,7 @@
 }
 
 .input {
-  @apply bg-neutral-50 font-medium text-lg rounded-lg border border-neutral-300 transition-colors duration-200;
+  @apply bg-neutral-50/80 font-medium text-lg rounded-lg border border-neutral-300 transition-all duration-200;
   @include shadow('md');
   width: 100%;
   height: 3rem;
@@ -21,7 +21,7 @@
   }
 
   &:focus {
-    @apply border-primary-500 ring-2 ring-inset ring-primary-500;
+    @apply border-primary-500 ring-2 ring-inset ring-primary-500 shadow-lg;
   }
 }
 

--- a/dashboard-ui/app/components/ui/header/login-form/LoginForm.module.scss
+++ b/dashboard-ui/app/components/ui/header/login-form/LoginForm.module.scss
@@ -8,16 +8,6 @@
     top: calc(100% + 1.1rem);
   }
 
-  .login {
-    @apply p-2 mt-6 mb-2 text-xl font-medium text-white bg-primary-500 rounded-lg text-center transition-colors duration-200 hover:bg-primary-400;
-    @include shadow('md');
-  }
-
-  .register {
-    @apply p-2 text-secondary-700 text-xl font-medium bg-primary-100 rounded-lg text-center w-full transition-colors duration-200 hover:bg-primary-200;
-    @include shadow('md');
-  }
-
   .button {
     @apply shadow-icon;
   }
@@ -28,5 +18,15 @@
 }
 
 .formPage {
-  @apply w-full max-w-sm z-20 p-8 bg-neutral-50 rounded-lg shadow-lg;
+  @apply w-full max-w-md z-20 p-8 bg-neutral-50 rounded-lg shadow-lg;
+}
+
+.login {
+  @apply w-full p-2 mt-6 mb-2 text-xl font-medium text-white bg-primary-500 rounded-lg text-center transition-colors duration-200 hover:bg-primary-400;
+  @include shadow('md');
+}
+
+.register {
+  @apply w-full p-2 text-xl font-medium text-white bg-secondary-500 rounded-lg text-center transition-colors duration-200 hover:bg-secondary-400;
+  @include shadow('md');
 }

--- a/dashboard-ui/app/components/ui/header/login-form/LoginForm.tsx
+++ b/dashboard-ui/app/components/ui/header/login-form/LoginForm.tsx
@@ -128,18 +128,16 @@ const LoginForm: FC<Props> = ({ inPage = false }) => {
                 error={errors.password}
                 type={'password'}
               />
-              <div className={styles.login}>
-                <Button
-                  className={'w-full'}
-                  type="submit"
-                  onClick={() => setType('login')}
-                >
-                  Войти
-                </Button>
-              </div>
+              <Button
+                className={styles.login}
+                type='submit'
+                onClick={() => setType('login')}
+              >
+                Войти
+              </Button>
               <Button
                 className={styles.register}
-                type="submit"
+                type='submit'
                 onClick={() => setType('register')}
               >
                 Регистрация

--- a/dashboard-ui/app/login/page.tsx
+++ b/dashboard-ui/app/login/page.tsx
@@ -17,7 +17,7 @@ export default function LoginPage() {
   return (
     <motion.div
       {...FADE_IN}
-      className='flex h-screen items-center justify-center bg-gradient-to-br from-primary-100 to-secondary-100'
+      className='flex min-h-screen w-screen items-center justify-center bg-gradient-to-br from-primary-100 to-secondary-100 bg-fixed'
     >
       <LoginForm inPage />
     </motion.div>


### PR DESCRIPTION
## Summary
- add full-screen fixed gradient background to login page
- refine login/register buttons and form container
- improve field and button focus/hover animations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689afa4e77e08329a1ec60c47d602659