### PR TITLE
feat: allow editing minimum stock in inventory

### DIFF
--- a/dashboard-ui/app/components/products/ProductDetails.test.tsx
+++ b/dashboard-ui/app/components/products/ProductDetails.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { vi } from 'vitest'
+import ProductDetails, { validateMinStock } from './ProductDetails'
+import { mockProducts } from '@/tests/mocks/handlers'
+import { calculateInventoryStats } from '@/utils/inventoryStats'
+
+const renderWithClient = (ui: React.ReactNode, client: QueryClient) =>
+  render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+
+describe('ProductDetails minStock', () => {
+  beforeEach(() => {
+    // @ts-ignore
+    window.alert = vi.fn()
+  })
+
+  it('validateMinStock works correctly', () => {
+    expect(validateMinStock('-1')).toBe('Введите целое число ≥ 0')
+    expect(validateMinStock('abc')).toBe('Введите целое число ≥ 0')
+    expect(validateMinStock('2.5')).toBe('Введите целое число ≥ 0')
+    expect(validateMinStock('0')).toBeNull()
+    expect(validateMinStock('100000')).toBeNull()
+  })
+
+  it('activates low stock after saving', async () => {
+    mockProducts[0].minStock = 3
+    mockProducts[1].minStock = 0
+    const client = new QueryClient()
+    const items = mockProducts.map(p => ({
+      id: p.id,
+      name: p.name,
+      code: p.articleNumber,
+      quantity: p.remains,
+      price: p.salePrice,
+      purchasePrice: p.purchasePrice,
+      minStock: p.minStock,
+    }))
+    client.setQueryData(['inventory', {}], {
+      items,
+      total: items.length,
+      page: 1,
+      pageSize: 10,
+      stats: calculateInventoryStats(items),
+    })
+    client.setQueryData(['warehouse'], [...mockProducts])
+    renderWithClient(
+      <ProductDetails product={mockProducts[1]} onClose={() => {}} />,
+      client
+    )
+    const input = await screen.findByLabelText('Минимальный остаток')
+    await waitFor(() => expect(input).toHaveValue(0))
+    fireEvent.change(input, { target: { value: '3' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Сохранить' }))
+    await waitFor(() => {
+      const inv = client.getQueriesData({ queryKey: ['inventory'] })[0][1]
+      expect(inv.stats.lowStock).toBe(1)
+    })
+  })
+
+  it('removes low stock after saving', async () => {
+    mockProducts[0].minStock = 5
+    mockProducts[1].minStock = 3
+    const client = new QueryClient()
+    const items = mockProducts.map(p => ({
+      id: p.id,
+      name: p.name,
+      code: p.articleNumber,
+      quantity: p.remains,
+      price: p.salePrice,
+      purchasePrice: p.purchasePrice,
+      minStock: p.minStock,
+    }))
+    client.setQueryData(['inventory', {}], {
+      items,
+      total: items.length,
+      page: 1,
+      pageSize: 10,
+      stats: calculateInventoryStats(items),
+    })
+    client.setQueryData(['warehouse'], [...mockProducts])
+    renderWithClient(
+      <ProductDetails product={mockProducts[0]} onClose={() => {}} />,
+      client
+    )
+    const input = await screen.findByLabelText('Минимальный остаток')
+    await waitFor(() => expect(input).toHaveValue(5))
+    fireEvent.change(input, { target: { value: '3' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Сохранить' }))
+    await waitFor(() => {
+      const inv = client.getQueriesData({ queryKey: ['inventory'] })[0][1]
+      expect(inv.stats.lowStock).toBe(1)
+    })
+  })
+})

--- a/dashboard-ui/tests/mocks/handlers.ts
+++ b/dashboard-ui/tests/mocks/handlers.ts
@@ -45,6 +45,17 @@ export const handlers = [
   http.get('http://localhost:4000/api/products', () => {
     return HttpResponse.json(mockProducts)
   }),
+  http.get('http://localhost:4000/api/products/:id', ({ params }) => {
+    const product = mockProducts.find(p => p.id === Number(params.id))
+    return HttpResponse.json(product)
+  }),
+  http.put('http://localhost:4000/api/products/:id', async ({ params, request }) => {
+    const id = Number(params.id)
+    const body = await request.json()
+    const product = mockProducts.find(p => p.id === id)
+    if (product) Object.assign(product, body)
+    return HttpResponse.json(product)
+  }),
   http.delete('http://localhost:4000/api/products/:id', () => {
     return HttpResponse.json({})
   }),

--- a/server/src/product/dto/product.dto.ts
+++ b/server/src/product/dto/product.dto.ts
@@ -29,7 +29,10 @@ export class CreateProductDto {
         @IsNumber({ maxDecimalPlaces: 2 })
         salePrice: number
 
-	@IsNumber() @Min(0) @IsOptional() remains?: number
+        @IsNumber() @Min(0) @IsOptional() remains?: number
+
+        @IsNumber() @Min(0) @IsOptional()
+        minStock?: number
 
 	@IsOptional()
 	@IsNumber()

--- a/server/src/product/product.model.ts
+++ b/server/src/product/product.model.ts
@@ -40,8 +40,11 @@ export class ProductModel extends Model {
         @Column({ field: 'sale_price', type: DataType.DECIMAL(12, 2) })
         salePrice: number // Продажная цена
 
-	@Column(DataType.INTEGER)
-	remains: number // Остаток
+        @Column(DataType.INTEGER)
+        remains: number // Остаток
+
+        @Column({ field: 'min_stock', type: DataType.INTEGER, allowNull: true })
+        minStock?: number // Минимальный остаток для уведомлений
 }
 
 /*

--- a/server/src/product/product.service.ts
+++ b/server/src/product/product.service.ts
@@ -55,14 +55,15 @@ export class ProductService {
 		}
 
 		// 3) Создаем продукт
-		return this.productRepo.create({
-			name: dto.name,
-			categoryId,
-			articleNumber: dto.articleNumber,
-			purchasePrice: dto.purchasePrice,
-			salePrice: dto.salePrice,
-			remains: dto.remains ?? 0
-		})
+                return this.productRepo.create({
+                        name: dto.name,
+                        categoryId,
+                        articleNumber: dto.articleNumber,
+                        purchasePrice: dto.purchasePrice,
+                        salePrice: dto.salePrice,
+                        remains: dto.remains ?? 0,
+                        minStock: dto.minStock ?? 0,
+                })
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- add modal input to manage minimum stock and sync low-stock indicator
- support minStock persistence on server and mock handlers
- cover minStock validation and low-stock updates with tests

## Testing
- `cd dashboard-ui && yarn lint`
- `cd dashboard-ui && yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68a30f81b0f8832991490d539ae07aec