### PR TITLE
feat: add financial summary kpi

### DIFF
--- a/dashboard-ui/app/components/dashboard/FinancialSummary.test.tsx
+++ b/dashboard-ui/app/components/dashboard/FinancialSummary.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { vi, afterEach } from 'vitest'
+import FinancialSummary from './FinancialSummary'
+import { PeriodProvider } from '@/store/period'
+import { AnalyticsService } from '@/services/analytics/analytics.service'
+
+vi.mock('@/services/analytics/analytics.service', () => ({
+  AnalyticsService: {
+    getKpis: vi.fn(),
+  },
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+const renderWidget = () => {
+  const client = new QueryClient()
+  render(
+    <QueryClientProvider client={client}>
+      <PeriodProvider>
+        <FinancialSummary />
+      </PeriodProvider>
+    </QueryClientProvider>
+  )
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('FinancialSummary', () => {
+  it('shows positive profit in green', async () => {
+    ;(AnalyticsService.getKpis as unknown as any).mockResolvedValueOnce({
+      revenue: 1000,
+      margin: 700,
+    })
+    renderWidget()
+    const value = await screen.findByText(/700,00/)
+    expect(value).toHaveClass('text-success')
+  })
+
+  it('shows negative profit in red', async () => {
+    ;(AnalyticsService.getKpis as unknown as any).mockResolvedValueOnce({
+      revenue: 1000,
+      margin: -200,
+    })
+    renderWidget()
+    const value = await screen.findByText(/-200,00/)
+    expect(value).toHaveClass('text-error')
+  })
+})

--- a/dashboard-ui/app/components/dashboard/FinancialSummary.tsx
+++ b/dashboard-ui/app/components/dashboard/FinancialSummary.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { FaBriefcase } from "react-icons/fa";
 import { useQuery } from "@tanstack/react-query";
 import { AnalyticsService } from "@/services/analytics/analytics.service";
 import { getPeriodRange } from "@/utils/buckets";
@@ -24,19 +25,28 @@ const FinancialSummary: React.FC = () => {
     keepPreviousData: true,
   });
 
-  const profit = data?.margin ?? 0;
+  const revenue = data?.revenue ?? 0;
+  const purchaseCost = revenue - (data?.margin ?? 0);
+  const profit = revenue - purchaseCost;
   const profitText = currency.format(profit);
-  const color = profit >= 0 ? "text-success" : "text-error";
+  const color =
+    profit > 0
+      ? "text-success"
+      : profit < 0
+        ? "text-error"
+        : "text-neutral-900";
 
   return (
-    <div className="bg-neutral-200 p-4 md:p-5 rounded-2xl shadow-card">
-      <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-        💼 Финансовый итог
-      </h3>
-      <div className="text-2xl md:text-3xl font-semibold tabular-nums">
-        <span className={color}>{profitText}</span>
-      </div>
-      <div className="text-sm text-neutral-600">Прибыль за период</div>
+    <div className="rounded-2xl shadow-card p-4 md:p-5 bg-neutral-200 flex items-center gap-3">
+      <span className="w-10 h-10 rounded-full flex items-center justify-center bg-primary-300 text-neutral-900">
+        <FaBriefcase />
+      </span>
+      <span className="flex flex-col">
+        <span className="text-sm text-neutral-600">Финансовый итог</span>
+        <span className={`text-2xl md:text-3xl font-semibold tabular-nums ${color}`}>
+          {profitText}
+        </span>
+      </span>
     </div>
   );
 };

--- a/dashboard-ui/app/page.tsx
+++ b/dashboard-ui/app/page.tsx
@@ -27,10 +27,10 @@ export default function Home() {
       </div>
       <div className="grid gap-4">
         <KpiCards />
+        <FinancialSummary />
         <SalesChart />
         <TopProducts />
         <WeeklyTasks />
-        <FinancialSummary />
       </div>
     </Layout>
   );


### PR DESCRIPTION
## Summary
- add profit summary card with color-coded value
- place financial summary below KPI cards on dashboard
- test financial summary rendering and colors

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68ab7aaedf5083299ccad871fe9a1721