### PR TITLE
feat: add warehouse snapshot title and low stock counter

### DIFF
--- a/dashboard-ui/app/components/dashboard/InventorySnapshot.tsx
+++ b/dashboard-ui/app/components/dashboard/InventorySnapshot.tsx
@@ -40,7 +40,9 @@ const InventorySnapshot: React.FC = () => {
     0
   );
   const outOfStock = data.filter((p) => p.remains === 0).length;
-  const lowStock = data.filter((p) => p.remains > 0 && p.remains < 5).length;
+  const lowStock = data.filter(
+    (p) => p.remains > 0 && p.remains <= (p.minStock ?? 0)
+  ).length;
 
   const counters = [
     { label: "Всего", value: totalSkus.toLocaleString("ru-RU") },
@@ -50,13 +52,16 @@ const InventorySnapshot: React.FC = () => {
   ];
 
   return (
-    <div className="bg-neutral-100 p-4 rounded-card shadow-card grid grid-cols-2 sm:grid-cols-4 gap-4 text-center">
-      {counters.map((c) => (
-        <div key={c.label} className="flex flex-col">
-          <span className="text-sm text-neutral-600">{c.label}</span>
-          <span className="text-lg font-semibold">{c.value}</span>
-        </div>
-      ))}
+    <div className="bg-neutral-100 p-4 rounded-card shadow-card">
+      <h3 className="text-lg font-semibold mb-4">Склад</h3>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-center">
+        {counters.map((c) => (
+          <div key={c.label} className="flex flex-col">
+            <span className="text-sm text-neutral-600">{c.label}</span>
+            <span className="text-lg font-semibold">{c.value}</span>
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/dashboard-ui/app/shared/interfaces/product.interface.ts
+++ b/dashboard-ui/app/shared/interfaces/product.interface.ts
@@ -17,6 +17,7 @@ export interface IProduct {
   purchasePrice: number
   salePrice: number
   remains: number
+  minStock?: number
   // Связанная категория может приходить из бэкенда
   category?: ICategory
 }
@@ -30,4 +31,5 @@ export interface IProductCreate {
   purchasePrice: number
   salePrice: number
   remains: number
+  minStock?: number
 }

--- a/dashboard-ui/tests/mocks/handlers.ts
+++ b/dashboard-ui/tests/mocks/handlers.ts
@@ -22,6 +22,7 @@ export const mockProducts: IProduct[] = [
     purchasePrice: 10,
     salePrice: 20,
     remains: 5,
+    minStock: 5,
   },
   {
     id: 2,
@@ -30,6 +31,7 @@ export const mockProducts: IProduct[] = [
     purchasePrice: 8,
     salePrice: 15,
     remains: 2,
+    minStock: 3,
   },
 ]
 


### PR DESCRIPTION
## Summary
- show inventory snapshot title "Склад"
- display low-stock items count using each product's threshold

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689df1c54cac83298f68558e5429e04d