### PR TITLE
Ensure inventory stats sync after minStock edits

### DIFF
--- a/dashboard-ui/app/components/products/ProductDetails.test.tsx
+++ b/dashboard-ui/app/components/products/ProductDetails.test.tsx
@@ -19,7 +19,7 @@ describe('ProductDetails minStock', () => {
   it('handles allowed and disallowed input values', async () => {
     const client = new QueryClient()
     renderWithClient(
-      <ProductDetails product={mockProducts[0]} onClose={() => {}} />,
+      <ProductDetails product={{ ...mockProducts[0] }} onClose={() => {}} />,
       client
     )
     const input = await screen.findByLabelText('Минимальный остаток')
@@ -53,7 +53,7 @@ describe('ProductDetails minStock', () => {
       .spyOn(ProductService, 'update')
       .mockResolvedValue({ ...mockProducts[0], minStock: 3 })
     renderWithClient(
-      <ProductDetails product={mockProducts[0]} onClose={() => {}} />,
+      <ProductDetails product={{ ...mockProducts[0] }} onClose={() => {}} />,
       client
     )
     const input = await screen.findByLabelText('Минимальный остаток')
@@ -68,7 +68,7 @@ describe('ProductDetails minStock', () => {
     const client = new QueryClient()
     const updateSpy = vi.spyOn(ProductService, 'update')
     renderWithClient(
-      <ProductDetails product={mockProducts[0]} onClose={() => {}} />,
+      <ProductDetails product={{ ...mockProducts[0] }} onClose={() => {}} />,
       client
     )
     const input = await screen.findByLabelText('Минимальный остаток')
@@ -81,16 +81,111 @@ describe('ProductDetails minStock', () => {
   it('syncs value when product changes', async () => {
     const client = new QueryClient()
     const { rerender } = renderWithClient(
-      <ProductDetails product={mockProducts[0]} onClose={() => {}} />,
+      <ProductDetails product={{ ...mockProducts[0] }} onClose={() => {}} />,
       client
     )
     await screen.findByLabelText('Минимальный остаток')
     rerender(
       <QueryClientProvider client={client}>
-        <ProductDetails product={mockProducts[1]} onClose={() => {}} />
+        <ProductDetails product={{ ...mockProducts[1] }} onClose={() => {}} />
       </QueryClientProvider>
     )
     const input = await screen.findByLabelText('Минимальный остаток')
     expect(input).toHaveValue(mockProducts[1].minStock)
+  })
+
+  it('updates list and KPI counters optimistically', async () => {
+    const client = new QueryClient()
+    client.setQueryData(['products', { page: 1 }], {
+      items: [
+        {
+          id: 1,
+          name: 'Product 1',
+          code: 'A1',
+          quantity: 5,
+          price: 20,
+          purchasePrice: 10,
+          minStock: 5,
+        },
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 10,
+      stats: { outOfStock: 0, lowStock: 1 },
+    })
+    client.setQueryData(['inventory-snapshot'], { outOfStock: 0, lowStock: 1 })
+    vi.spyOn(ProductService, 'update').mockImplementation(async () => {
+      mockProducts[0].minStock = 3
+      return { ...mockProducts[0] }
+    })
+
+    renderWithClient(
+      <ProductDetails product={{ ...mockProducts[0] }} onClose={() => {}} />,
+      client,
+    )
+    const input = await screen.findByLabelText('Минимальный остаток')
+    fireEvent.change(input, { target: { value: '3' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Сохранить' }))
+    await waitFor(() => expect(ProductService.update).toHaveBeenCalled())
+
+    expect(client.getQueryData(['product', 1])).toMatchObject({
+      minStock: 3,
+    })
+    expect(client.getQueryData(['products', { page: 1 }])).toMatchObject({
+      items: [expect.objectContaining({ minStock: 3 })],
+      stats: { outOfStock: 0, lowStock: 0 },
+    })
+    expect(client.getQueryData(['inventory-snapshot'])).toMatchObject({
+      lowStock: 0,
+    })
+  })
+
+  it('removes product from low filter when threshold decreases', async () => {
+    const client = new QueryClient()
+    client.setQueryData(
+      ['products', { page: 1, filters: { stock: 'low' } }],
+      {
+        items: [
+          {
+            id: 2,
+            name: 'Second',
+            code: 'B2',
+            quantity: 2,
+            price: 15,
+            purchasePrice: 8,
+            minStock: 3,
+          },
+        ],
+        total: 1,
+        page: 1,
+        pageSize: 10,
+        stats: { outOfStock: 0, lowStock: 1 },
+      },
+    )
+    client.setQueryData(['inventory-snapshot'], { outOfStock: 0, lowStock: 1 })
+    vi.spyOn(ProductService, 'update').mockImplementation(async () => {
+      mockProducts[1].minStock = 1
+      return { ...mockProducts[1] }
+    })
+
+    renderWithClient(
+      <ProductDetails product={{ ...mockProducts[1] }} onClose={() => {}} />,
+      client,
+    )
+    const input = await screen.findByLabelText('Минимальный остаток')
+    fireEvent.change(input, { target: { value: '1' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Сохранить' }))
+    await waitFor(() => expect(ProductService.update).toHaveBeenCalled())
+
+    expect(
+      client.getQueryData(['products', { page: 1, filters: { stock: 'low' } }]),
+    ).toMatchObject({
+      items: [],
+      total: 0,
+      stats: { lowStock: 0 },
+    })
+    expect(client.getQueryData(['inventory-snapshot'])).toMatchObject({
+      lowStock: 0,
+    })
   })
 })

--- a/dashboard-ui/app/components/ui/Field/Field.tsx
+++ b/dashboard-ui/app/components/ui/Field/Field.tsx
@@ -1,25 +1,30 @@
 import { forwardRef } from 'react'
 import cn from 'classnames'
 
-import styles from "./Field.module.scss"
-import {IField} from "@/ui/Field/field.interface";
+import styles from './Field.module.scss'
+import { IField } from '@/ui/Field/field.interface'
 
 
 const Field = forwardRef<HTMLInputElement, IField>(
-    ({ error, label, type = 'text', style, ...rest }, ref) => {
-        return (
-            <div className={styles.field} style={style}>
-                {label && <label className={styles.label}>{label}</label>}
-                <input
-                    className={cn(styles.input, { [styles.inputError]: error })}
-                    ref={ref}
-                    type={type}
-                    {...rest}
-                />
-                {error && <div className={styles.error}>{error.message}</div>}
-            </div>
-        )
-    }
+  ({ error, label, type = 'text', style, id, ...rest }, ref) => {
+    return (
+      <div className={styles.field} style={style}>
+        {label && (
+          <label htmlFor={id} className={styles.label}>
+            {label}
+          </label>
+        )}
+        <input
+          id={id}
+          className={cn(styles.input, { [styles.inputError]: error })}
+          ref={ref}
+          type={type}
+          {...rest}
+        />
+        {error && <div className={styles.error}>{error.message}</div>}
+      </div>
+    )
+  },
 )
 
 

--- a/dashboard-ui/app/hooks/useInventoryList.ts
+++ b/dashboard-ui/app/hooks/useInventoryList.ts
@@ -22,7 +22,7 @@ export interface InventoryListParams {
 
 export const useInventoryList = (params: InventoryListParams) => {
   return useQuery<InventoryList, Error>({
-    queryKey: ['inventory', params],
+    queryKey: ['products', params],
     queryFn: ({ signal }) =>
       ProductService.getAll(
         {


### PR DESCRIPTION
## Summary
- sync product list and KPI snapshot after minStock updates with optimistic cache updates
- standardize minStock input styling and accessibility
- add regression tests for inventory counters

## Testing
- `yarn test`
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68a31ab6ac0c8329bb9e8584c4c44c8f