### PR TITLE
fix: allow server port override

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -2,6 +2,8 @@
 CLIENT_URL=http://localhost:3000
 # Environment mode
 NODE_ENV=development
+# Port to run the server
+PORT=4000
 # Database connection settings
 DB_HOST=localhost
 DB_PORT=5432

--- a/server/README.md
+++ b/server/README.md
@@ -44,6 +44,8 @@ $ yarn run start:dev
 $ yarn run start:prod
 ```
 
+The server listens on port `4000` by default. Set the `PORT` environment variable to use a different port.
+
 ## Run tests
 
 ```bash

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -34,9 +34,10 @@ async function bootstrap() {
                         transform: true // автоматически приводит типы
                 })
         )
-	console.log('> BOOTSTRAP: перед listen')
-	await app.listen(4000)
-	console.log('> BOOTSTRAP: после listen')
+        console.log('> BOOTSTRAP: перед listen')
+        const port = config.get<number>('PORT') || 4000
+        await app.listen(port)
+        console.log(`> BOOTSTRAP: после listen на порту ${port}`)
 }
 
 bootstrap()


### PR DESCRIPTION
## Summary
- allow overriding server port via PORT env var to avoid EADDRINUSE
- document PORT variable and add to .env example

## Testing
- `cd server && yarn test`


------
https://chatgpt.com/codex/tasks/task_e_689b55b9f484832981045c39397889bf