### PR TITLE
feat: automatically sync DB schema

### DIFF
--- a/server/src/config/db.config.ts
+++ b/server/src/config/db.config.ts
@@ -2,35 +2,34 @@ import { ConfigService } from '@nestjs/config'
 import { SequelizeModuleOptions } from '@nestjs/sequelize'
 
 export function getSequelizeConfig(
-	configService: ConfigService
+        configService: ConfigService
 ): SequelizeModuleOptions {
         const host = configService.get<string>('DB_HOST', '127.0.0.1')
         const port = configService.get<number>('DB_PORT', 5432)
         const database = configService.get<string>('DB_DATABASE')
         const username = configService.get<string>('DB_USERNAME')
         const password = configService.get<string>('DB_PASSWORD')
-        const isDevelopment = configService.get<string>('NODE_ENV') === 'development'
 
-	if (!database || !username || !password) {
-		throw new Error(
-			'Не заданы переменные DB_DATABASE, DB_USERNAME или DB_PASSWORD'
-		)
-	}
+        if (!database || !username || !password) {
+                throw new Error(
+                        'Не заданы переменные DB_DATABASE, DB_USERNAME или DB_PASSWORD'
+                )
+        }
 
-	return {
-		dialect: 'postgres',
-		host, // используем локальную переменную
-		port,
-		database,
-		username,
-		password,
+        return {
+                dialect: 'postgres',
+                host, // используем локальную переменную
+                port,
+                database,
+                username,
+                password,
                 autoLoadModels: true,
-                synchronize: isDevelopment,
+                synchronize: true,
                 dialectOptions: { connectTimeout: 5000 }, // 5 сек таймаут
                 retryAttempts: 1,
                 retryDelay: 2000,
                 logging: false,
-								sync: { force: true },
+                sync: { alter: true },
                 // Use camelCase column names for automatically managed timestamps
                 // to match the existing database schema
                 define: {


### PR DESCRIPTION
## Summary
- ensure Sequelize always synchronizes schema and uses `alter` to add missing columns like `priority`

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_689c698a960c83298af900328182223d