### PR TITLE
feat: searchable warehouse with pagination

### DIFF
--- a/dashboard-ui/app/hooks/useDebounce.ts
+++ b/dashboard-ui/app/hooks/useDebounce.ts
@@ -1,0 +1,16 @@
+"use client"
+
+import { useEffect, useState } from 'react'
+
+export function useDebounce<T>(value: T, delay = 300): T {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(handler)
+  }, [value, delay])
+
+  return debounced
+}
+
+export default useDebounce

--- a/dashboard-ui/app/hooks/useInventoryList.ts
+++ b/dashboard-ui/app/hooks/useInventoryList.ts
@@ -10,7 +10,8 @@ import {
 export interface InventoryListParams {
   page?: number
   pageSize?: number
-  search?: string
+  searchName?: string
+  searchSku?: string
   sort?: string
   filters?: Record<string, string>
 }
@@ -19,7 +20,15 @@ export const useInventoryList = (params: InventoryListParams) => {
   return useQuery<InventoryList, Error>({
     queryKey: ['inventory', params],
     queryFn: ({ signal }) =>
-      ProductService.getAll(undefined, signal).then(products => {
+      ProductService.getAll(
+        {
+          page: params.page,
+          pageSize: params.pageSize,
+          searchName: params.searchName,
+          searchSku: params.searchSku,
+        },
+        signal
+      ).then(products => {
         const items: IInventory[] = products.map(p => ({
           id: p.id,
           name: p.name,
@@ -32,13 +41,13 @@ export const useInventoryList = (params: InventoryListParams) => {
         }))
 
         let filtered = items
-        if (params.search) {
-          const q = params.search.toLowerCase()
-          filtered = filtered.filter(
-            it =>
-              it.name.toLowerCase().includes(q) ||
-              it.code.toLowerCase().includes(q)
-          )
+        if (params.searchName) {
+          const q = params.searchName.toLowerCase()
+          filtered = filtered.filter(it => it.name.toLowerCase().includes(q))
+        }
+        if (params.searchSku) {
+          const q = params.searchSku.toLowerCase()
+          filtered = filtered.filter(it => it.code.toLowerCase().includes(q))
         }
 
         if (params.sort) {


### PR DESCRIPTION
## Summary
- add debounced name and SKU filters with URL sync
- localize warehouse table and add pagination controls
- adjust inventory hook to support new search params

## Testing
- `cd dashboard-ui && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d8f343cd48329ab4ad42df438184c