### PR TITLE
Fix duplicate key in WeeklyTasks and guard TopProducts payload

### DIFF
--- a/dashboard-ui/app/components/dashboard/TopProducts.tsx
+++ b/dashboard-ui/app/components/dashboard/TopProducts.tsx
@@ -252,8 +252,8 @@ const TopProducts: React.FC = () => {
         transform={labelAngle ? `rotate(${labelAngle})` : undefined}
         fontSize={12}
       >
-        <title>{payload.payload.fullName}</title>
-        {payload.value}
+        <title>{payload?.payload?.fullName ?? payload?.value}</title>
+        {payload?.value}
       </text>
     </g>
   )

--- a/dashboard-ui/app/components/dashboard/WeeklyTasks.tsx
+++ b/dashboard-ui/app/components/dashboard/WeeklyTasks.tsx
@@ -36,12 +36,16 @@ const WeeklyTasks = () => {
   });
   const [segment, setSegment] = useState<"all" | "today" | "overdue">("all");
 
+  const tasks: ITask[] = useMemo(() => {
+    const unique = new Map<number, ITask>();
+    (data || []).forEach((t) => unique.set(t.id, t));
+    return Array.from(unique.values());
+  }, [data]);
+  const now = new Date();
+
   if (isLoading) {
     return <div className="bg-neutral-200 p-4 md:p-5 rounded-2xl shadow-card h-40 animate-pulse" />;
   }
-
-  const now = new Date();
-  const tasks: ITask[] = data || [];
   const todayTasks = tasks.filter((t) => {
     const d = new Date(t.deadline);
     return (


### PR DESCRIPTION
## Summary
- remove duplicate tasks so list item keys remain unique
- avoid undefined payloads when rendering chart axis ticks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab786c8c2483299032bd619e617371