### PR TITLE
Fix user confirmation fields mapping

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -9,7 +9,8 @@ module.exports = {
     database: process.env.DB_DATABASE || 'postgres',
     host: process.env.DB_HOST || '127.0.0.1',
     port: Number(process.env.DB_PORT) || 5432,
-    dialect: 'postgres'
+    dialect: 'postgres',
+    define: { underscored: true }
   },
   production: {
     username: process.env.DB_USERNAME,
@@ -17,6 +18,7 @@ module.exports = {
     database: process.env.DB_DATABASE,
     host: process.env.DB_HOST,
     port: Number(process.env.DB_PORT) || 5432,
-    dialect: 'postgres'
+    dialect: 'postgres',
+    define: { underscored: true }
   }
 };

--- a/server/migrations/20240201000000-add-confirmation-fields-to-user.js
+++ b/server/migrations/20240201000000-add-confirmation-fields-to-user.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('User', 'is_confirmed', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+    await queryInterface.addColumn('User', 'confirmation_token', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('User', 'confirmation_token_expires', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('User', 'is_confirmed');
+    await queryInterface.removeColumn('User', 'confirmation_token');
+    await queryInterface.removeColumn('User', 'confirmation_token_expires');
+  },
+};

--- a/server/src/auth/user.model.ts
+++ b/server/src/auth/user.model.ts
@@ -6,8 +6,8 @@ import { Column, DataType, Model, Table } from 'sequelize-typescript'
 	version: false
 })
 export class UserModel extends Model {
-	@Column({ type: DataType.STRING, allowNull: true })
-	name?: string
+        @Column({ type: DataType.STRING, allowNull: true })
+        name?: string
 
         @Column({ type: DataType.STRING, allowNull: false, unique: true })
         email: string
@@ -15,12 +15,17 @@ export class UserModel extends Model {
         @Column({ type: DataType.STRING, allowNull: false })
         password: string
 
-        @Column({ type: DataType.BOOLEAN, allowNull: false, defaultValue: false })
+        @Column({
+                field: 'is_confirmed',
+                type: DataType.BOOLEAN,
+                allowNull: false,
+                defaultValue: false
+        })
         isConfirmed: boolean
 
-        @Column({ type: DataType.STRING, allowNull: true })
+        @Column({ field: 'confirmation_token', type: DataType.STRING, allowNull: true })
         confirmationToken?: string | null
 
-        @Column({ type: DataType.DATE, allowNull: true })
+        @Column({ field: 'confirmation_token_expires', type: DataType.DATE, allowNull: true })
         confirmationTokenExpires?: Date | null
 }

--- a/server/src/config/db.config.ts
+++ b/server/src/config/db.config.ts
@@ -29,6 +29,9 @@ export function getSequelizeConfig(
                 dialectOptions: { connectTimeout: 5000 }, // 5 сек таймаут
                 retryAttempts: 1,
                 retryDelay: 2000,
-                logging: false
+                logging: false,
+                define: {
+                        underscored: true
+                }
         }
 }


### PR DESCRIPTION
## Summary
- map user confirmation columns to snake_case fields
- enable underscored naming in Sequelize config
- add migration to create confirmation columns in User table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b099e18a483298072989f86d87a14