### PR TITLE
feat: sync low stock state on inventory edit

### DIFF
--- a/dashboard-ui/app/components/products/ProductDetails.tsx
+++ b/dashboard-ui/app/components/products/ProductDetails.tsx
@@ -8,7 +8,7 @@ import { IProduct } from '@/shared/interfaces/product.interface'
 import { formatCurrency } from '@/utils/formatCurrency'
 import { toast } from '@/utils/toast'
 import Field from '@/ui/Field/Field'
-import { DEFAULT_LOW_STOCK } from '@/utils/inventoryStats'
+import { isLowStock } from '@/utils/inventoryStats'
 import { InventoryList } from '@/shared/interfaces/inventory.interface'
 
 interface Props {
@@ -84,8 +84,8 @@ const ProductDetails: FC<Props> = ({
 
       const wasLow =
         product.remains > 0 &&
-        product.remains <= (product.minStock ?? DEFAULT_LOW_STOCK)
-      const isLow = product.remains > 0 && product.remains <= n
+        isLowStock(product.remains, product.minStock)
+      const isLow = product.remains > 0 && isLowStock(product.remains, n)
       const deltaLow = (isLow ? 1 : 0) - (wasLow ? 1 : 0)
 
       // update individual product cache
@@ -104,10 +104,9 @@ const ProductDetails: FC<Props> = ({
         const filter = (key[1] as any)?.filters?.stock
         const item = old.items[index]
         const wasLowItem =
-          item.quantity > 0 &&
-          item.quantity <= (item.minStock ?? DEFAULT_LOW_STOCK)
+          item.quantity > 0 && isLowStock(item.quantity, item.minStock)
         const updated = { ...item, minStock: n }
-        const isLowItem = item.quantity > 0 && item.quantity <= n
+        const isLowItem = item.quantity > 0 && isLowStock(item.quantity, n)
         let items = [...old.items]
         let total = old.total
         let lowStock = old.stats.lowStock

--- a/dashboard-ui/app/components/products/ProductsTable.test.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.test.tsx
@@ -1,10 +1,11 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { vi } from 'vitest'
 import ProductsTable from './ProductsTable'
 import { server } from '@/tests/mocks/server'
+import { mockProducts } from '@/tests/mocks/handlers'
 
 const replace = vi.fn()
 vi.mock('next/navigation', () => ({
@@ -12,16 +13,45 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(),
 }))
 
+const defaultProducts = [
+  {
+    id: 1,
+    name: 'Product 1',
+    articleNumber: 'A1',
+    purchasePrice: 10,
+    salePrice: 20,
+    remains: 5,
+    minStock: 5,
+  },
+  {
+    id: 2,
+    name: 'Second',
+    articleNumber: 'B2',
+    purchasePrice: 8,
+    salePrice: 15,
+    remains: 2,
+    minStock: 3,
+  },
+]
+
+const setProducts = (products = defaultProducts) => {
+  mockProducts.splice(0, mockProducts.length, ...products.map(p => ({ ...p })))
+}
+
 const renderTable = () => {
   const queryClient = new QueryClient()
   render(
     <QueryClientProvider client={queryClient}>
       <ProductsTable />
-    </QueryClientProvider>
+    </QueryClientProvider>,
   )
 }
 
 describe('ProductsTable', () => {
+  beforeEach(() => {
+    setProducts()
+  })
+
   it('renders products from API (happy path)', async () => {
     renderTable()
     expect(await screen.findByText('Product 1')).toBeInTheDocument()
@@ -94,5 +124,133 @@ describe('ProductsTable', () => {
 
     await waitFor(() => expect(screen.getByText('Новый')).toBeInTheDocument())
     expect(lowBlock?.querySelector('div.text-xl')?.textContent).toBe('1')
+  })
+
+  it('marks product low when minStock increases', async () => {
+    setProducts([
+      {
+        id: 1,
+        name: 'Product 1',
+        articleNumber: 'A1',
+        purchasePrice: 10,
+        salePrice: 20,
+        remains: 5,
+        minStock: 2,
+      },
+      {
+        id: 2,
+        name: 'Second',
+        articleNumber: 'B2',
+        purchasePrice: 8,
+        salePrice: 15,
+        remains: 2,
+        minStock: 3,
+      },
+    ])
+    renderTable()
+    await screen.findByText('Product 1')
+    const lowBlock = screen.getByText('Мало на складе').parentElement
+    expect(lowBlock?.querySelector('div.text-xl')?.textContent).toBe('1')
+
+    const row = screen.getByText('Product 1').closest('tr')!
+    expect(within(row).queryByText('мало')).toBeNull()
+
+    const editBtn = within(row).getByTitle('Редактировать')
+    await userEvent.click(editBtn)
+    const minStockInput = await screen.findByLabelText('Минимальный остаток')
+    await userEvent.clear(minStockInput)
+    await userEvent.type(minStockInput, '6')
+    await userEvent.click(screen.getByRole('button', { name: 'Сохранить' }))
+
+    await waitFor(() => {
+      const updatedRow = screen.getByText('Product 1').closest('tr')!
+      expect(within(updatedRow).getByText('мало')).toBeInTheDocument()
+    })
+    expect(lowBlock?.querySelector('div.text-xl')?.textContent).toBe('2')
+  })
+
+  it('removes low flag when minStock decreases', async () => {
+    setProducts([
+      {
+        id: 1,
+        name: 'Product 1',
+        articleNumber: 'A1',
+        purchasePrice: 10,
+        salePrice: 20,
+        remains: 5,
+        minStock: 6,
+      },
+      {
+        id: 2,
+        name: 'Second',
+        articleNumber: 'B2',
+        purchasePrice: 8,
+        salePrice: 15,
+        remains: 2,
+        minStock: 1,
+      },
+    ])
+    renderTable()
+    await screen.findByText('Product 1')
+    const lowBlock = screen.getByText('Мало на складе').parentElement
+    expect(lowBlock?.querySelector('div.text-xl')?.textContent).toBe('1')
+    const row = screen.getByText('Product 1').closest('tr')!
+    expect(within(row).getByText('мало')).toBeInTheDocument()
+
+    const editBtn = within(row).getByTitle('Редактировать')
+    await userEvent.click(editBtn)
+    const minStockInput = await screen.findByLabelText('Минимальный остаток')
+    await userEvent.clear(minStockInput)
+    await userEvent.type(minStockInput, '2')
+    await userEvent.click(screen.getByRole('button', { name: 'Сохранить' }))
+
+    await waitFor(() => {
+      const updatedRow = screen.getByText('Product 1').closest('tr')!
+      expect(within(updatedRow).queryByText('мало')).toBeNull()
+    })
+    expect(lowBlock?.querySelector('div.text-xl')?.textContent).toBe('0')
+  })
+
+  it('updates list with active low filter', async () => {
+    setProducts([
+      {
+        id: 1,
+        name: 'Product 1',
+        articleNumber: 'A1',
+        purchasePrice: 10,
+        salePrice: 20,
+        remains: 5,
+        minStock: 6,
+      },
+      {
+        id: 2,
+        name: 'Second',
+        articleNumber: 'B2',
+        purchasePrice: 8,
+        salePrice: 15,
+        remains: 2,
+        minStock: 1,
+      },
+    ])
+    renderTable()
+    await screen.findByText('Product 1')
+    const lowBlock = screen.getByText('Мало на складе').parentElement!
+    await userEvent.click(lowBlock)
+    await waitFor(() => {
+      expect(screen.queryByText('Second')).not.toBeInTheDocument()
+    })
+
+    const row = screen.getByText('Product 1').closest('tr')!
+    const editBtn = within(row).getByTitle('Редактировать')
+    await userEvent.click(editBtn)
+    const minStockInput = await screen.findByLabelText('Минимальный остаток')
+    await userEvent.clear(minStockInput)
+    await userEvent.type(minStockInput, '2')
+    await userEvent.click(screen.getByRole('button', { name: 'Сохранить' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Product 1')).not.toBeInTheDocument()
+    })
+    expect(lowBlock.querySelector('div.text-xl')?.textContent).toBe('0')
   })
 })

--- a/dashboard-ui/app/hooks/useInventoryList.ts
+++ b/dashboard-ui/app/hooks/useInventoryList.ts
@@ -8,7 +8,8 @@ import {
 } from '@/shared/interfaces/inventory.interface'
 import {
   calculateInventoryStats,
-  DEFAULT_LOW_STOCK,
+  DEFAULT_MIN_STOCK,
+  isLowStock,
 } from '@/utils/inventoryStats'
 
 export interface InventoryListParams {
@@ -59,15 +60,13 @@ export const useInventoryList = (params: InventoryListParams) => {
           filtered = filtered.filter(it => it.code.toLowerCase().includes(q))
         }
 
-        const stats = calculateInventoryStats(filtered, DEFAULT_LOW_STOCK)
+        const stats = calculateInventoryStats(filtered, DEFAULT_MIN_STOCK)
 
         if (params.filters?.stock === 'out') {
           filtered = filtered.filter(it => it.quantity === 0)
         } else if (params.filters?.stock === 'low') {
           filtered = filtered.filter(
-            it =>
-              it.quantity > 0 &&
-              it.quantity <= (it.minStock ?? DEFAULT_LOW_STOCK),
+            it => it.quantity > 0 && isLowStock(it.quantity, it.minStock),
           )
         }
 

--- a/dashboard-ui/app/utils/inventoryStats.ts
+++ b/dashboard-ui/app/utils/inventoryStats.ts
@@ -1,6 +1,14 @@
 import { IInventory } from '@/shared/interfaces/inventory.interface'
 
-export const DEFAULT_LOW_STOCK = 2
+export const DEFAULT_MIN_STOCK = 2
+
+export const isLowStock = (
+  remains: number,
+  minStock: number | undefined | null,
+  fallback = DEFAULT_MIN_STOCK,
+) =>
+  remains <=
+  (Number.isFinite(minStock as number) ? (minStock as number) : fallback)
 
 export interface InventoryStats {
   outOfStock: number
@@ -9,11 +17,11 @@ export interface InventoryStats {
 
 export const calculateInventoryStats = (
   items: Pick<IInventory, 'quantity' | 'minStock'>[],
-  defaultLowStock = DEFAULT_LOW_STOCK,
+  fallback = DEFAULT_MIN_STOCK,
 ): InventoryStats => {
   const outOfStock = items.filter(it => it.quantity === 0).length
   const lowStock = items.filter(
-    it => it.quantity > 0 && it.quantity <= (it.minStock ?? defaultLowStock),
+    it => it.quantity > 0 && isLowStock(it.quantity, it.minStock, fallback),
   ).length
   return { outOfStock, lowStock }
 }


### PR DESCRIPTION
## Summary
- add shared isLowStock helper and integrate across inventory
- optimistic cache updates for product edit keep table and KPI in sync
- show low-stock badge and update stats instantly when editing

## Testing
- `cd dashboard-ui && yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a333997f048329a716d19b87011964