### PR TITLE
Fix dashboard period selector and metrics fetching

### DIFF
--- a/dashboard-ui/app/components/dashboard/DashboardControls.tsx
+++ b/dashboard-ui/app/components/dashboard/DashboardControls.tsx
@@ -25,7 +25,7 @@ const DashboardControls: React.FC<Props> = ({
   onWarehouseChange,
 }) => {
   return (
-    <div className="flex items-center gap-4">
+    <div className="inline-flex items-center gap-4">
       <select
         aria-label="Выбор периода"
         className="border border-neutral-300 rounded px-2 py-1 text-sm w-auto"
@@ -41,7 +41,7 @@ const DashboardControls: React.FC<Props> = ({
       {onWarehouseChange && (
         <select
           aria-label="Склад"
-          className="border border-neutral-300 rounded px-2 py-1 text-sm ml-auto w-auto"
+          className="border border-neutral-300 rounded px-2 py-1 text-sm w-auto"
           value={warehouse ?? ""}
           onChange={(e) => onWarehouseChange(e.target.value)}
         >

--- a/dashboard-ui/app/components/dashboard/KpiCards.test.tsx
+++ b/dashboard-ui/app/components/dashboard/KpiCards.test.tsx
@@ -3,14 +3,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { vi } from 'vitest'
 import KpiCards from './KpiCards'
 
-const today = new Date().toISOString().slice(0, 10)
-
 vi.mock('@/services/analytics/analytics.service', () => ({
   AnalyticsService: {
-    getDailyRevenue: vi.fn(() =>
-      Promise.resolve([{ date: today, total: 1000 }])
+    getKpis: vi.fn(() =>
+      Promise.resolve({ revenue: 1000, orders: 2, avgCheck: 500 })
     ),
-    getSales: vi.fn(() => Promise.resolve([{ date: today, total: 2 }])),
   },
 }))
 
@@ -27,6 +24,7 @@ describe('KpiCards', () => {
   it('aggregates KPIs', async () => {
     renderKpis()
     expect(await screen.findByText('2')).toBeInTheDocument()
+    expect(await screen.findByText(/1[\s\u00A0]?000,00/)).toBeInTheDocument()
     expect(await screen.findByText(/500,00/)).toBeInTheDocument()
   })
 })

--- a/dashboard-ui/app/page.tsx
+++ b/dashboard-ui/app/page.tsx
@@ -18,12 +18,14 @@ export default function Home() {
 
   return (
     <Layout>
-      <div className="space-y-8">
+      <div className="flex justify-end mb-4">
         <DashboardControls period={period} onPeriodChange={setPeriod} />
+      </div>
+      <div className="space-y-8">
         <KpiCards period={period} />
         <SalesChart period={period} />
-        <InventorySnapshot />
         <TopProducts />
+        <InventorySnapshot />
         <WeeklyTasks />
       </div>
     </Layout>

--- a/dashboard-ui/app/services/analytics/analytics.service.ts
+++ b/dashboard-ui/app/services/analytics/analytics.service.ts
@@ -32,6 +32,21 @@ export const AnalyticsService = {
     })
     return res.data
   },
+  async getKpis(
+    startDate?: string,
+    endDate?: string,
+    categories?: number[]
+  ) {
+    const params: any = {}
+    if (startDate) params.startDate = startDate
+    if (endDate) params.endDate = endDate
+    if (categories && categories.length) params.categories = categories.join(',')
+    const res = await axios.get(
+      '/analytics/kpis',
+      { params }
+    )
+    return res.data
+  },
   async getSales(period: number) {
     const res = await axios.get<ISalesStat[]>(`/analytics/sales`, { params: { period } })
     return res.data


### PR DESCRIPTION
## Summary
- Refine period selector layout and order Top Products after Sales
- Fetch dashboard KPIs via new analytics endpoint with zero defaults
- Stabilize sales chart data and show zero-line when empty

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f0276cdfc8329bb797f3dc4190b46