### PR TITLE
feat: add inventory KPIs and purchase price column

### DIFF
--- a/dashboard-ui/app/shared/interfaces/inventory.interface.ts
+++ b/dashboard-ui/app/shared/interfaces/inventory.interface.ts
@@ -5,10 +5,20 @@ export interface IInventory {
   name: string
   code: string
   quantity: number
+  /** Цена продажи */
   price: number
+  /** Закупочная цена */
+  purchasePrice: number
+  /** Минимальный остаток для уведомления */
+  minStock?: number
   status?: string
   updatedAt?: string
   category?: ICategory
+}
+
+export interface InventoryStats {
+  outOfStock: number
+  lowStock: number
 }
 
 export interface InventoryList {
@@ -16,4 +26,5 @@ export interface InventoryList {
   total: number
   page: number
   pageSize: number
+  stats: InventoryStats
 }

--- a/dashboard-ui/app/utils/formatCurrency.test.ts
+++ b/dashboard-ui/app/utils/formatCurrency.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import formatCurrency from './formatCurrency'
+
+describe('formatCurrency', () => {
+  it('formats number to RUB currency', () => {
+    const value = 1234.5
+    expect(formatCurrency(value)).toBe(
+      new Intl.NumberFormat('ru-RU', {
+        style: 'currency',
+        currency: 'RUB',
+      }).format(value),
+    )
+  })
+})

--- a/dashboard-ui/app/utils/inventoryStats.test.ts
+++ b/dashboard-ui/app/utils/inventoryStats.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { calculateInventoryStats } from './inventoryStats'
+
+describe('calculateInventoryStats', () => {
+  it('calculates out of stock and low stock counts', () => {
+    const stats = calculateInventoryStats([
+      { quantity: 0 },
+      { quantity: 1, minStock: 2 },
+      { quantity: 3, minStock: 2 },
+      { quantity: 1 },
+    ])
+    expect(stats.outOfStock).toBe(1)
+    expect(stats.lowStock).toBe(2)
+  })
+})

--- a/dashboard-ui/app/utils/inventoryStats.ts
+++ b/dashboard-ui/app/utils/inventoryStats.ts
@@ -1,0 +1,21 @@
+import { IInventory } from '@/shared/interfaces/inventory.interface'
+
+export const DEFAULT_LOW_STOCK = 2
+
+export interface InventoryStats {
+  outOfStock: number
+  lowStock: number
+}
+
+export const calculateInventoryStats = (
+  items: Pick<IInventory, 'quantity' | 'minStock'>[],
+  defaultLowStock = DEFAULT_LOW_STOCK,
+): InventoryStats => {
+  const outOfStock = items.filter(it => it.quantity === 0).length
+  const lowStock = items.filter(
+    it => it.quantity > 0 && it.quantity <= (it.minStock ?? defaultLowStock),
+  ).length
+  return { outOfStock, lowStock }
+}
+
+export default calculateInventoryStats


### PR DESCRIPTION
## Summary
- show KPI counters for out-of-stock and low-stock products with filtering
- display purchase price alongside sale price in inventory table
- add tests for inventory stats and currency formatting

## Testing
- `cd dashboard-ui && yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68a30437a9a88329aceee836f025972e