### PR TITLE
Remove email confirmation and improve error messages

### DIFF
--- a/dashboard-ui/app/components/ui/header/login-form/LoginForm.tsx
+++ b/dashboard-ui/app/components/ui/header/login-form/LoginForm.tsx
@@ -25,7 +25,6 @@ const LoginForm: FC<Props> = ({ inPage = false }) => {
   const { ref, isShow, setIsShow } = useOutside<HTMLDivElement>(false)
   const [type, setType] = useState<'login' | 'register'>('login')
   const [error, setError] = useState<string | null>(null)
-  const [message, setMessage] = useState<string | null>(null)
 
   const {
     register,
@@ -57,13 +56,13 @@ const LoginForm: FC<Props> = ({ inPage = false }) => {
     mutationFn: (data: IAuthFields) =>
       AuthService.register(data.email, data.password),
     onSuccess: data => {
-      setMessage(data.message)
-      setError(null)
+      if (setUser) setUser(data.user)
       reset()
+      setIsShow(false)
+      router.replace(redirect)
     },
     onError: (e: any) => {
       setError(e.message)
-      setMessage(null)
     },
   })
 
@@ -118,10 +117,10 @@ const LoginForm: FC<Props> = ({ inPage = false }) => {
               />
               <Field
                 {...register('password', {
-                  required: 'Введите password',
+                  required: 'Введите пароль',
                   minLength: {
                     value: 8,
-                    message: 'Минимальная длина пароля 8 символов',
+                    message: 'Минимальная длина пароля — 8 символов',
                   },
                 })}
                 placeholder="Введите пароль"
@@ -143,7 +142,6 @@ const LoginForm: FC<Props> = ({ inPage = false }) => {
                 Регистрация
               </Button>
               {error && <p className="text-error text-sm mt-2">{error}</p>}
-              {message && <p className="text-success text-sm mt-2">{message}</p>}
             </form>
           )}
         </motion.div>

--- a/dashboard-ui/app/services/auth/auth.service.ts
+++ b/dashboard-ui/app/services/auth/auth.service.ts
@@ -24,7 +24,7 @@ export const AuthService = {
 
   /**
    * POST /auth/register
-   * Регистрирует нового пользователя.
+   * Регистрирует нового пользователя и сохраняет токен для входа.
    */
   async register(email: string, password: string) {
     const respone = await axiosClassic.post<IAuthResponse>('/auth/register', {

--- a/server/package.json
+++ b/server/package.json
@@ -38,7 +38,6 @@
     "class-validator": "^0.14.2",
     "dotenv": "^17.2.1",
     "luxon": "^3.7.1",
-    "nodemailer": "^6.9.15",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.16.3",

--- a/server/src/auth/auth.service.spec.ts
+++ b/server/src/auth/auth.service.spec.ts
@@ -85,7 +85,9 @@ describe('AuthService', () => {
     userModel.findOne.mockResolvedValue(mockUser)
     await expect(
       service.register({ email: 'test@example.com', password: '12345678' })
-    ).rejects.toThrow('Пользователь с таким email уже существует')
+    ).rejects.toThrow(
+      'Такой email уже зарегистрирован. Пожалуйста, используйте другой.'
+    )
   })
 
 

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -41,7 +41,7 @@ export class AuthService {
 
                 if (oldUser)
                         throw new BadRequestException(
-                                'Пользователь с таким email уже существует'
+                                'Такой email уже зарегистрирован. Пожалуйста, используйте другой.'
                         )
 
                 const salt = await genSalt(10)
@@ -67,12 +67,17 @@ export class AuthService {
                         attributes: ['id', 'email', 'password', 'name']
                 })
 
-                if (!user) throw new UnauthorizedException('Пользователь не найден')
+                if (!user)
+                        throw new UnauthorizedException(
+                                'Пользователь с таким email не найден.'
+                        )
 
                 const isValidPassword = await compare(dto.password, user.get().password)
 
                 if (!isValidPassword)
-                        throw new UnauthorizedException('Некорректные email или пароль')
+                        throw new UnauthorizedException(
+                                'Неверный email или пароль. Пожалуйста, попробуйте снова.'
+                        )
 
                 return user
         }

--- a/server/src/auth/dto/auth.dto.ts
+++ b/server/src/auth/dto/auth.dto.ts
@@ -8,9 +8,9 @@ export class AuthDto {
 	@IsEmail()
 	email: string
 
-	@MinLength(8, {
-		message: 'Пароль должен быть не менее 8 символов'
-	})
+        @MinLength(8, {
+                message: 'Минимальная длина пароля — 8 символов.'
+        })
 	@IsString()
 	password: string
 }

--- a/server/src/auth/user.model.ts
+++ b/server/src/auth/user.model.ts
@@ -14,6 +14,4 @@ export class UserModel extends Model {
 
         @Column({ type: DataType.STRING, allowNull: false })
         password: string
-
-        // Email confirmation fields removed
 }

--- a/server/src/category/category.service.ts
+++ b/server/src/category/category.service.ts
@@ -48,9 +48,9 @@ export class CategoryService {
 		const category = await this.categoryRepo.findByPk(id, {
 			include: [ProductModel]
 		})
-		if (!category) {
-			throw new NotFoundException(`Категория с id=${id} не найдена`)
-		}
+                if (!category) {
+                        throw new NotFoundException(`Категория с ID ${id} не найдена.`)
+                }
 		return category
 	}
 
@@ -73,9 +73,9 @@ export class CategoryService {
 	 * @throws NotFoundException - Если категория не найдена
 	 */
 	async remove(id: number): Promise<void> {
-		const deletedCount = await this.categoryRepo.destroy({ where: { id } })
-		if (!deletedCount) {
-			throw new NotFoundException(`Категория с id=${id} не найдена`)
-		}
+                const deletedCount = await this.categoryRepo.destroy({ where: { id } })
+                if (!deletedCount) {
+                        throw new NotFoundException(`Категория с ID ${id} не найдена.`)
+                }
 	}
 }

--- a/server/src/product/product.service.ts
+++ b/server/src/product/product.service.ts
@@ -35,8 +35,11 @@ export class ProductService {
 
 		if (dto.categoryId) {
 			// 1) Если передан ID — проверяем наличие
-			const cat = await this.categoryRepo.findByPk(dto.categoryId)
-			if (!cat) throw new NotFoundException('Категория с таким ID не найдена')
+                        const cat = await this.categoryRepo.findByPk(dto.categoryId)
+                        if (!cat)
+                                throw new NotFoundException(
+                                        'Категория с указанным ID не найдена.'
+                                )
 			categoryId = dto.categoryId
 		} else if (dto.categoryName) {
 			// 2) Если передано имя — ищем или создаем
@@ -46,7 +49,9 @@ export class ProductService {
 			})
 			categoryId = cat.id
 		} else {
-			throw new BadRequestException('Укажите categoryId или categoryName')
+                        throw new BadRequestException(
+                                'Пожалуйста, укажите categoryId или categoryName.'
+                        )
 		}
 
 		// 3) Создаем продукт
@@ -77,9 +82,9 @@ export class ProductService {
 			include: ['category', 'sales'],
 			transaction: trx
 		})
-		if (!prod) {
-			throw new NotFoundException(`Product #${id} не найден`)
-		}
+                if (!prod) {
+                        throw new NotFoundException(`Товар с ID ${id} не найден.`)
+                }
 		return prod
 	}
 
@@ -97,7 +102,9 @@ export class ProductService {
                         if (dto.categoryId) {
                                 const cat = await this.categoryRepo.findByPk(dto.categoryId)
                                 if (!cat)
-                                        throw new NotFoundException('Категория с таким ID не найдена')
+                                        throw new NotFoundException(
+                                                'Категория с указанным ID не найдена.'
+                                        )
                                 updateData.categoryId = dto.categoryId
                         } else if (dto.categoryName) {
                                 const [cat] = await this.categoryRepo.findOrCreate({
@@ -158,9 +165,9 @@ export class ProductService {
 	): Promise<void> {
 		const operation = async (t: Transaction) => {
 			const product = await this.findOne(productId, t)
-			if (product.remains < qty) {
-				throw new BadRequestException('Недостаточно остатков')
-			}
+                        if (product.remains < qty) {
+                                throw new BadRequestException('Недостаточно товара на складе.')
+                        }
 			await this.productRepo.decrement(
 				{ remains: qty },
 				{ where: { id: productId }, transaction: t }

--- a/server/src/sale/sale.service.ts
+++ b/server/src/sale/sale.service.ts
@@ -64,7 +64,7 @@ export class SaleService {
 	async findOne(id: number): Promise<SaleModel> {
 		const sale = await this.saleRepo.findByPk(id, { include: ['product'] })
 		if (!sale) {
-			throw new NotFoundException(`Sale #${id} не найдена`)
+                        throw new NotFoundException(`Продажа с ID ${id} не найдена.`)
 		}
 		return sale
 	}
@@ -84,7 +84,7 @@ export class SaleService {
 				transaction: trx
 			})
 			if (!sale) {
-				throw new NotFoundException(`Sale #${id} не найдена`)
+                                throw new NotFoundException(`Продажа с ID ${id} не найдена.`)
 			}
 
 			// 2) Корректируем запасы и цену
@@ -144,7 +144,7 @@ export class SaleService {
 			// 1) Читаем sale внутри trx
 			const sale = await this.saleRepo.findByPk(id, { transaction: trx })
 			if (!sale) {
-				throw new NotFoundException(`Sale #${id} не найдена`)
+                                throw new NotFoundException(`Продажа с ID ${id} не найдена.`)
 			}
 
 			// 2) Возвращаем запасы в контексте trx

--- a/server/src/task/task.service.ts
+++ b/server/src/task/task.service.ts
@@ -20,9 +20,9 @@ export class TaskService {
 
 	async findOne(id: number): Promise<TaskModel> {
 		const task = await this.taskRepo.findByPk(id)
-		if (!task) {
-			throw new NotFoundException(`Task #${id} не найдена`)
-		}
+                if (!task) {
+                        throw new NotFoundException(`Задача с ID ${id} не найдена.`)
+                }
 		return task
 	}
 


### PR DESCRIPTION
## Summary
- Drop residual email confirmation code and nodemailer dependency.
- Refresh API error messages for clearer feedback across modules.
- Auto-login and redirect users after registration; update form validation messages.

## Testing
- `npm test --prefix server`
- `npm test --prefix dashboard-ui`


------
https://chatgpt.com/codex/tasks/task_e_689b602505688329adcf27f586bcc1c6