### PR TITLE
feat: show low stock badge

### DIFF
--- a/dashboard-ui/app/components/products/ProductsTable.test.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.test.tsx
@@ -13,6 +13,11 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(),
 }))
 
+beforeAll(() => {
+  // Stub alert used in toast notifications to avoid jsdom errors
+  window.alert = vi.fn()
+})
+
 const defaultProducts = [
   {
     id: 1,
@@ -153,7 +158,7 @@ describe('ProductsTable', () => {
     expect(lowBlock?.querySelector('div.text-xl')?.textContent).toBe('1')
 
     const row = screen.getByText('Product 1').closest('tr')!
-    expect(within(row).queryByText('(мало)')).toBeNull()
+    expect(within(row).queryByText('Мало')).toBeNull()
 
     const editBtn = within(row).getByTitle('Редактировать')
     await userEvent.click(editBtn)
@@ -164,7 +169,7 @@ describe('ProductsTable', () => {
 
     await waitFor(() => {
       const updatedRow = screen.getByText('Product 1').closest('tr')!
-      expect(within(updatedRow).getByText('(мало)')).toBeInTheDocument()
+      expect(within(updatedRow).getByText('Мало')).toBeInTheDocument()
     })
     expect(lowBlock?.querySelector('div.text-xl')?.textContent).toBe('2')
   })
@@ -195,7 +200,7 @@ describe('ProductsTable', () => {
     const lowBlock = screen.getByText('Мало на складе').parentElement
     expect(lowBlock?.querySelector('div.text-xl')?.textContent).toBe('1')
     const row = screen.getByText('Product 1').closest('tr')!
-    expect(within(row).getByText('(мало)')).toBeInTheDocument()
+    expect(within(row).getByText('Мало')).toBeInTheDocument()
 
     const editBtn = within(row).getByTitle('Редактировать')
     await userEvent.click(editBtn)
@@ -206,7 +211,7 @@ describe('ProductsTable', () => {
 
     await waitFor(() => {
       const updatedRow = screen.getByText('Product 1').closest('tr')!
-      expect(within(updatedRow).queryByText('(мало)')).toBeNull()
+      expect(within(updatedRow).queryByText('Мало')).toBeNull()
     })
     expect(lowBlock?.querySelector('div.text-xl')?.textContent).toBe('0')
   })

--- a/dashboard-ui/app/components/products/ProductsTable.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.tsx
@@ -275,7 +275,7 @@ const ProductsTable = () => {
                   </td>
                   <td className="p-2 col-quantity">
                     <div className="flex items-center">
-                      <div className="h-4 bg-neutral-200 rounded w-1/4 ml-auto min-w-[3rem]" />
+                      <div className="h-4 bg-neutral-200 rounded ml-auto min-w-[3rem]" />
                     </div>
                   </td>
                   <td className="p-2 col-sale">
@@ -314,12 +314,11 @@ const ProductsTable = () => {
                   <td className="p-2 col-quantity">
                     <div className="flex items-center">
                       <span className="text-right min-w-[3rem]">{prod.quantity}</span>
-                      {prod.quantity > 0 &&
-                        isLowStock(prod.quantity, prod.minStock) && (
-                          <span className="ml-2 text-xs text-red-600 font-medium">
-                            (мало)
-                          </span>
-                        )}
+                      {isLowStock(prod.quantity, prod.minStock) && (
+                        <span className="ml-2 rounded-full bg-red-100 text-red-600 text-xs font-medium px-2 py-0.5">
+                          Мало
+                        </span>
+                      )}
                     </div>
                   </td>
                   <td className="p-2 col-sale">{formatCurrency(prod.price)}</td>


### PR DESCRIPTION
## Summary
- align stock numbers with `min-w` to prevent truncation
- display a rounded red "Мало" badge when stock is at or below minimum
- adjust tests to expect the new badge and stub `alert`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a33f6acb1c8329a8a9907d83dab4a4