### PR TITLE
feat: add combined warehouse search

### DIFF
--- a/dashboard-ui/app/components/products/ProductsTable.test.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.test.tsx
@@ -48,7 +48,7 @@ describe('ProductsTable', () => {
   it('filters by name', async () => {
     renderTable()
     await screen.findByText('Product 1')
-    const input = screen.getByLabelText('Название')
+    const input = screen.getByPlaceholderText('Поиск...')
     await userEvent.type(input, 'Second')
     await waitFor(() => {
       expect(screen.getByText('Second')).toBeInTheDocument()
@@ -58,7 +58,9 @@ describe('ProductsTable', () => {
   it('filters by sku', async () => {
     renderTable()
     await screen.findByText('Product 1')
-    const input = screen.getByLabelText('Артикул')
+    const select = screen.getByRole('combobox')
+    await userEvent.selectOptions(select, 'sku')
+    const input = screen.getByPlaceholderText('Поиск...')
     await userEvent.type(input, 'B2')
     await waitFor(() => {
       expect(screen.getByText('Second')).toBeInTheDocument()

--- a/server/src/product/product.controller.spec.ts
+++ b/server/src/product/product.controller.spec.ts
@@ -62,7 +62,10 @@ describe('ProductController', () => {
     const data = [{ id: 1 }]
     service.findAll.mockResolvedValue(data)
     await request(app.getHttpServer()).get('/products').expect(200).expect(data)
-    expect(service.findAll).toHaveBeenCalled()
+    expect(service.findAll).toHaveBeenCalledWith({
+      searchName: undefined,
+      searchSku: undefined,
+    })
   })
 
   it('/products/:id GET', async () => {

--- a/server/src/product/product.controller.ts
+++ b/server/src/product/product.controller.ts
@@ -5,6 +5,7 @@ import {
         Get,
         Param,
         ParseIntPipe,
+        Query,
         Post,
         Put,
         UseGuards
@@ -32,10 +33,13 @@ export class ProductController {
 	/**
 	 * Получение списка всех продуктов
 	 */
-	@Get()
-	async findAll(): Promise<ProductModel[]> {
-		return this.productService.findAll()
-	}
+        @Get()
+        async findAll(
+                @Query('searchName') searchName?: string,
+                @Query('searchSku') searchSku?: string
+        ): Promise<ProductModel[]> {
+                return this.productService.findAll({ searchName, searchSku })
+        }
 
 	/**
 	 * Получение одного продукта по ID

--- a/server/src/product/product.service.ts
+++ b/server/src/product/product.service.ts
@@ -4,7 +4,7 @@ import {
 	NotFoundException
 } from '@nestjs/common'
 import { InjectConnection, InjectModel } from '@nestjs/sequelize'
-import { Sequelize, Transaction } from 'sequelize'
+import { Op, Sequelize, Transaction } from 'sequelize'
 import { ProductModel } from './product.model'
 import { CreateProductDto } from './dto/product.dto'
 import { UpdateProductDto } from './dto/update.product.dto'
@@ -68,9 +68,24 @@ export class ProductService {
 	/**
 	 * 2) Возвращает все продукты с категориями и продажами.
 	 */
-	async findAll(): Promise<ProductModel[]> {
-		return this.productRepo.findAll({ include: ['category', 'sales'] })
-	}
+        async findAll(params?: {
+                searchName?: string
+                searchSku?: string
+        }): Promise<ProductModel[]> {
+                const where: any = {}
+                if (params?.searchName) {
+                        where.name = { [Op.iLike]: `%${params.searchName}%` }
+                }
+                if (params?.searchSku) {
+                        where.articleNumber = {
+                                [Op.iLike]: `%${params.searchSku}%`,
+                        }
+                }
+                return this.productRepo.findAll({
+                        where,
+                        include: ['category', 'sales'],
+                })
+        }
 
 	/**
 	 * 3) Возвращает один продукт по ID.


### PR DESCRIPTION
## Summary
- replace dual filters with unified search + field selector
- filter inventory API by name or sku

## Testing
- `npm test` in `dashboard-ui`
- `npm run lint` in `dashboard-ui`
- `npm test` in `server`
- `npm run lint` (fails: Key "@typescript-eslint/no-extraneous-class" invalid) in `server`


------
https://chatgpt.com/codex/tasks/task_e_689d92fdeb9083299a88e6549784d8c3