### PR TITLE
fix: show specific message on duplicate registration email

### DIFF
--- a/server/src/auth/auth.service.spec.ts
+++ b/server/src/auth/auth.service.spec.ts
@@ -85,7 +85,7 @@ describe('AuthService', () => {
     userModel.findOne.mockResolvedValue(mockUser)
     await expect(
       service.register({ email: 'test@example.com', password: '12345678' })
-    ).rejects.toBeInstanceOf(BadRequestException)
+    ).rejects.toThrow('Пользователь с таким email уже существует')
   })
 
   it('resendConfirmation', async () => {

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -41,7 +41,10 @@ export class AuthService {
                         where: { email: dto.email }
                 })
 
-                if (oldUser) throw new BadRequestException('Некорректные email или пароль')
+                if (oldUser)
+                        throw new BadRequestException(
+                                'Пользователь с таким email уже существует'
+                        )
 
                 const salt = await genSalt(10)
                 const token = randomUUID()


### PR DESCRIPTION
## Summary
- show explicit error when trying to register with existing email
- cover duplicate email case with unit test

## Testing
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_e_689b405c3d048329a4185ed884df3ad5