### PR TITLE
fix: correct sum argument in analytics revenue

### DIFF
--- a/server/src/analytics/analytics.service.spec.ts
+++ b/server/src/analytics/analytics.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { getModelToken } from '@nestjs/sequelize'
-import { Op, col } from 'sequelize'
+import { Op } from 'sequelize'
 import { DateTime } from 'luxon'
 import { AnalyticsService } from './analytics.service'
 import { SaleModel } from '../sale/sale.model'
@@ -31,7 +31,7 @@ describe('AnalyticsService', () => {
     it('calculates revenue with filters', async () => {
       saleRepo.sum.mockResolvedValue('100')
       const result = await service.getRevenue('2024-01-01', '2024-01-31', [1, 2])
-      expect(saleRepo.sum).toHaveBeenCalledWith(col('SaleModel.total_price'), expect.objectContaining({
+      expect(saleRepo.sum).toHaveBeenCalledWith('totalPrice', expect.objectContaining({
         where: expect.objectContaining({
           saleDate: { [Op.between]: ['2024-01-01', '2024-01-31'] },
           '$product.category_id$': { [Op.in]: [1, 2] }

--- a/server/src/analytics/analytics.service.ts
+++ b/server/src/analytics/analytics.service.ts
@@ -44,7 +44,7 @@ export class AnalyticsService {
 		if (categoryIds && categoryIds.length) {
 			where['$product.category_id$'] = { [Op.in]: categoryIds }
 		}
-                const revenue = await this.saleRepo.sum(col('SaleModel.total_price'), {
+                const revenue = await this.saleRepo.sum('totalPrice', {
                         where,
                         // @ts-ignore
                         include:


### PR DESCRIPTION
## Summary
- fix analytics revenue calculation by using attribute name instead of Sequelize column helper
- adjust analytics service tests for new sum call

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f0ee4d11c83298b168d1d1dd3aaa7