### PR TITLE
Simplify weekly tasks widget

### DIFF
--- a/dashboard-ui/app/components/dashboard/WeeklyTasks.tsx
+++ b/dashboard-ui/app/components/dashboard/WeeklyTasks.tsx
@@ -1,99 +1,131 @@
 "use client";
 
-import React, { useState } from "react";
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import { TaskService } from "@/services/task/task.service";
-import { TaskStatus } from "@/shared/interfaces/task.interface";
-import { useAuth } from "@/hooks/useAuth";
+import { ITask, TaskStatus } from "@/shared/interfaces/task.interface";
+import { useMemo } from "react";
 
-const WeeklyTasks: React.FC = () => {
-  const { user } = useAuth();
-  const [onlyMine, setOnlyMine] = useState(false);
-  const { data, isLoading, error } = useQuery({
-    queryKey: ["weekly-tasks"],
-    queryFn: () => TaskService.getAll(),
+function getWeekRange() {
+  const today = new Date();
+  const day = today.getDay(); // 0 (Sun) - 6 (Sat)
+  const diffToMonday = day === 0 ? 6 : day - 1;
+  const start = new Date(today);
+  start.setDate(today.getDate() - diffToMonday);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(start);
+  end.setDate(start.getDate() + 6);
+  end.setHours(23, 59, 59, 999);
+  return { start, end };
+}
+
+const WeeklyTasks = () => {
+  const { start, end } = useMemo(getWeekRange, []);
+  const startIso = start.toISOString();
+  const endIso = end.toISOString();
+
+  const {
+    data,
+    isLoading,
+    isError,
+    refetch,
+    isFetching,
+  } = useQuery({
+    queryKey: ["weekly-tasks", startIso, endIso],
+    queryFn: () => TaskService.getAll({ start: startIso, end: endIso }),
   });
 
   if (isLoading) {
-    return <div className="h-40 bg-neutral-100 rounded-card animate-pulse" />;
+    return <div className="bg-neutral-100 p-4 rounded-card shadow-card h-40 animate-pulse" />;
   }
 
-  if (error || !data) {
-    return <div className="text-error">Нет данных</div>;
-  }
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
 
-  const now = new Date();
-  now.setHours(0, 0, 0, 0);
-  const weekEnd = new Date(now);
-  weekEnd.setDate(now.getDate() + 7);
-  weekEnd.setHours(23, 59, 59, 999);
-
-  let tasks = data;
-  if (onlyMine && user?.name) {
-    tasks = tasks.filter((t) => t.executor === user.name);
-  }
-
-  const overdue = tasks.filter(
-    (t) => new Date(t.deadline) < now && t.status !== TaskStatus.Completed
-  ).length;
-  const thisWeek = tasks.filter((t) => {
-    const d = new Date(t.deadline);
-    return d >= now && d <= weekEnd;
-  }).length;
-  const inProgress = tasks.filter((t) => t.status === TaskStatus.InProgress).length;
-
-  const list = tasks
-    .filter((t) => {
-      const d = new Date(t.deadline);
-      return d >= now && d <= weekEnd;
-    })
-    .slice(0, 5);
+  const tasks = (data || [])
+    .filter((t: ITask) => t.status !== TaskStatus.Completed)
+    .sort(
+      (a: ITask, b: ITask) =>
+        new Date(a.deadline).getTime() - new Date(b.deadline).getTime()
+    )
+    .slice(0, 10);
 
   return (
-    <div className="bg-neutral-100 p-4 rounded-card shadow-card">
+    <div className="bg-neutral-100 p-4 rounded-card shadow-card relative overflow-hidden">
+      {isFetching && (
+        <div className="absolute inset-0 bg-neutral-100/50 animate-pulse" />
+      )}
       <div className="flex justify-between items-center mb-4">
         <h3 className="text-lg font-semibold">Задачи недели</h3>
-        <Link href="/tasks" className="text-sm text-primary-600">
+        <Link
+          href={`/tasks?start=${encodeURIComponent(startIso)}&end=${encodeURIComponent(
+            endIso
+          )}`}
+          className="text-sm text-primary-600"
+        >
           Показать все
         </Link>
       </div>
-      {user && (
-        <label className="flex items-center gap-2 mb-2 text-sm">
-          <input
-            type="checkbox"
-            checked={onlyMine}
-            onChange={(e) => setOnlyMine(e.target.checked)}
-          />
-          Только мои
-        </label>
+      {isError && (
+        <div className="text-center">
+          <p className="text-error mb-2">Не удалось загрузить</p>
+          <button
+            onClick={() => refetch()}
+            className="text-sm text-primary-600"
+          >
+            Повторить
+          </button>
+        </div>
       )}
-      <div className="flex gap-4 mb-4 text-center">
-        <div className="flex-1">
-          <div className="text-2xl font-semibold">{overdue}</div>
-          <div className="text-sm text-neutral-600">Просрочено</div>
+      {!isError && tasks.length === 0 && (
+        <div className="text-sm text-neutral-600">
+          Нет задач на этой неделе
         </div>
-        <div className="flex-1">
-          <div className="text-2xl font-semibold">{thisWeek}</div>
-          <div className="text-sm text-neutral-600">На этой неделе</div>
-        </div>
-        <div className="flex-1">
-          <div className="text-2xl font-semibold">{inProgress}</div>
-          <div className="text-sm text-neutral-600">В работе</div>
-        </div>
-      </div>
-      {list.length === 0 ? (
-        <div className="text-sm text-neutral-600">Нет данных</div>
-      ) : (
-        <ul className="space-y-2 text-sm">
-          {list.map((t) => (
-            <li key={t.id} className="flex justify-between">
-              <span>{t.title}</span>
-              <span className="text-neutral-600">
-                {new Date(t.deadline).toLocaleDateString("ru-RU")}
-              </span>
-            </li>
-          ))}
+      )}
+      {!isError && tasks.length > 0 && (
+        <ul className="text-sm divide-y divide-neutral-200">
+          <li className="grid grid-cols-3 py-1 text-xs text-neutral-600">
+            <span>Название</span>
+            <span>Ответственный</span>
+            <span>Дедлайн</span>
+          </li>
+          {tasks.map((t) => {
+            const deadline = new Date(t.deadline);
+            const diff = deadline.getTime() - today.getTime();
+            const daysLeft = Math.ceil(diff / (1000 * 60 * 60 * 24));
+            const isOverdue = daysLeft < 0;
+            let badge: string | null = null;
+            if (!isOverdue && daysLeft >= 0 && daysLeft <= 3) {
+              if (daysLeft === 0) badge = "Сегодня";
+              else if (daysLeft === 1) badge = "Завтра";
+              else badge = "≤ 3 дня";
+            }
+            return (
+              <li key={t.id}>
+                <Link
+                  href={`/tasks/${t.id}`}
+                  className={`grid grid-cols-3 py-2 hover:bg-neutral-200 rounded ${
+                    isOverdue ? "text-error" : ""
+                  }`}
+                >
+                  <span>{t.title}</span>
+                  <span>{t.executor || "-"}</span>
+                  <span className="flex items-center gap-2">
+                    {deadline.toLocaleDateString("ru-RU")}
+                    {isOverdue ? (
+                      <span className="text-error text-xs">просрочено</span>
+                    ) : (
+                      badge && (
+                        <span className="bg-primary-100 text-primary-700 text-xs px-2 py-0.5 rounded">
+                          {badge}
+                        </span>
+                      )
+                    )}
+                  </span>
+                </Link>
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/dashboard-ui/app/services/task/task.service.ts
+++ b/dashboard-ui/app/services/task/task.service.ts
@@ -6,8 +6,8 @@ export const TaskService = {
    * GET /task
    * Получение всех задач.
    */
-  async getAll() {
-    const response = await axios.get<ITask[]>('/task')
+  async getAll(params?: { start?: string; end?: string }) {
+    const response = await axios.get<ITask[]>('/task', { params })
     return response.data
   },
 

--- a/server/src/task/task.controller.spec.ts
+++ b/server/src/task/task.controller.spec.ts
@@ -54,7 +54,18 @@ describe('TaskController', () => {
     const data = [{ id: 1 }]
     service.findAll.mockResolvedValue(data)
     await request(app.getHttpServer()).get('/task').expect(200).expect(data)
-    expect(service.findAll).toHaveBeenCalled()
+    expect(service.findAll).toHaveBeenCalledWith(undefined, undefined)
+  })
+
+  it('/task GET with range', async () => {
+    const data = [{ id: 1 }]
+    service.findAll.mockResolvedValue(data)
+    await request(app.getHttpServer())
+      .get('/task')
+      .query({ start: '2024-01-01', end: '2024-01-07' })
+      .expect(200)
+      .expect(data)
+    expect(service.findAll).toHaveBeenCalledWith('2024-01-01', '2024-01-07')
   })
 
   it('/task/:id GET', async () => {

--- a/server/src/task/task.controller.ts
+++ b/server/src/task/task.controller.ts
@@ -7,6 +7,7 @@ import {
         ParseIntPipe,
         Post,
         Put,
+        Query,
         UseGuards
 } from '@nestjs/common'
 import { AuthGuard } from '@nestjs/passport'
@@ -25,10 +26,13 @@ export class TaskController {
 		return this.taskService.create(dto)
 	}
 
-	@Get()
-	async findAll(): Promise<TaskModel[]> {
-		return this.taskService.findAll()
-	}
+        @Get()
+        async findAll(
+                @Query('start') start?: string,
+                @Query('end') end?: string
+        ): Promise<TaskModel[]> {
+                return this.taskService.findAll(start, end)
+        }
 
 	@Get(':id')
 	async findOne(@Param('id', ParseIntPipe) id: number): Promise<TaskModel> {

--- a/server/src/task/task.service.spec.ts
+++ b/server/src/task/task.service.spec.ts
@@ -3,6 +3,7 @@ import { TaskService } from './task.service'
 import { getModelToken } from '@nestjs/sequelize'
 import { TaskModel } from './task.model'
 import { NotFoundException } from '@nestjs/common'
+import { Op } from 'sequelize'
 
 const mockTask = { id: 1, title: 'Test', update: jest.fn(), destroy: jest.fn() }
 
@@ -38,10 +39,17 @@ describe('TaskService', () => {
     expect(repo.create).toHaveBeenCalledWith({ ...dto })
   })
 
-  it('findAll', async () => {
+  it('findAll without params', async () => {
     const res = await service.findAll()
     expect(res).toEqual([mockTask])
-    expect(repo.findAll).toHaveBeenCalled()
+    expect(repo.findAll).toHaveBeenCalledWith({ where: {} })
+  })
+
+  it('findAll with range', async () => {
+    await service.findAll('2024-01-01', '2024-01-07')
+    expect(repo.findAll).toHaveBeenCalledWith({
+      where: { deadline: { [Op.between]: [new Date('2024-01-01'), new Date('2024-01-07')] } }
+    })
   })
 
   it('findOne success', async () => {

--- a/server/src/task/task.service.ts
+++ b/server/src/task/task.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
+import { Op } from 'sequelize'
 import { TaskModel } from './task.model'
 import { CreateTaskDto } from './dto/task.dto'
 import { UpdateTaskDto } from './dto/update.task.dto'
@@ -14,9 +15,15 @@ export class TaskService {
 		return this.taskRepo.create({ ...dto })
 	}
 
-	async findAll(): Promise<TaskModel[]> {
-		return this.taskRepo.findAll()
-	}
+        async findAll(start?: string, end?: string): Promise<TaskModel[]> {
+                const where: any = {}
+                if (start && end) {
+                        where.deadline = {
+                                [Op.between]: [new Date(start), new Date(end)]
+                        }
+                }
+                return this.taskRepo.findAll({ where })
+        }
 
 	async findOne(id: number): Promise<TaskModel> {
 		const task = await this.taskRepo.findByPk(id)


### PR DESCRIPTION
## Summary
- filter backend tasks by date range
- streamline weekly tasks widget to show current week tasks only
- highlight tasks due within three days and mark overdue

## Testing
- `npm test` (server)
- `npm test` (dashboard-ui)


------
https://chatgpt.com/codex/tasks/task_e_689dd0bcbd9483299816b3d32e2ab8bc