### PR TITLE
Fix inventory table jank during sort and search

### DIFF
--- a/dashboard-ui/app/components/products/ProductsTable.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.tsx
@@ -41,12 +41,15 @@ const ProductsTable = () => {
   useEffect(() => {
     const params = new URLSearchParams()
     if (page > 1) params.set('page', String(page))
-    if (searchTerm) {
-      if (searchField === 'name') params.set('searchName', searchTerm)
-      else params.set('searchSku', searchTerm)
+    if (debouncedTerm) {
+      if (debouncedField === 'name') params.set('searchName', debouncedTerm)
+      else params.set('searchSku', debouncedTerm)
     }
-    router.replace(`?${params.toString()}`)
-  }, [page, searchTerm, searchField, router])
+    const newQuery = params.toString()
+    if (newQuery !== searchParams.toString()) {
+      router.replace(`?${newQuery}`)
+    }
+  }, [page, debouncedTerm, debouncedField, router, searchParams])
 
   useEffect(() => {
     setPage(1)
@@ -136,15 +139,30 @@ const ProductsTable = () => {
           <thead>
             <tr className="text-left border-b border-neutral-300">
               <th className="p-2 cursor-pointer" onClick={() => handleSort('name')}>
-                Название {sortField === 'name' && (sortOrder === 'asc' ? '↑' : '↓')}
+                <span className="inline-flex items-center">
+                  Название
+                  <span className="ml-1 inline-block w-4">
+                    {sortField === 'name' ? (sortOrder === 'asc' ? '↑' : '↓') : ''}
+                  </span>
+                </span>
               </th>
               <th className="p-2">Категория</th>
               <th className="p-2">Артикул</th>
               <th className="p-2 cursor-pointer" onClick={() => handleSort('quantity')}>
-                Остаток {sortField === 'quantity' && (sortOrder === 'asc' ? '↑' : '↓')}
+                <span className="inline-flex items-center">
+                  Остаток
+                  <span className="ml-1 inline-block w-4">
+                    {sortField === 'quantity' ? (sortOrder === 'asc' ? '↑' : '↓') : ''}
+                  </span>
+                </span>
               </th>
               <th className="p-2 cursor-pointer" onClick={() => handleSort('price')}>
-                Цена продажи {sortField === 'price' && (sortOrder === 'asc' ? '↑' : '↓')}
+                <span className="inline-flex items-center">
+                  Цена продажи
+                  <span className="ml-1 inline-block w-4">
+                    {sortField === 'price' ? (sortOrder === 'asc' ? '↑' : '↓') : ''}
+                  </span>
+                </span>
               </th>
               <th className="p-2">Действия</th>
             </tr>

--- a/dashboard-ui/app/hooks/useInventoryList.ts
+++ b/dashboard-ui/app/hooks/useInventoryList.ts
@@ -71,6 +71,7 @@ export const useInventoryList = (params: InventoryListParams) => {
       }),
     keepPreviousData: true,
     placeholderData: prev => prev,
+    staleTime: 30000,
     retry: 1,
     refetchOnWindowFocus: false,
   })


### PR DESCRIPTION
## Summary
- keep inventory query data around with a stale time to avoid empty flashes
- debounce URL updates and keep table mounted while search runs
- reserve space for sort arrows to prevent header jumps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dbe438ff48329b223e23a9293325f