### PR TITLE
Remove obsolete search reset on warehouse page

### DIFF
--- a/dashboard-ui/app/components/products/ProductsTable.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.tsx
@@ -80,10 +80,6 @@ const ProductsTable = () => {
     }
   }
 
-  const handleReset = () => {
-    setSearchTerm('')
-  }
-
   const totalPages = data ? Math.ceil(data.total / data.pageSize) : 1
 
   return (
@@ -106,9 +102,6 @@ const ProductsTable = () => {
             <option value="sku">Артикул</option>
           </select>
         </div>
-        <Button className="bg-neutral-200 px-4 py-1" onClick={handleReset}>
-          Сброс
-        </Button>
         <Button
           className="ml-auto bg-primary-500 text-white px-4 py-1"
           onClick={() => setIsCreating(true)}


### PR DESCRIPTION
## Summary
- remove unused reset button from warehouse products table search

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d95e53c7083299d473c330a4aabad