### PR TITLE
fix: enable dev API communication

### DIFF
--- a/dashboard-ui/.env.example
+++ b/dashboard-ui/.env.example
@@ -1,2 +1,3 @@
 # URL of the backend API (used by axios)
-NEXT_PUBLIC_API_URL=http://localhost:4000
+# Include the `/api` prefix used by the backend in development.
+NEXT_PUBLIC_API_URL=http://localhost:4000/api

--- a/dashboard-ui/app/api/interceptor.ts
+++ b/dashboard-ui/app/api/interceptor.ts
@@ -17,7 +17,10 @@ export const getContentType = () => ({
  * знал адрес бекенда при сборке.
  * Пример: http://localhost:4000/api
  */
-export const API_URL = `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000'}/api/`
+// Базовый URL API. Переменная окружения должна содержать полный путь до API,
+// например: http://localhost:4000/api
+const rawApiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api'
+export const API_URL = rawApiUrl.endsWith('/') ? rawApiUrl : `${rawApiUrl}/`
 
 /**
  * Экземпляр Axios без авторизации.
@@ -26,6 +29,7 @@ export const API_URL = `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4
 export const axiosClassic = axios.create({
   baseURL: API_URL,
   headers: getContentType(), // Установка заголовков по умолчанию
+  withCredentials: true,
 })
 
 // Убираем начальный слэш, чтобы базовый URL корректно дополнялся `/api`
@@ -51,6 +55,7 @@ axiosClassic.interceptors.response.use(
 const instance = axios.create({
   baseURL: API_URL,
   headers: getContentType(),
+  withCredentials: true,
 })
 
 /**

--- a/dashboard-ui/next.config.ts
+++ b/dashboard-ui/next.config.ts
@@ -6,7 +6,7 @@ const nextConfig: NextConfig = {
 
   env: {
     NEXT_PUBLIC_API_URL:
-      process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000',
+      process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api',
   },
   images: {
     domains: ['localhost'],

--- a/server/src/app.controller.ts
+++ b/server/src/app.controller.ts
@@ -1,14 +1,14 @@
-import { Controller, Get, UseGuards } from '@nestjs/common'
-import { AuthGuard } from '@nestjs/passport'
+import { Controller, Get } from '@nestjs/common'
 import { AppService } from './app.service'
 
-@UseGuards(AuthGuard('jwt'))
+// Маршруты этого контроллера используются как публичные
+// (например, для health check), поэтому защита JWT здесь не нужна.
 @Controller()
 export class AppController {
-	constructor(private readonly appService: AppService) {}
+        constructor(private readonly appService: AppService) {}
 
-	@Get()
-	getHello(): string {
-		return this.appService.getHello()
-	}
+        @Get()
+        getHello(): string {
+                return this.appService.getHello()
+        }
 }

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -12,13 +12,14 @@ async function bootstrap() {
         // URL фронта задаётся через переменную окружения CLIENT_URL,
         // что позволяет легко менять адрес, не перекомпилируя приложение.
         const config = app.get(ConfigService)
-        const clientUrl = config.get<string>('CLIENT_URL', 'http://localhost:3000')
+        const clientUrl = config.get<string>('CLIENT_URL') || 'http://localhost:3000'
 
         // Настройка CORS, чтобы фронтенд мог обращаться к бекенду без ошибок.
         // credentials:true позволяет отправлять cookie (например, JWT токен).
         app.enableCors({
-                origin: clientUrl,
-                credentials: true
+                origin: [clientUrl],
+                credentials: true,
+                allowedHeaders: ['Content-Type', 'Authorization']
         })
         console.log(`> BOOTSTRAP: CORS configured for ${clientUrl}`)
 


### PR DESCRIPTION
## Summary
- relax root controller to allow unauthenticated health checks
- expose API url with `/api` prefix and send credentials in Axios calls
- tighten CORS to allow localhost with auth headers

## Testing
- `cd server && npm test`
- `cd dashboard-ui && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b3d27f4488329901c6a5c6a6a2877