### PR TITLE
Fix sales chart data aggregation

### DIFF
--- a/dashboard-ui/app/components/dashboard/SalesChart.tsx
+++ b/dashboard-ui/app/components/dashboard/SalesChart.tsx
@@ -20,11 +20,6 @@ const SalesChart: React.FC<Props> = ({ period }) => {
     "revenue"
   );
   const { start, end } = getPeriodRange(period);
-  const today = new Date();
-  const days =
-    Math.floor(
-      (Math.min(today.getTime(), end.getTime()) - start.getTime()) / 86400000
-    ) + 1;
 
   const {
     data,
@@ -40,13 +35,12 @@ const SalesChart: React.FC<Props> = ({ period }) => {
       end.toISOString(),
     ],
     queryFn: async () => {
+      const s = start.toISOString().slice(0, 10);
+      const e = end.toISOString().slice(0, 10);
       if (metric === "revenue") {
-        return AnalyticsService.getDailyRevenue(
-          start.toISOString().slice(0, 10),
-          end.toISOString().slice(0, 10)
-        );
+        return AnalyticsService.getDailyRevenue(s, e);
       }
-      return AnalyticsService.getSales(days);
+      return AnalyticsService.getSales(s, e);
     },
     keepPreviousData: true,
   });

--- a/dashboard-ui/app/services/analytics/analytics.service.ts
+++ b/dashboard-ui/app/services/analytics/analytics.service.ts
@@ -47,8 +47,16 @@ export const AnalyticsService = {
     )
     return res.data
   },
-  async getSales(period: number) {
-    const res = await axios.get<ISalesStat[]>(`/analytics/sales`, { params: { period } })
+  async getSales(
+    startDate?: string,
+    endDate?: string,
+    categories?: number[]
+  ) {
+    const params: any = {}
+    if (startDate) params.startDate = startDate
+    if (endDate) params.endDate = endDate
+    if (categories && categories.length) params.categories = categories.join(',')
+    const res = await axios.get<ISalesStat[]>(`/analytics/sales`, { params })
     return res.data
   },
   async getTurnover() {

--- a/dashboard-ui/app/utils/buckets.ts
+++ b/dashboard-ui/app/utils/buckets.ts
@@ -44,7 +44,10 @@ export function buildBuckets(
       const date = new Date(range.start.getFullYear(), m, 1);
       buckets.push({
         key: `${date.getFullYear()}-${String(m + 1).padStart(2, "0")}`,
-        label: date.toLocaleDateString("ru-RU", { month: "short" }),
+        label: date.toLocaleDateString("ru-RU", {
+          month: "short",
+          year: "numeric",
+        }),
         value: 0,
       });
     }
@@ -59,8 +62,8 @@ export function buildBuckets(
     buckets.push({
       key,
       label: current.toLocaleDateString("ru-RU", {
-        day: "numeric",
-        month: "short",
+        day: "2-digit",
+        month: "2-digit",
       }),
       value: 0,
     });

--- a/server/src/analytics/analytics.controller.ts
+++ b/server/src/analytics/analytics.controller.ts
@@ -5,7 +5,6 @@ import { ProductModel } from '../product/product.model'
 import { AnalyticsQueryDto } from './dto/analytics.query.dto'
 import { LowStockQueryDto } from './dto/low-stock.query.dto'
 import { TopProductsQueryDto } from './dto/top-products.query.dto'
-import { SalesPeriodQueryDto } from './dto/sales-period.query.dto'
 
 @UseGuards(AuthGuard('jwt'))
 @Controller('analytics')
@@ -126,16 +125,14 @@ export class AnalyticsController {
         }
 
         /**
-         * Возвращает суммы продаж по дням за выбранный период.
-         *
-         * @param period - Период в днях (7, 14, 30, 365)
+         * Возвращает количество продаж по дням за выбранный период.
          */
         @Get('sales')
         getSales(
                 @Query(new ValidationPipe({ transform: true }))
-                query: SalesPeriodQueryDto
+                query: AnalyticsQueryDto
         ) {
-                const { period } = query
-                return this.analyticsService.getSales(period)
+                const { startDate, endDate, categories } = query
+                return this.analyticsService.getSales(startDate, endDate, categories)
         }
 }

--- a/server/src/analytics/analytics.service.spec.ts
+++ b/server/src/analytics/analytics.service.spec.ts
@@ -123,15 +123,20 @@ describe('AnalyticsService', () => {
   })
 
   describe('getSales', () => {
-    it('builds date range and maps result', async () => {
-      saleRepo.findAll.mockResolvedValue([{ date: '2024-01-01', total: '40' }])
-      const result = await service.getSales(7)
+    it('maps results with filters', async () => {
+      saleRepo.findAll.mockResolvedValue([{ date: '2024-01-01', total: '3' }])
+      const result = await service.getSales('2024-01-01', '2024-01-07', [1])
       expect(saleRepo.findAll).toHaveBeenCalledWith(expect.objectContaining({
         where: expect.objectContaining({
-          saleDate: { [Op.between]: [expect.any(String), expect.any(String)] }
-        })
+          saleDate: { [Op.between]: ['2024-01-01', '2024-01-07'] },
+          '$product.category_id$': { [Op.in]: [1] }
+        }),
+        include: [{ model: ProductModel, attributes: [] }],
+        group: [expect.anything()],
+        order: [[expect.anything(), 'ASC']],
+        raw: true
       }))
-      expect(result).toEqual([{ date: '2024-01-01', total: 40 }])
+      expect(result).toEqual([{ date: '2024-01-01', total: 3 }])
     })
   })
 })


### PR DESCRIPTION
## Summary
- request sales chart data using start/end dates and metric-specific endpoints
- bucket chart dates consistently and show dd.MM or MMM YYYY labels
- expose backend daily sales count endpoint with optional category filters

## Testing
- `npm test` (server)
- `npm test` (dashboard-ui)


------
https://chatgpt.com/codex/tasks/task_e_689f1267ae248329b225991f69c8976e