### PR TITLE
feat: remove number input spinners in add product modal

### DIFF
--- a/dashboard-ui/app/assets/styles/global.scss
+++ b/dashboard-ui/app/assets/styles/global.scss
@@ -70,3 +70,14 @@ button {
   font: inherit;
 }
 
+/* Remove spinners from number inputs in Add Product modal */
+.add-product-modal input[type='number']::-webkit-outer-spin-button,
+.add-product-modal input[type='number']::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.add-product-modal input[type='number'] {
+  -moz-appearance: textfield;
+}
+

--- a/dashboard-ui/app/components/products/ProductForm.tsx
+++ b/dashboard-ui/app/components/products/ProductForm.tsx
@@ -85,6 +85,7 @@ const ProductForm = ({ product, onSuccess, onCancel }: Props) => {
       <Field
         type="number"
         {...register('purchasePrice', { valueAsNumber: true })}
+        onWheel={e => e.currentTarget.blur()}
         placeholder="Закупочная цена"
         label="Закупочная цена"
         error={errors.purchasePrice}
@@ -92,6 +93,7 @@ const ProductForm = ({ product, onSuccess, onCancel }: Props) => {
       <Field
         type="number"
         {...register('salePrice', { valueAsNumber: true })}
+        onWheel={e => e.currentTarget.blur()}
         placeholder="Цена продажи"
         label="Цена продажи"
         error={errors.salePrice}
@@ -99,6 +101,7 @@ const ProductForm = ({ product, onSuccess, onCancel }: Props) => {
       <Field
         type="number"
         {...register('remains', { valueAsNumber: true })}
+        onWheel={e => e.currentTarget.blur()}
         placeholder="Остаток"
         label="Остаток"
         error={errors.remains}

--- a/dashboard-ui/app/components/products/ProductsTable.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.tsx
@@ -217,13 +217,15 @@ const ProductsTable = () => {
           )}
           {isCreating && (
             <Modal isOpen={isCreating} onClose={() => setIsCreating(false)}>
-              <ProductForm
-                onSuccess={() => {
-                  refetch()
-                  setIsCreating(false)
-                }}
-                onCancel={() => setIsCreating(false)}
-              />
+              <div className="add-product-modal">
+                <ProductForm
+                  onSuccess={() => {
+                    refetch()
+                    setIsCreating(false)
+                  }}
+                  onCancel={() => setIsCreating(false)}
+                />
+              </div>
             </Modal>
           )}
           {error && <p className="text-error mt-2">{error}</p>}


### PR DESCRIPTION
## Summary
- style Add Product modal inputs to hide native number spinners across browsers
- prevent mouse wheel from altering numeric fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d9f0fae40832993accd35bafa6fde