### PR TITLE
feat: inventory editing and stable table layout

### DIFF
--- a/dashboard-ui/app/components/products/EditProductForm.tsx
+++ b/dashboard-ui/app/components/products/EditProductForm.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { useForm } from 'react-hook-form'
+import Field from '@/ui/Field/Field'
+import Button from '@/ui/Button/Button'
+
+interface Props {
+  product: {
+    purchasePrice: number
+    salePrice: number
+    remains: number
+  }
+  onSave: (data: FormData) => Promise<void> | void
+  onCancel: () => void
+}
+
+interface FormData {
+  purchasePrice: number
+  salePrice: number
+  remains: number
+}
+
+const EditProductForm = ({ product, onSave, onCancel }: Props) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid, isSubmitting },
+  } = useForm<FormData>({
+    mode: 'onChange',
+    defaultValues: {
+      purchasePrice: product.purchasePrice,
+      salePrice: product.salePrice,
+      remains: product.remains,
+    },
+  })
+
+  const onSubmit = async (data: FormData) => {
+    await onSave(data)
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <Field
+        type="text"
+        inputMode="decimal"
+        step="0.01"
+        min="0"
+        {...register('purchasePrice', {
+          setValueAs: v => {
+            const normalized = String(v).replace(',', '.')
+            const num = parseFloat(normalized)
+            return isNaN(num) ? undefined : num
+          },
+          validate: {
+            nonNegative: v =>
+              v === undefined || v >= 0 || 'Цена не может быть отрицательной',
+          },
+        })}
+        label="Закупочная цена"
+        error={errors.purchasePrice}
+      />
+      <Field
+        type="text"
+        inputMode="decimal"
+        step="0.01"
+        min="0"
+        {...register('salePrice', {
+          setValueAs: v => {
+            const normalized = String(v).replace(',', '.')
+            const num = parseFloat(normalized)
+            return isNaN(num) ? undefined : num
+          },
+          validate: {
+            nonNegative: v =>
+              v === undefined || v >= 0 || 'Цена не может быть отрицательной',
+          },
+        })}
+        label="Цена продажи"
+        error={errors.salePrice}
+      />
+      <Field
+        type="number"
+        min="0"
+        {...register('remains', {
+          valueAsNumber: true,
+          min: { value: 0, message: 'Значение не может быть отрицательным' },
+        })}
+        onWheel={e => e.currentTarget.blur()}
+        label="Остаток"
+        error={errors.remains}
+      />
+      <div className="flex justify-end space-x-2">
+        <Button
+          type="submit"
+          className="bg-primary-500 text-white px-4 py-1"
+          disabled={!isValid || isSubmitting}
+        >
+          Сохранить
+        </Button>
+        <Button
+          type="button"
+          onClick={onCancel}
+          className="bg-secondary-500 text-white px-4 py-1"
+          disabled={isSubmitting}
+        >
+          Отмена
+        </Button>
+      </div>
+    </form>
+  )
+}
+
+export default EditProductForm
+

--- a/dashboard-ui/app/components/products/ProductsTable.css
+++ b/dashboard-ui/app/components/products/ProductsTable.css
@@ -7,6 +7,39 @@
   height: 44px;
 }
 
+.inventory-table table {
+  table-layout: fixed;
+  width: 100%;
+}
+
+.inventory-table .col-name {
+  width: 240px;
+}
+
+.inventory-table .col-category {
+  width: 160px;
+}
+
+.inventory-table .col-code {
+  width: 120px;
+}
+
+.inventory-table .col-quantity {
+  width: 100px;
+}
+
+.inventory-table .col-sale {
+  width: 120px;
+}
+
+.inventory-table .col-purchase {
+  width: 140px;
+}
+
+.inventory-table .col-actions {
+  width: 140px;
+}
+
 .inventory-table.loading::after {
   content: '';
   position: absolute;


### PR DESCRIPTION
## Summary
- keep inventory table columns fixed and truncate long values
- replace stats action with edit modal for inventory items
- recalc stock KPIs after inline edits

## Testing
- `cd dashboard-ui && yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a324f74a7c8329855a8149dc9bed83