### PR TITLE
feat: top products and categories charts

### DIFF
--- a/dashboard-ui/app/components/dashboard/TopProducts.test.tsx
+++ b/dashboard-ui/app/components/dashboard/TopProducts.test.tsx
@@ -7,27 +7,33 @@ vi.mock('@/services/analytics/analytics.service', () => ({
   AnalyticsService: {
     getTopProducts: vi.fn(() =>
       Promise.resolve([
-        { productId: 1, productName: 'Test', totalUnits: 1, totalRevenue: 1000 },
+        { productId: 1, productName: 'Prod1', categoryName: 'Cat1', totalUnits: 10, totalRevenue: 1000 },
+      ])
+    ),
+    getCategorySales: vi.fn(() =>
+      Promise.resolve([
+        { categoryId: 1, categoryName: 'Cat1', totalUnits: 10, totalRevenue: 1000 },
       ])
     ),
   },
 }))
-vi.mock('@/services/product/product.service', () => ({
-  ProductService: { getById: vi.fn(() => Promise.resolve({ remains: 5 })) },
-}))
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }))
 
 const renderWidget = () => {
   const client = new QueryClient()
   render(
     <QueryClientProvider client={client}>
-      <TopProducts />
+      <TopProducts period="day" />
     </QueryClientProvider>
   )
 }
 
-describe('TopProducts', () => {
-  it('renders items', async () => {
+describe('TopProducts charts', () => {
+  it('renders headings', async () => {
     renderWidget()
-    expect(await screen.findByText('Test')).toBeInTheDocument()
+    expect(await screen.findByText('Топ товаров')).toBeInTheDocument()
+    expect(screen.getByText('Товары')).toBeInTheDocument()
+    expect(screen.getByText('Категории')).toBeInTheDocument()
   })
 })

--- a/dashboard-ui/app/page.tsx
+++ b/dashboard-ui/app/page.tsx
@@ -24,7 +24,7 @@ export default function Home() {
       <div className="space-y-8">
         <KpiCards period={period} />
         <SalesChart period={period} />
-        <TopProducts />
+        <TopProducts period={period} />
         <InventorySnapshot />
         <WeeklyTasks />
       </div>

--- a/dashboard-ui/app/services/analytics/analytics.service.ts
+++ b/dashboard-ui/app/services/analytics/analytics.service.ts
@@ -1,5 +1,6 @@
 import axios from '../../api/interceptor'
 import { ITopProduct } from '@/shared/interfaces/top-product.interface'
+import { ICategorySales } from '@/shared/interfaces/category-sales.interface'
 import { ISalesStat } from '@/shared/interfaces/sales-stat.interface'
 import { ITurnover } from '@/shared/interfaces/turnover.interface'
 
@@ -16,6 +17,21 @@ export const AnalyticsService = {
     if (endDate) params.endDate = endDate
     if (categories && categories.length) params.categories = categories.join(',')
     const res = await axios.get<ITopProduct[]>('/analytics/top-products', { params })
+    return res.data
+  },
+  async getCategorySales(
+    startDate?: string,
+    endDate?: string,
+    categories?: number[]
+  ) {
+    const params: any = {}
+    if (startDate) params.startDate = startDate
+    if (endDate) params.endDate = endDate
+    if (categories && categories.length) params.categories = categories.join(',')
+    const res = await axios.get<ICategorySales[]>(
+      '/analytics/category-sales',
+      { params }
+    )
     return res.data
   },
   async getDailyRevenue(

--- a/dashboard-ui/app/shared/interfaces/category-sales.interface.ts
+++ b/dashboard-ui/app/shared/interfaces/category-sales.interface.ts
@@ -1,0 +1,6 @@
+export interface ICategorySales {
+  categoryId: number
+  categoryName: string
+  totalUnits: number
+  totalRevenue: number
+}

--- a/dashboard-ui/vitest.setup.tsx
+++ b/dashboard-ui/vitest.setup.tsx
@@ -16,3 +16,12 @@ afterEach(() => {
   cleanup()
 })
 afterAll(() => server.close())
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+// @ts-ignore
+vi.stubGlobal('ResizeObserver', ResizeObserverMock)


### PR DESCRIPTION
## Summary
- add category sales API client
- refactor dashboard TopProducts widget into charts with shared controls
- cover charts with test and polyfill ResizeObserver

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_689f1cc658108329878ac05dfda7c99a