### PR TITLE
fix: ensure warehouse product list renders

### DIFF
--- a/dashboard-ui/app/hooks/useWarehouseData.ts
+++ b/dashboard-ui/app/hooks/useWarehouseData.ts
@@ -1,3 +1,5 @@
+"use client"
+
 import { useQuery } from '@tanstack/react-query'
 import { ProductService } from '@/services/product/product.service'
 import { IProduct } from '@/shared/interfaces/product.interface'
@@ -8,7 +10,6 @@ export const useWarehouseData = () =>
     queryFn: ({ signal }) => ProductService.getAll(signal),
     retry: 1,
     refetchOnWindowFocus: false,
-    refetchOnMount: false,
   })
 
 export default useWarehouseData


### PR DESCRIPTION
## Summary
- fix warehouse page infinite loading by marking data hook as client-side and allowing initial fetch

## Testing
- `npm test` (dashboard-ui)
- `npm test` (server)`

------
https://chatgpt.com/codex/tasks/task_e_689c916f93548329ba8f25c289f07f3a