### PR TITLE
feat: align warehouse loading with tasks

### DIFF
--- a/dashboard-ui/app/hooks/useWarehouseData.ts
+++ b/dashboard-ui/app/hooks/useWarehouseData.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query'
+import { ProductService } from '@/services/product/product.service'
+import { IProduct } from '@/shared/interfaces/product.interface'
+
+export const useWarehouseData = () =>
+  useQuery<IProduct[], Error>({
+    queryKey: ['warehouse'],
+    queryFn: ({ signal }) => ProductService.getAll(signal),
+    retry: 1,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  })
+
+export default useWarehouseData


### PR DESCRIPTION
## Summary
- add `useWarehouseData` hook backed by React Query
- update warehouse products table to show loading first and only surface errors after initial fetch failure

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c8ab9c3e483299e517558b5582e82