### PR TITLE
feat: highlight stock based on min level

### DIFF
--- a/dashboard-ui/app/components/products/ProductsTable.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.tsx
@@ -520,6 +520,7 @@ const ProductsTable = () => {
                     <div
                       className={`inline-flex items-center justify-end min-w-[3rem] px-2 py-1 rounded-lg whitespace-nowrap ${stockTone(
                         prod.quantity,
+                        prod.minStock,
                       )}`}
                     >
                       <span className="tabular-nums">{prod.quantity}</span>

--- a/dashboard-ui/app/utils/inventoryStats.test.ts
+++ b/dashboard-ui/app/utils/inventoryStats.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { calculateInventoryStats } from './inventoryStats'
+import { calculateInventoryStats, stockTone } from './inventoryStats'
 
 describe('calculateInventoryStats', () => {
   it('calculates out of stock and low stock counts', () => {
@@ -7,12 +7,22 @@ describe('calculateInventoryStats', () => {
       { quantity: 0 },
       { quantity: 1, minStock: 2 },
       { quantity: 3, minStock: 2 },
+      { quantity: 3 },
       { quantity: 1 },
     ])
     expect(stats.outOfStock).toBe(1)
-    expect(stats.lowStock).toBe(2)
-    expect(stats.totalCount).toBe(4)
+    expect(stats.lowStock).toBe(3)
+    expect(stats.totalCount).toBe(5)
     expect(stats.purchaseValue).toBe(0)
     expect(stats.saleValue).toBe(0)
+  })
+})
+
+describe('stockTone', () => {
+  it('returns color based on quantity and min stock', () => {
+    expect(stockTone(5, 3)).toBe('bg-green-50 text-green-700')
+    expect(stockTone(3, 3)).toBe('bg-orange-50 text-orange-700')
+    expect(stockTone(2, 3)).toBe('bg-red-50 text-red-700')
+    expect(stockTone(3, undefined)).toBe('bg-orange-50 text-orange-700')
   })
 })

--- a/dashboard-ui/app/utils/inventoryStats.ts
+++ b/dashboard-ui/app/utils/inventoryStats.ts
@@ -1,6 +1,6 @@
 import { IInventory } from '@/shared/interfaces/inventory.interface'
 
-export const DEFAULT_MIN_STOCK = 2
+export const DEFAULT_MIN_STOCK = 3
 
 export const isLowStock = (
   remains: number,
@@ -10,9 +10,16 @@ export const isLowStock = (
   remains <=
   (Number.isFinite(minStock as number) ? (minStock as number) : fallback)
 
-export function stockTone(qty: number) {
-  if (qty < 20) return 'bg-red-50 text-red-700'
-  if (qty <= 100) return 'bg-orange-50 text-orange-700'
+export function stockTone(
+  remains: number,
+  minStock: number | undefined | null,
+  fallback = DEFAULT_MIN_STOCK,
+) {
+  const min = Number.isFinite(minStock as number)
+    ? (minStock as number)
+    : fallback
+  if (remains < min) return 'bg-red-50 text-red-700'
+  if (remains === min) return 'bg-orange-50 text-orange-700'
   return 'bg-green-50 text-green-700'
 }
 


### PR DESCRIPTION
## Summary
- add min stock-based tone for stock cell
- use default min stock when product has no minimum
- test inventory stats and stock tone

## Testing
- `cd dashboard-ui && yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68ab65280c048329897a1b9b53523c6a