### PR TITLE
fix: align sequelize timestamps with camelCase schema

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -10,7 +10,8 @@ module.exports = {
     host: process.env.DB_HOST || '127.0.0.1',
     port: Number(process.env.DB_PORT) || 5432,
     dialect: 'postgres',
-    define: { underscored: true }
+    // Use camelCase column names to align with existing schema
+    define: { underscored: false }
   },
   production: {
     username: process.env.DB_USERNAME,
@@ -19,6 +20,7 @@ module.exports = {
     host: process.env.DB_HOST,
     port: Number(process.env.DB_PORT) || 5432,
     dialect: 'postgres',
-    define: { underscored: true }
+    // Use camelCase column names to align with existing schema
+    define: { underscored: false }
   }
 };

--- a/server/src/config/db.config.ts
+++ b/server/src/config/db.config.ts
@@ -30,8 +30,10 @@ export function getSequelizeConfig(
                 retryAttempts: 1,
                 retryDelay: 2000,
                 logging: false,
+                // Use camelCase column names for automatically managed timestamps
+                // to match the existing database schema
                 define: {
-                        underscored: true
+                        underscored: false
                 }
         }
 }

--- a/server/src/report/report.migration.ts
+++ b/server/src/report/report.migration.ts
@@ -19,12 +19,13 @@ export async function up(queryInterface: QueryInterface): Promise<void> {
                         type: DataTypes.JSONB,
                         allowNull: true
                 },
-                created_at: {
+                // Standard timestamp columns
+                createdAt: {
                         type: DataTypes.DATE,
                         allowNull: false,
                         defaultValue: DataTypes.NOW
                 },
-                updated_at: {
+                updatedAt: {
                         type: DataTypes.DATE,
                         allowNull: false,
                         defaultValue: DataTypes.NOW


### PR DESCRIPTION
## Summary
- avoid underscored column names in Sequelize config
- adjust report migration to use camelCase timestamps

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b106754e883299498ab3c812e4678