### PR TITLE
feat: add floating add product button

### DIFF
--- a/dashboard-ui/app/components/products/ProductsTable.test.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.test.tsx
@@ -48,7 +48,7 @@ const renderTable = () => {
   const queryClient = new QueryClient()
   render(
     <QueryClientProvider client={queryClient}>
-      <ProductsTable />
+      <ProductsTable isAddOpen={false} onCloseAdd={() => {}} />
     </QueryClientProvider>,
   )
 }

--- a/dashboard-ui/app/components/products/ProductsTable.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.tsx
@@ -25,7 +25,12 @@ import {
 import EditProductForm from './EditProductForm'
 import './ProductsTable.css'
 
-const ProductsTable = () => {
+interface ProductsTableProps {
+  isAddOpen: boolean
+  onCloseAdd: () => void
+}
+
+const ProductsTable = ({ isAddOpen, onCloseAdd }: ProductsTableProps) => {
   const router = useRouter()
   const searchParams = useSearchParams()
 
@@ -39,7 +44,6 @@ const ProductsTable = () => {
   const [sortField, setSortField] = useState<'name' | 'quantity' | 'price'>('name')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
   const [editingIndex, setEditingIndex] = useState<number | null>(null)
-  const [isCreating, setIsCreating] = useState(false)
   const [products, setProducts] = useState<IInventory[]>([])
   const [stats, setStats] = useState({
     outOfStock: 0,
@@ -303,7 +307,7 @@ const ProductsTable = () => {
 
   return (
     <>
-      <div className="space-y-4">
+      <div className="space-y-4 pb-24">
       <div className="bg-white rounded shadow p-4">
         <h2 className="text-lg mb-2">Фильтры и поиск</h2>
         <div className="flex flex-wrap items-center gap-2">
@@ -664,14 +668,6 @@ const ProductsTable = () => {
       </div>
       {error && <p className="text-error mt-2">{error}</p>}
     </div>
-    <button
-      aria-label="Добавить товар"
-      title="Добавить товар"
-      className="fixed z-50 bottom-4 right-4 md:bottom-6 md:right-6 inline-flex items-center justify-center w-14 h-14 md:w-16 md:h-16 rounded-full shadow-lg bg-brand-600 hover:bg-brand-700 focus:ring-2 focus:ring-brand-500 text-white"
-      onClick={() => setIsCreating(true)}
-    >
-      +
-    </button>
     {editingIndex !== null && (
       <Modal isOpen={editingIndex !== null} onClose={() => setEditingIndex(null)}>
         <EditProductForm
@@ -689,15 +685,15 @@ const ProductsTable = () => {
         />
       </Modal>
     )}
-    {isCreating && (
-      <Modal isOpen={isCreating} onClose={() => setIsCreating(false)}>
+    {isAddOpen && (
+      <Modal isOpen={isAddOpen} onClose={onCloseAdd}>
         <div className="add-product-modal">
           <ProductForm
             onSuccess={() => {
               refetch()
-              setIsCreating(false)
+              onCloseAdd()
             }}
-            onCancel={() => setIsCreating(false)}
+            onCancel={onCloseAdd}
           />
         </div>
       </Modal>

--- a/dashboard-ui/app/products/page.tsx
+++ b/dashboard-ui/app/products/page.tsx
@@ -1,15 +1,31 @@
+"use client"
+
 import Layout from '@/ui/Layout'
 import ProductsTable from '@/components/products/ProductsTable'
 import type { Metadata } from 'next'
+import { useState } from 'react'
 
 export const metadata: Metadata = {
   title: 'Склад'
 }
 
 export default function ProductsPage() {
+  const [isAddOpen, setIsAddOpen] = useState(false)
   return (
     <Layout>
-      <ProductsTable />
+      <ProductsTable isAddOpen={isAddOpen} onCloseAdd={() => setIsAddOpen(false)} />
+      {!isAddOpen && (
+        <div className="fixed z-50 bottom-6 right-6 md:bottom-8 md:right-8 pb-[env(safe-area-inset-bottom)]">
+          <button
+            aria-label="Добавить товар"
+            title="Добавить товар"
+            onClick={() => setIsAddOpen(true)}
+            className="rounded-full w-14 h-14 md:w-16 md:h-16 flex items-center justify-center bg-primary-500 hover:bg-primary-400 text-neutral-50 shadow-lg focus:outline-none focus:ring-2 focus:ring-primary-300 transition-transform hover:scale-105 active:scale-95"
+          >
+            +
+          </button>
+        </div>
+      )}
     </Layout>
   )
 }


### PR DESCRIPTION
## Summary
- add floating action button on inventory page using primary palette
- move product add modal state to page and prevent overlap with FAB
- adjust inventory table and tests for new modal control

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68ab6f98be7c8329a9f7a4682286cc63