### PR TITLE
feat: persist dashboard period

### DIFF
--- a/dashboard-ui/app/components/dashboard/DashboardControls.tsx
+++ b/dashboard-ui/app/components/dashboard/DashboardControls.tsx
@@ -1,15 +1,12 @@
 "use client";
 
 import React from "react";
+import { usePeriod, Period } from "@/store/period";
 
 interface Props {
-  period: Period;
-  onPeriodChange: (p: Period) => void;
   warehouse?: string;
   onWarehouseChange?: (w: string) => void;
 }
-
-export type Period = "day" | "week" | "month" | "year";
 
 const periodOptions: { value: Period; label: string }[] = [
   { value: "day", label: "День" },
@@ -18,19 +15,15 @@ const periodOptions: { value: Period; label: string }[] = [
   { value: "year", label: "Год" },
 ];
 
-const DashboardControls: React.FC<Props> = ({
-  period,
-  onPeriodChange,
-  warehouse,
-  onWarehouseChange,
-}) => {
+const DashboardControls: React.FC<Props> = ({ warehouse, onWarehouseChange }) => {
+  const { period, set } = usePeriod();
   return (
     <div className="inline-flex items-center gap-4">
       <select
         aria-label="Выбор периода"
         className="border border-neutral-300 rounded px-2 py-1 text-sm w-auto"
         value={period}
-        onChange={(e) => onPeriodChange(e.target.value as Period)}
+        onChange={(e) => set(e.target.value as Period)}
       >
         {periodOptions.map((o) => (
           <option key={o.value} value={o.value}>

--- a/dashboard-ui/app/components/dashboard/KpiCards.test.tsx
+++ b/dashboard-ui/app/components/dashboard/KpiCards.test.tsx
@@ -2,6 +2,12 @@ import { render, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { vi } from 'vitest'
 import KpiCards from './KpiCards'
+import { PeriodProvider } from '@/store/period'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}))
 
 vi.mock('@/services/analytics/analytics.service', () => ({
   AnalyticsService: {
@@ -15,7 +21,9 @@ const renderKpis = () => {
   const client = new QueryClient()
   render(
     <QueryClientProvider client={client}>
-      <KpiCards period="day" />
+      <PeriodProvider>
+        <KpiCards />
+      </PeriodProvider>
     </QueryClientProvider>
   )
 }

--- a/dashboard-ui/app/components/dashboard/KpiCards.tsx
+++ b/dashboard-ui/app/components/dashboard/KpiCards.tsx
@@ -4,19 +4,16 @@ import React from "react";
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import { AnalyticsService } from "@/services/analytics/analytics.service";
-import { Period } from "./DashboardControls";
 import { getPeriodRange } from "@/utils/buckets";
+import { usePeriod } from "@/store/period";
 
 const currency = new Intl.NumberFormat("ru-RU", {
   style: "currency",
   currency: "RUB",
 });
 
-interface Props {
-  period: Period;
-}
-
-const KpiCards: React.FC<Props> = ({ period }) => {
+const KpiCards: React.FC = () => {
+  const { period } = usePeriod();
   const { start, end } = getPeriodRange(period);
   const {
     data,
@@ -25,7 +22,7 @@ const KpiCards: React.FC<Props> = ({ period }) => {
     error,
     refetch,
   } = useQuery({
-    queryKey: ["kpi", start.toISOString(), end.toISOString()],
+    queryKey: ["kpi", period, start.toISOString(), end.toISOString()],
     queryFn: async () =>
       AnalyticsService.getKpis(
         start.toISOString().slice(0, 10),

--- a/dashboard-ui/app/components/dashboard/SalesChart.tsx
+++ b/dashboard-ui/app/components/dashboard/SalesChart.tsx
@@ -14,19 +14,16 @@ import {
   ReferenceLine,
 } from "recharts";
 import { AnalyticsService } from "@/services/analytics/analytics.service";
-import { Period } from "./DashboardControls";
 import { buildBuckets, getPeriodRange } from "@/utils/buckets";
-
-interface Props {
-  period: Period;
-}
+import { usePeriod } from "@/store/period";
 
 const metricOptions = [
   { value: "revenue", label: "Выручка" },
   { value: "sales", label: "Количество" },
 ] as const;
 
-const SalesChart: React.FC<Props> = ({ period }) => {
+const SalesChart: React.FC = () => {
+  const { period } = usePeriod();
   const [metric, setMetric] = useState<(typeof metricOptions)[number]["value"]>(
     "revenue"
   );
@@ -48,6 +45,7 @@ const SalesChart: React.FC<Props> = ({ period }) => {
     queryKey: [
       "sales-chart",
       metric,
+      period,
       formatDate(start),
       formatDate(end),
     ],

--- a/dashboard-ui/app/components/dashboard/TopProducts.test.tsx
+++ b/dashboard-ui/app/components/dashboard/TopProducts.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { vi } from 'vitest'
 import TopProducts from './TopProducts'
+import { PeriodProvider } from '@/store/period'
 
 vi.mock('@/services/analytics/analytics.service', () => ({
   AnalyticsService: {
@@ -18,13 +19,18 @@ vi.mock('@/services/analytics/analytics.service', () => ({
   },
 }))
 
-vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}))
 
 const renderWidget = () => {
   const client = new QueryClient()
   render(
     <QueryClientProvider client={client}>
-      <TopProducts period="day" />
+      <PeriodProvider>
+        <TopProducts />
+      </PeriodProvider>
     </QueryClientProvider>
   )
 }

--- a/dashboard-ui/app/components/dashboard/TopProducts.tsx
+++ b/dashboard-ui/app/components/dashboard/TopProducts.tsx
@@ -15,12 +15,8 @@ import {
   Cell,
 } from "recharts"
 import { AnalyticsService } from "@/services/analytics/analytics.service"
-import { Period } from "./DashboardControls"
 import { getPeriodRange } from "@/utils/buckets"
-
-interface Props {
-  period: Period
-}
+import { usePeriod } from "@/store/period"
 
 const metricOptions = [
   { value: "revenue", label: "Выручка" },
@@ -61,8 +57,9 @@ const formatDate = (date: Date) =>
     .toISOString()
     .slice(0, 10)
 
-const TopProducts: React.FC<Props> = ({ period }) => {
+const TopProducts: React.FC = () => {
   const router = useRouter()
+  const { period } = usePeriod()
   const [metric, setMetric] = useState<(typeof metricOptions)[number]["value"]>(
     "revenue",
   )
@@ -78,7 +75,7 @@ const TopProducts: React.FC<Props> = ({ period }) => {
     error: prodError,
     refetch: refetchProducts,
   } = useQuery({
-    queryKey: ["top-products", s, e, metric, limit],
+    queryKey: ["top-products", period, s, e, metric, limit],
     queryFn: () => AnalyticsService.getTopProducts(15, s, e),
     keepPreviousData: true,
     placeholderData: (prev) => prev,
@@ -91,7 +88,7 @@ const TopProducts: React.FC<Props> = ({ period }) => {
     error: catError,
     refetch: refetchCategories,
   } = useQuery({
-    queryKey: ["category-sales", s, e, metric, limit],
+    queryKey: ["category-sales", period, s, e, metric, limit],
     queryFn: () => AnalyticsService.getCategorySales(s, e),
     keepPreviousData: true,
     placeholderData: (prev) => prev,

--- a/dashboard-ui/app/layout.tsx
+++ b/dashboard-ui/app/layout.tsx
@@ -6,6 +6,7 @@ import { Metadata } from 'next'
 import AuthProvider from 'providers/auth-provider/AuthProvider'
 import { ReactQueryProvider } from './providers/react-query-provider/react-query-provider'
 import { FilterProvider } from './providers/filter-provider/filter-provider'
+import { PeriodProvider } from '@/store/period'
 
 export const metadata: Metadata = {
   icons: {
@@ -29,7 +30,9 @@ export default function RootLayout({
         <FilterProvider>
           <AuthProvider>
             <FontProviders>
-              <body>{children}</body>
+              <PeriodProvider>
+                <body>{children}</body>
+              </PeriodProvider>
             </FontProviders>
           </AuthProvider>
         </FilterProvider>

--- a/dashboard-ui/app/page.tsx
+++ b/dashboard-ui/app/page.tsx
@@ -1,29 +1,33 @@
 'use client'
 import Layout from "@/ui/Layout";
-import React, { useState } from "react";
+import React, { useEffect } from "react";
 import type { Metadata } from "next";
-import DashboardControls, { Period } from "@/components/dashboard/DashboardControls";
+import DashboardControls from "@/components/dashboard/DashboardControls";
 import KpiCards from "@/components/dashboard/KpiCards";
 import SalesChart from "@/components/dashboard/SalesChart";
 import TopProducts from "@/components/dashboard/TopProducts";
 import WeeklyTasks from "@/components/dashboard/WeeklyTasks";
+import { usePeriod } from "@/store/period";
 
 const metadata: Metadata = {
   title: "Главная",
 };
 
 export default function Home() {
-  const [period, setPeriod] = useState<Period>("day");
+  const { initFrom } = usePeriod();
+  useEffect(() => {
+    initFrom();
+  }, [initFrom]);
 
   return (
     <Layout>
       <div className="flex justify-end mb-4">
-        <DashboardControls period={period} onPeriodChange={setPeriod} />
+        <DashboardControls />
       </div>
       <div className="space-y-8">
-        <KpiCards period={period} />
-        <SalesChart period={period} />
-        <TopProducts period={period} />
+        <KpiCards />
+        <SalesChart />
+        <TopProducts />
         <WeeklyTasks />
       </div>
     </Layout>

--- a/dashboard-ui/app/store/period.tsx
+++ b/dashboard-ui/app/store/period.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+
+export type Period = 'day' | 'week' | 'month' | 'year'
+
+interface PeriodCtx {
+  period: Period
+  get: () => Period
+  set: (p: Period) => void
+  initFrom: () => void
+}
+
+const PeriodContext = createContext<PeriodCtx | null>(null)
+
+const STORAGE_KEY = 'dashboard.period'
+const isValid = (p: any): p is Period =>
+  p === 'day' || p === 'week' || p === 'month' || p === 'year'
+
+let initialized = false
+
+export const PeriodProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [period, setPeriod] = useState<Period>('day')
+
+  const syncUrl = useCallback(
+    (p: Period) => {
+      const params = new URLSearchParams(window.location.search)
+      params.set('period', p)
+      router.replace(`?${params.toString()}`, { scroll: false })
+    },
+    [router],
+  )
+
+  const get = useCallback(() => period, [period])
+
+  const set = useCallback(
+    (p: Period) => {
+      setPeriod(p)
+      if (typeof window !== 'undefined') {
+        localStorage.setItem(STORAGE_KEY, p)
+        syncUrl(p)
+      }
+    },
+    [syncUrl],
+  )
+
+  const initFrom = useCallback(() => {
+    if (initialized || typeof window === 'undefined') return
+    initialized = true
+    const params = new URLSearchParams(window.location.search)
+    const urlPeriod = params.get('period')
+    const storagePeriod = localStorage.getItem(STORAGE_KEY)
+    const initial = isValid(urlPeriod)
+      ? urlPeriod
+      : isValid(storagePeriod)
+        ? storagePeriod
+        : 'day'
+    setPeriod(initial)
+    params.set('period', initial)
+    router.replace(`?${params.toString()}`, { scroll: false })
+    localStorage.setItem(STORAGE_KEY, initial)
+
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY && e.newValue && isValid(e.newValue)) {
+        setPeriod(e.newValue as Period)
+        const params = new URLSearchParams(window.location.search)
+        params.set('period', e.newValue)
+        router.replace(`?${params.toString()}`, { scroll: false })
+      }
+    }
+    window.addEventListener('storage', handleStorage)
+  }, [router])
+
+  useEffect(() => {
+    const p = searchParams.get('period')
+    if (isValid(p) && p !== period) {
+      setPeriod(p as Period)
+      if (typeof window !== 'undefined') {
+        localStorage.setItem(STORAGE_KEY, p)
+      }
+    }
+  }, [searchParams, period])
+
+  const value = { period, get, set, initFrom }
+  return <PeriodContext.Provider value={value}>{children}</PeriodContext.Provider>
+}
+
+export function usePeriod() {
+  const ctx = useContext(PeriodContext)
+  if (!ctx) throw new Error('usePeriod must be used within PeriodProvider')
+  return ctx
+}
+

--- a/dashboard-ui/app/utils/buckets.ts
+++ b/dashboard-ui/app/utils/buckets.ts
@@ -1,4 +1,4 @@
-import { Period } from "@/components/dashboard/DashboardControls";
+import { Period } from "@/store/period";
 
 export interface Bucket {
   key: string; // ISO date (YYYY-MM-DD) or YYYY-MM for months


### PR DESCRIPTION
## Summary
- add global period context with URL and localStorage sync
- connect dashboard widgets to period store
- include PeriodProvider in app layout

## Testing
- `npx vitest run`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68a5cef583e483299244f77966ad3075