### PR TITLE
feat: auto reload products on connection restore

### DIFF
--- a/dashboard-ui/app/components/products/ProductsTable.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.tsx
@@ -52,6 +52,22 @@ const ProductsTable = () => {
     fetchProducts()
   }, [fetchProducts])
 
+  // Если загрузка завершилась ошибкой, пытаемся повторить
+  // автоматически: разово через небольшой интервал и
+  // при восстановлении соединения
+  useEffect(() => {
+    if (!error) return
+
+    const retry = () => fetchProducts()
+    const timer = setTimeout(retry, 5000)
+    window.addEventListener('online', retry)
+
+    return () => {
+      clearTimeout(timer)
+      window.removeEventListener('online', retry)
+    }
+  }, [error, fetchProducts])
+
   // Обновляем значение поиска с задержкой
   useEffect(() => {
     if (firstSearch.current) {


### PR DESCRIPTION
## Summary
- retry warehouse product loading automatically after failures
- refetch when network connection restores

## Testing
- `npm test --prefix dashboard-ui`
- `npm run lint --prefix dashboard-ui`


------
https://chatgpt.com/codex/tasks/task_e_689c75db1cd883299e22b8cf8d09a799