### PR TITLE
fix: show server error messages on unauthenticated requests

### DIFF
--- a/dashboard-ui/app/api/interceptor.ts
+++ b/dashboard-ui/app/api/interceptor.ts
@@ -34,6 +34,16 @@ axiosClassic.interceptors.request.use(config => {
   return config
 })
 
+// Обработка ответов для axiosClassic, чтобы показывать понятные сообщения об ошибках
+axiosClassic.interceptors.response.use(
+  response => response,
+  error => {
+    // Если сервер вернул сообщение об ошибке — используем его, иначе стандартное сообщение
+    const message = error?.response?.data?.message || error.message
+    return Promise.reject(new Error(message))
+  }
+)
+
 /**
  * Основной экземпляр Axios.
  * Поддерживает автоматическое добавление токена в заголовки запроса.


### PR DESCRIPTION
## Summary
- improve axiosClassic response handling so server-side messages surface on registration errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b39f8a0e483298d8169db4aa9f08d