### PR TITLE
feat: improve inventory actions menu

### DIFF
--- a/dashboard-ui/app/components/products/ProductsTable.test.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.test.tsx
@@ -105,8 +105,10 @@ describe('ProductsTable', () => {
     renderTable()
     const menuBtn = (await screen.findAllByRole('button', { name: 'Действия' }))[0]
     await userEvent.click(menuBtn)
-    const deleteBtn = await screen.findByRole('button', { name: 'Удалить' })
-    await userEvent.click(deleteBtn)
+    const deleteMenuItem = await screen.findByRole('menuitem', { name: 'Удалить' })
+    await userEvent.click(deleteMenuItem)
+    const confirmBtn = await screen.findByRole('button', { name: 'Удалить' })
+    await userEvent.click(confirmBtn)
     await waitFor(() => {
       expect(screen.queryByText('Product 1')).not.toBeInTheDocument()
     })
@@ -117,8 +119,8 @@ describe('ProductsTable', () => {
     await screen.findByText('Product 1')
     const menuBtn = (await screen.findAllByRole('button', { name: 'Действия' }))[0]
     await userEvent.click(menuBtn)
-    const editBtn = await screen.findByRole('button', { name: 'Редактировать' })
-    await userEvent.click(editBtn)
+    const editMenuItem = await screen.findByRole('menuitem', { name: 'Редактировать' })
+    await userEvent.click(editMenuItem)
     const nameInput = await screen.findByLabelText('Название товара')
     await userEvent.clear(nameInput)
     await userEvent.type(nameInput, 'Новый')


### PR DESCRIPTION
## Summary
- replace stock add button with rounded + shortcut
- add portal-based row action menu with edit & delete options
- confirm product deletions with modal and toast

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68ab51ce8d908329bcf979fe9f97dd82