### PR TITLE
feat: modal for inventory product stats with arrow navigation

### DIFF
--- a/dashboard-ui/app/components/products/ProductDetails.tsx
+++ b/dashboard-ui/app/components/products/ProductDetails.tsx
@@ -1,34 +1,139 @@
-import { FC } from 'react'
+import { FC, useEffect } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa'
 import Button from '@/ui/Button/Button'
+import Modal from '@/ui/Modal/Modal'
+import { ProductService } from '@/services/product/product.service'
 import { IProduct } from '@/shared/interfaces/product.interface'
 import { formatCurrency } from '@/utils/formatCurrency'
 
 interface Props {
   product: IProduct
   onClose: () => void
+  onPrev?: () => void
+  onNext?: () => void
+  onFirst?: () => void
+  onLast?: () => void
 }
 
-const ProductDetails: FC<Props> = ({ product, onClose }) => {
-  return (
-    <div className="mt-4 p-4 border border-neutral-300 rounded bg-neutral-100">
-      <div className="flex justify-between items-center mb-2">
-        <h2 className="text-lg font-semibold">{product.name}</h2>
+const ProductDetails: FC<Props> = ({
+  product,
+  onClose,
+  onPrev,
+  onNext,
+  onFirst,
+  onLast,
+}) => {
+  const hasPrev = !!onPrev
+  const hasNext = !!onNext
+  const titleId = `product-modal-${product.id}`
+
+  const { data, status, refetch } = useQuery<IProduct, Error>({
+    queryKey: ['product', product.id],
+    queryFn: ({ signal }) => ProductService.getById(product.id, signal),
+  })
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft' && hasPrev) onPrev?.()
+      if (e.key === 'ArrowRight' && hasNext) onNext?.()
+      if (e.key === 'Home') onFirst?.()
+      if (e.key === 'End') onLast?.()
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [hasPrev, hasNext, onPrev, onNext, onFirst, onLast])
+
+  let content: React.ReactNode
+  if (status === 'pending') {
+    content = (
+      <div className="space-y-4">
+        <div className="h-6 bg-neutral-200 rounded w-1/2" />
+        <div className="h-4 bg-neutral-200 rounded w-1/3" />
+        <div className="space-y-2">
+          <div className="h-4 bg-neutral-200 rounded w-full" />
+          <div className="h-4 bg-neutral-200 rounded w-5/6" />
+          <div className="h-4 bg-neutral-200 rounded w-2/3" />
+          <div className="h-4 bg-neutral-200 rounded w-1/2" />
+          <div className="h-4 bg-neutral-200 rounded w-1/3" />
+        </div>
+      </div>
+    )
+  } else if (status === 'error') {
+    content = (
+      <div className="text-center">
+        <p className="mb-4">Ошибка загрузки</p>
         <Button
-          onClick={onClose}
-          className="bg-secondary-500 text-white px-2 py-1"
+          onClick={() => refetch()}
+          className="bg-primary-500 text-white px-4 py-2"
         >
-          Закрыть
+          Повторить
         </Button>
       </div>
-      <div className="space-y-1 text-sm">
-        <p>Артикул: {product.articleNumber}</p>
-        <p>Категория: {product.category?.name || '-'}</p>
-        <p>Закупочная цена: {formatCurrency(product.purchasePrice)}</p>
-        <p>Цена продажи: {formatCurrency(product.salePrice)}</p>
-        <p>Остаток: {product.remains}</p>
-      </div>
-    </div>
+    )
+  } else {
+    const p = data ?? product
+    content = (
+      <>
+        <div className="flex items-center justify-between mb-4">
+          {hasPrev && (
+            <Button
+              onClick={onPrev}
+              className="p-2 rounded-full bg-neutral-200 hover:bg-neutral-300 active:bg-neutral-400"
+              aria-label="Предыдущий товар"
+              title="Предыдущий товар"
+            >
+              <FaChevronLeft />
+            </Button>
+          )}
+          <div className="flex-1 text-center">
+            <h2 id={titleId} className="text-xl font-semibold">
+              {p.name} <span className="text-neutral-500 text-sm">{p.articleNumber}</span>
+            </h2>
+            <p className="text-sm text-neutral-500">
+              {p.category?.name || '-'}
+            </p>
+          </div>
+          {hasNext && (
+            <Button
+              onClick={onNext}
+              className="p-2 rounded-full bg-neutral-200 hover:bg-neutral-300 active:bg-neutral-400"
+              aria-label="Следующий товар"
+              title="Следующий товар"
+            >
+              <FaChevronRight />
+            </Button>
+          )}
+        </div>
+        <div className="space-y-1 text-sm">
+          <p>Закупочная цена: {formatCurrency(p.purchasePrice)}</p>
+          <p>Цена продажи: {formatCurrency(p.salePrice)}</p>
+          <p>Остаток: {p.remains}</p>
+          <p>Минимальный остаток: {p.minStock}</p>
+        </div>
+        <div className="mt-4 text-right">
+          <Button
+            onClick={onClose}
+            className="bg-secondary-500 text-white px-4 py-2"
+          >
+            Закрыть
+          </Button>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <Modal
+      isOpen
+      onClose={onClose}
+      ariaLabelledby={titleId}
+      className="max-w-full md:max-w-4xl w-full rounded-2xl bg-white shadow-xl p-6 md:p-8 max-h-[90vh] overflow-y-auto"
+    >
+      {content}
+    </Modal>
   )
 }
 
 export default ProductDetails
+

--- a/dashboard-ui/app/components/products/ProductsTable.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Button from '@/ui/Button/Button'
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa'
 import { ProductService } from '@/services/product/product.service'
 import ProductForm from './ProductForm'
 import ProductDetails from './ProductDetails'
@@ -31,7 +32,7 @@ const ProductsTable = () => {
   const [searchField, setSearchField] = useState<'name' | 'sku'>(initialField)
   const [sortField, setSortField] = useState<'name' | 'quantity' | 'price'>('name')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
-  const [selected, setSelected] = useState<IProduct | null>(null)
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
   const [isCreating, setIsCreating] = useState(false)
   const [products, setProducts] = useState<IInventory[]>([])
   const [error, setError] = useState<string | null>(null)
@@ -90,17 +91,8 @@ const ProductsTable = () => {
     }
   }
 
-  const openDetails = (prod: IInventory) => {
-    setSelected({
-      id: prod.id,
-      name: prod.name,
-      articleNumber: prod.code,
-      purchasePrice: prod.purchasePrice,
-      salePrice: prod.price,
-      remains: prod.quantity,
-      minStock: prod.minStock,
-      category: prod.category,
-    })
+  const openDetails = (index: number) => {
+    setSelectedIndex(index)
   }
 
   const isInitialLoading = status === 'pending' && !data
@@ -257,7 +249,7 @@ const ProductsTable = () => {
               </tr>
             )}
             {!isInitialLoading &&
-              products.map(prod => (
+              products.map((prod, index) => (
                 <tr
                   key={prod.id}
                   className="row border-b border-neutral-200 hover:bg-neutral-200"
@@ -271,7 +263,7 @@ const ProductsTable = () => {
                   <td className="p-2 space-x-2 flex justify-end">
                     <Button
                       className="bg-primary-500 text-white px-2 py-1"
-                      onClick={() => openDetails(prod)}
+                      onClick={() => openDetails(index)}
                     >
                       Статистика
                     </Button>
@@ -289,29 +281,59 @@ const ProductsTable = () => {
       </div>
 
       {totalPages > 1 && (
-        <div className="flex justify-center mt-4 space-x-2">
-          <Button
-            className="px-3 py-1 bg-neutral-200"
-            disabled={page <= 1}
-            onClick={() => setPage(p => Math.max(1, p - 1))}
-          >
-            Предыдущая
-          </Button>
+        <div className="flex justify-center mt-4 space-x-2 items-center">
+          {page > 1 && (
+            <Button
+              className="p-2 rounded-full bg-neutral-200 hover:bg-neutral-300 active:bg-neutral-400"
+              onClick={() => setPage(p => Math.max(1, p - 1))}
+              aria-label="Предыдущий товар"
+              title="Предыдущий товар"
+            >
+              <FaChevronLeft />
+            </Button>
+          )}
           <span>
             {page} / {totalPages}
           </span>
-          <Button
-            className="px-3 py-1 bg-neutral-200"
-            disabled={page >= totalPages}
-            onClick={() => setPage(p => Math.min(totalPages, p + 1))}
-          >
-            Следующая
-          </Button>
+          {page < totalPages && (
+            <Button
+              className="p-2 rounded-full bg-neutral-200 hover:bg-neutral-300 active:bg-neutral-400"
+              onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+              aria-label="Следующий товар"
+              title="Следующий товар"
+            >
+              <FaChevronRight />
+            </Button>
+          )}
         </div>
       )}
 
-      {selected && (
-        <ProductDetails product={selected} onClose={() => setSelected(null)} />
+      {selectedIndex !== null && (
+        <ProductDetails
+          product={
+            {
+              id: products[selectedIndex].id,
+              name: products[selectedIndex].name,
+              articleNumber: products[selectedIndex].code,
+              purchasePrice: products[selectedIndex].purchasePrice,
+              salePrice: products[selectedIndex].price,
+              remains: products[selectedIndex].quantity,
+              minStock: products[selectedIndex].minStock,
+              category: products[selectedIndex].category,
+            } as IProduct
+          }
+          onClose={() => setSelectedIndex(null)}
+          onPrev={
+            selectedIndex > 0 ? () => setSelectedIndex(i => i! - 1) : undefined
+          }
+          onNext={
+            selectedIndex < products.length - 1
+              ? () => setSelectedIndex(i => i! + 1)
+              : undefined
+          }
+          onFirst={() => setSelectedIndex(0)}
+          onLast={() => setSelectedIndex(products.length - 1)}
+        />
       )}
       {isCreating && (
         <Modal isOpen={isCreating} onClose={() => setIsCreating(false)}>

--- a/dashboard-ui/app/components/ui/Modal/Modal.tsx
+++ b/dashboard-ui/app/components/ui/Modal/Modal.tsx
@@ -5,9 +5,11 @@ interface Props {
   isOpen: boolean
   onClose: () => void
   children: React.ReactNode
+  className?: string
+  ariaLabelledby?: string
 }
 
-const Modal = ({ isOpen, onClose, children }: Props) => {
+const Modal = ({ isOpen, onClose, children, className, ariaLabelledby }: Props) => {
   const ref = useRef<HTMLDivElement>(null)
   const previousFocus = useRef<HTMLElement | null>(null)
 
@@ -58,7 +60,7 @@ const Modal = ({ isOpen, onClose, children }: Props) => {
     <AnimatePresence>
       {isOpen && (
         <motion.div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
           onClick={handleClick}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -66,12 +68,13 @@ const Modal = ({ isOpen, onClose, children }: Props) => {
         >
           <motion.div
             ref={ref}
-            className="bg-white rounded p-4 max-w-lg w-full"
+            className={`bg-white rounded p-4 max-w-lg w-full ${className ?? ''}`}
             initial={{ scale: 0.9, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             exit={{ scale: 0.9, opacity: 0 }}
             role="dialog"
             aria-modal="true"
+            aria-labelledby={ariaLabelledby}
           >
             {children}
           </motion.div>


### PR DESCRIPTION
## Summary
- show product statistics in centered modal with focus trap and scroll lock
- add keyboard and arrow-button navigation between products
- replace pagination text buttons with circular arrow icons

## Testing
- `yarn lint`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68a30921e6988329ac715a16a19796c6