### PR TITLE
Align warehouse stock column and show low stock badge

### DIFF
--- a/dashboard-ui/app/components/products/ProductsTable.css
+++ b/dashboard-ui/app/components/products/ProductsTable.css
@@ -25,7 +25,7 @@
 }
 
 .inventory-table .col-quantity {
-  width: 100px;
+  min-width: 100px;
 }
 
 .inventory-table .col-sale {

--- a/dashboard-ui/app/components/products/ProductsTable.test.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.test.tsx
@@ -153,7 +153,7 @@ describe('ProductsTable', () => {
     expect(lowBlock?.querySelector('div.text-xl')?.textContent).toBe('1')
 
     const row = screen.getByText('Product 1').closest('tr')!
-    expect(within(row).queryByText('мало')).toBeNull()
+    expect(within(row).queryByText('(мало)')).toBeNull()
 
     const editBtn = within(row).getByTitle('Редактировать')
     await userEvent.click(editBtn)
@@ -164,7 +164,7 @@ describe('ProductsTable', () => {
 
     await waitFor(() => {
       const updatedRow = screen.getByText('Product 1').closest('tr')!
-      expect(within(updatedRow).getByText('мало')).toBeInTheDocument()
+      expect(within(updatedRow).getByText('(мало)')).toBeInTheDocument()
     })
     expect(lowBlock?.querySelector('div.text-xl')?.textContent).toBe('2')
   })
@@ -195,7 +195,7 @@ describe('ProductsTable', () => {
     const lowBlock = screen.getByText('Мало на складе').parentElement
     expect(lowBlock?.querySelector('div.text-xl')?.textContent).toBe('1')
     const row = screen.getByText('Product 1').closest('tr')!
-    expect(within(row).getByText('мало')).toBeInTheDocument()
+    expect(within(row).getByText('(мало)')).toBeInTheDocument()
 
     const editBtn = within(row).getByTitle('Редактировать')
     await userEvent.click(editBtn)
@@ -206,7 +206,7 @@ describe('ProductsTable', () => {
 
     await waitFor(() => {
       const updatedRow = screen.getByText('Product 1').closest('tr')!
-      expect(within(updatedRow).queryByText('мало')).toBeNull()
+      expect(within(updatedRow).queryByText('(мало)')).toBeNull()
     })
     expect(lowBlock?.querySelector('div.text-xl')?.textContent).toBe('0')
   })

--- a/dashboard-ui/app/components/products/ProductsTable.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.tsx
@@ -274,7 +274,9 @@ const ProductsTable = () => {
                     <div className="h-4 bg-neutral-200 rounded w-1/3" />
                   </td>
                   <td className="p-2 col-quantity">
-                    <div className="h-4 bg-neutral-200 rounded w-1/4 ml-auto" />
+                    <div className="flex items-center">
+                      <div className="h-4 bg-neutral-200 rounded w-1/4 ml-auto min-w-[3rem]" />
+                    </div>
                   </td>
                   <td className="p-2 col-sale">
                     <div className="h-4 bg-neutral-200 rounded w-1/4 ml-auto" />
@@ -310,13 +312,15 @@ const ProductsTable = () => {
                     <span className="block truncate">{prod.code}</span>
                   </td>
                   <td className="p-2 col-quantity">
-                    {prod.quantity}
-                    {prod.quantity > 0 &&
-                      isLowStock(prod.quantity, prod.minStock) && (
-                        <span className="ml-2 bg-warning text-white text-xs px-2 py-0.5 rounded">
-                          мало
-                        </span>
-                      )}
+                    <div className="flex items-center">
+                      <span className="text-right min-w-[3rem]">{prod.quantity}</span>
+                      {prod.quantity > 0 &&
+                        isLowStock(prod.quantity, prod.minStock) && (
+                          <span className="ml-2 text-xs text-red-600 font-medium">
+                            (мало)
+                          </span>
+                        )}
+                    </div>
                   </td>
                   <td className="p-2 col-sale">{formatCurrency(prod.price)}</td>
                   <td className="p-2 col-purchase">{formatCurrency(prod.purchasePrice)}</td>


### PR DESCRIPTION
## Summary
- align stock numbers in warehouse table and show `(мало)` badge when below min
- allow stock column to expand with content instead of fixed width
- update tests for new low stock badge

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68a33b09e53483299794d2618b3393f1