### PR TITLE
fix: relax validation and rely on global pipes

### DIFF
--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -1,13 +1,4 @@
-import {
-        Body,
-        Controller,
-        Get,
-        HttpCode,
-        Param,
-        Post,
-        UsePipes,
-        ValidationPipe
-} from '@nestjs/common'
+import { Body, Controller, Get, HttpCode, Param, Post } from '@nestjs/common'
 import { AuthService } from './auth.service'
 import { AuthDto } from './dto/auth.dto'
 import { EmailDto } from './dto/email.dto'
@@ -23,19 +14,17 @@ export class AuthController {
 	 * Метод для входа (логина) пользователя.
 	 * Принимает email и пароль, возвращает токен и данные пользователя.
 	 */
-	@UsePipes(new ValidationPipe())
-	@HttpCode(200)
-	@Post('login')
-	async login(@Body() dto: AuthDto) {
-		return this.authService.login(dto)
-	}
+        @HttpCode(200)
+        @Post('login')
+        async login(@Body() dto: AuthDto) {
+                return this.authService.login(dto)
+        }
 
 	/**
 	 * Метод для регистрации нового пользователя.
 	 * Принимает имя, email и пароль, создаёт запись в БД и возвращает токен.
 	 */
-	@UsePipes(new ValidationPipe())
-	@HttpCode(200)
+        @HttpCode(200)
         @Post('register')
         async register(@Body() dto: AuthDto) {
                 return this.authService.register(dto)
@@ -47,7 +36,6 @@ export class AuthController {
                 return this.authService.confirmEmail(token)
         }
 
-        @UsePipes(new ValidationPipe())
         @HttpCode(200)
         @Post('resend')
         async resend(@Body() dto: EmailDto) {

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -28,10 +28,11 @@ async function bootstrap() {
         app.useGlobalPipes(
                 new ValidationPipe({
                         whitelist: true, // убирает лишние поля
-                        forbidNonWhitelisted: true, // бросает ошибку при лишних полях
+                        // Не блокируем запросы с неизвестными полями,
+                        // просто удаляем их через `whitelist`
                         transform: true // автоматически приводит типы
                 })
-	)
+        )
 	console.log('> BOOTSTRAP: перед listen')
 	await app.listen(4000)
 	console.log('> BOOTSTRAP: после listen')


### PR DESCRIPTION
## Summary
- remove redundant ValidationPipe usage in auth controller
- relax global validation to ignore unknown fields instead of 400

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b31976bd08329b878b6b0977400d0