### PR TITLE
feat: add warehouse KPI cards

### DIFF
--- a/dashboard-ui/app/components/products/ProductsTable.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.tsx
@@ -23,6 +23,7 @@ import {
   stockTone,
 } from '@/utils/inventoryStats'
 import EditProductForm from './EditProductForm'
+import WarehouseKpiCards from './WarehouseKpiCards'
 import './ProductsTable.css'
 
 interface ProductsTableProps {
@@ -397,15 +398,13 @@ const ProductsTable = ({ isAddOpen, onCloseAdd }: ProductsTableProps) => {
               )}
             </div>
           </div>
-          <div className="flex flex-wrap items-center gap-4">
-            <span>Товаров: {stats.totalCount}</span>
-            <span>
-              Закупочная стоимость: {formatCurrency(stats.purchaseValue)}
-            </span>
-            <span>
-              Продажная стоимость: {formatCurrency(stats.saleValue)}
-            </span>
-          <div className="ml-auto flex gap-2">
+          <WarehouseKpiCards
+            totalCount={stats.totalCount}
+            purchaseValue={stats.purchaseValue}
+            saleValue={stats.saleValue}
+            isLoading={isInitialLoading}
+          />
+          <div className="flex justify-end gap-2 mt-4">
             <Button
               className="bg-neutral-200 px-2 py-1"
               onClick={handleExport}
@@ -423,7 +422,6 @@ const ProductsTable = ({ isAddOpen, onCloseAdd }: ProductsTableProps) => {
               <FaPrint aria-hidden="true" />
             </Button>
           </div>
-        </div>
       </>
       )}
 

--- a/dashboard-ui/app/components/products/WarehouseKpiCards.tsx
+++ b/dashboard-ui/app/components/products/WarehouseKpiCards.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+interface WarehouseKpiCardsProps {
+  totalCount: number
+  purchaseValue: number
+  saleValue: number
+  isLoading: boolean
+}
+
+const numberFormatter = new Intl.NumberFormat('ru-RU')
+const currencyFormatter = new Intl.NumberFormat('ru-RU', {
+  style: 'currency',
+  currency: 'RUB',
+})
+
+export default function WarehouseKpiCards({
+  totalCount,
+  purchaseValue,
+  saleValue,
+  isLoading,
+}: WarehouseKpiCardsProps) {
+  const cards = [
+    {
+      label: 'Товаров',
+      icon: '📦',
+      value: numberFormatter.format(totalCount),
+      circle: 'bg-info/10 text-info',
+      valueClass: 'text-info',
+    },
+    {
+      label: 'Закупочная стоимость',
+      icon: '💰',
+      value: currencyFormatter.format(purchaseValue),
+      circle: 'bg-primary-300 text-neutral-900',
+      valueClass: 'text-neutral-900',
+    },
+    {
+      label: 'Продажная стоимость',
+      icon: '💵',
+      value: currencyFormatter.format(saleValue),
+      circle: 'bg-success/10 text-success',
+      valueClass: 'text-success',
+    },
+  ]
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 md:gap-4">
+      {cards.map(card => (
+        <div
+          key={card.label}
+          role="region"
+          aria-label={card.label}
+          className="rounded-2xl shadow-card p-4 md:p-5 flex items-center gap-3 bg-neutral-200"
+        >
+          <div
+            className={`w-10 h-10 rounded-full flex items-center justify-center ${card.circle}`}
+          >
+            <span aria-hidden="true">{card.icon}</span>
+          </div>
+          <div className="flex flex-col">
+            <span className="text-sm text-neutral-800">{card.label}</span>
+            {isLoading ? (
+              <div className="mt-1 h-7 w-20 bg-neutral-300 rounded animate-pulse" />
+            ) : (
+              <span
+                className={`text-2xl md:text-3xl font-semibold tabular-nums ${card.valueClass}`}
+              >
+                {card.value}
+              </span>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- show inventory KPIs with colored icons and formatting
- integrate KPI cards into products table

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68ab736ca2808329b23f5eaf45c3cbe4