### PR TITLE
fix: separate client logic from products page to allow metadata

### DIFF
--- a/dashboard-ui/app/products/ProductsPageClient.tsx
+++ b/dashboard-ui/app/products/ProductsPageClient.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import ProductsTable from '@/components/products/ProductsTable'
+import { useState } from 'react'
+
+export default function ProductsPageClient() {
+  const [isAddOpen, setIsAddOpen] = useState(false)
+
+  return (
+    <>
+      <ProductsTable isAddOpen={isAddOpen} onCloseAdd={() => setIsAddOpen(false)} />
+      {!isAddOpen && (
+        <div className="fixed z-50 bottom-6 right-6 md:bottom-8 md:right-8 pb-[env(safe-area-inset-bottom)]">
+          <button
+            aria-label="Добавить товар"
+            title="Добавить товар"
+            onClick={() => setIsAddOpen(true)}
+            className="rounded-full w-14 h-14 md:w-16 md:h-16 flex items-center justify-center bg-primary-500 hover:bg-primary-400 text-neutral-50 shadow-lg focus:outline-none focus:ring-2 focus:ring-primary-300 transition-transform hover:scale-105 active:scale-95"
+          >
+            +
+          </button>
+        </div>
+      )}
+    </>
+  )
+}

--- a/dashboard-ui/app/products/page.tsx
+++ b/dashboard-ui/app/products/page.tsx
@@ -1,31 +1,15 @@
-"use client"
-
 import Layout from '@/ui/Layout'
-import ProductsTable from '@/components/products/ProductsTable'
+import ProductsPageClient from './ProductsPageClient'
 import type { Metadata } from 'next'
-import { useState } from 'react'
 
 export const metadata: Metadata = {
-  title: 'Склад'
+  title: 'Склад',
 }
 
 export default function ProductsPage() {
-  const [isAddOpen, setIsAddOpen] = useState(false)
   return (
     <Layout>
-      <ProductsTable isAddOpen={isAddOpen} onCloseAdd={() => setIsAddOpen(false)} />
-      {!isAddOpen && (
-        <div className="fixed z-50 bottom-6 right-6 md:bottom-8 md:right-8 pb-[env(safe-area-inset-bottom)]">
-          <button
-            aria-label="Добавить товар"
-            title="Добавить товар"
-            onClick={() => setIsAddOpen(true)}
-            className="rounded-full w-14 h-14 md:w-16 md:h-16 flex items-center justify-center bg-primary-500 hover:bg-primary-400 text-neutral-50 shadow-lg focus:outline-none focus:ring-2 focus:ring-primary-300 transition-transform hover:scale-105 active:scale-95"
-          >
-            +
-          </button>
-        </div>
-      )}
+      <ProductsPageClient />
     </Layout>
   )
 }


### PR DESCRIPTION
## Summary
- move stateful logic into new `ProductsPageClient` component
- restore metadata export on server-rendered products page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab716c59ac8329b022eff87e3fada5