### PR TITLE
feat(tasks): enhance task table UI

### DIFF
--- a/dashboard-ui/app/components/tasks/TasksTable.test.tsx
+++ b/dashboard-ui/app/components/tasks/TasksTable.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 import TasksTable from './TasksTable'
@@ -33,15 +33,20 @@ describe('TasksTable', () => {
   it('filters by priority', async () => {
     render(<TasksTable />)
     await screen.findByText('Task 1')
-    const select = screen.getByRole('combobox')
+    const select = screen.getByRole('combobox', { name: /приоритет/i })
     await userEvent.selectOptions(select, 'Высокий')
     expect(screen.getByText('Task 1')).toBeInTheDocument()
   })
 
   it('deletes a task', async () => {
     render(<TasksTable />)
-    const deleteBtn = await screen.findByRole('button', { name: /удалить/i })
-    await userEvent.click(deleteBtn)
+    const menuBtn = await screen.findByRole('button', { name: /действия/i })
+    await userEvent.click(menuBtn)
+    const deleteItem = await screen.findByRole('menuitem', { name: /удалить/i })
+    await userEvent.click(deleteItem)
+    const dialog = await screen.findByRole('dialog')
+    const confirm = within(dialog).getByRole('button', { name: /удалить/i })
+    await userEvent.click(confirm)
     await waitFor(() => {
       expect(screen.queryByText('Task 1')).not.toBeInTheDocument()
     })

--- a/dashboard-ui/app/components/tasks/TasksTable.tsx
+++ b/dashboard-ui/app/components/tasks/TasksTable.tsx
@@ -2,14 +2,27 @@
 
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { createPortal } from 'react-dom'
+import { HiDotsVertical } from 'react-icons/hi'
+
 import Button from '@/ui/Button/Button'
 import { TaskService } from '@/services/task/task.service'
-import { ITask, TaskPriority } from '@/shared/interfaces/task.interface'
+import {
+  ITask,
+  TaskPriority,
+  TaskStatus,
+} from '@/shared/interfaces/task.interface'
+
+const chipBase =
+  'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium whitespace-nowrap'
 
 const TasksTable = () => {
   const [tasks, setTasks] = useState<ITask[]>([])
   const [date, setDate] = useState('')
   const [priority, setPriority] = useState('')
+  const [status, setStatus] = useState('')
+  const [menuId, setMenuId] = useState<number | null>(null)
+  const [confirmId, setConfirmId] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -17,6 +30,20 @@ const TasksTable = () => {
       .then(setTasks)
       .catch(e => setError(e.message))
   }, [])
+
+  useEffect(() => {
+    if (menuId === null) return
+    const handleClick = () => setMenuId(null)
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMenuId(null)
+    }
+    document.addEventListener('click', handleClick)
+    document.addEventListener('keydown', handleEsc)
+    return () => {
+      document.removeEventListener('click', handleClick)
+      document.removeEventListener('keydown', handleEsc)
+    }
+  }, [menuId])
 
   const handleDelete = async (id: number) => {
     try {
@@ -27,26 +54,39 @@ const TasksTable = () => {
     }
   }
 
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
   const filtered = tasks.filter(task => {
     const matchesDate = !date || task.deadline.slice(0, 10) === date
     const matchesPriority = !priority || task.priority === priority
-    return matchesDate && matchesPriority
+    let matchesStatus = true
+    if (status === 'В работе') matchesStatus = task.status === TaskStatus.InProgress
+    else if (status === 'Завершённые') matchesStatus = task.status === TaskStatus.Completed
+    else if (status === 'Просроченные') {
+      const d = new Date(task.deadline)
+      d.setHours(0, 0, 0, 0)
+      matchesStatus = d < today && task.status !== TaskStatus.Completed
+    }
+    return matchesDate && matchesPriority && matchesStatus
   })
 
   return (
     <div>
       <div className="flex justify-between mb-4">
-        <div className="flex space-x-2">
+        <div className="flex gap-2">
           <input
             type="date"
             value={date}
             onChange={e => setDate(e.target.value)}
             className="border border-neutral-300 rounded px-2 py-1"
+            aria-label="Фильтр по дате"
           />
           <select
             value={priority}
             onChange={e => setPriority(e.target.value)}
             className="border border-neutral-300 rounded px-2 py-1"
+            aria-label="Фильтр по приоритету"
           >
             <option value="">Все приоритеты</option>
             {Object.values(TaskPriority).map(p => (
@@ -55,9 +95,20 @@ const TasksTable = () => {
               </option>
             ))}
           </select>
+          <select
+            value={status}
+            onChange={e => setStatus(e.target.value)}
+            className="border border-neutral-300 rounded px-2 py-1"
+            aria-label="Фильтр по статусу"
+          >
+            <option value="">Все</option>
+            <option value="В работе">В работе</option>
+            <option value="Просроченные">Просроченные</option>
+            <option value="Завершённые">Завершённые</option>
+          </select>
         </div>
-        <Link href="/tasks/new">
-          <Button className="bg-primary-500 text-white px-4 py-1">
+        <Link href="/tasks/new" className="ml-auto">
+          <Button className="rounded-2xl px-4 py-2 shadow-card bg-info text-neutral-50 hover:brightness-95 focus:ring-2 focus:ring-info">
             Добавить задачу
           </Button>
         </Link>
@@ -71,37 +122,161 @@ const TasksTable = () => {
             <th className="p-2">Дедлайн</th>
             <th className="p-2">Приоритет</th>
             <th className="p-2">Статус</th>
-            <th className="p-2">Действия</th>
+            <th className="p-2" />
           </tr>
         </thead>
         <tbody>
-          {filtered.map(task => (
-            <tr
-              key={task.id}
-              className="border-b border-neutral-200 hover:bg-neutral-200"
-            >
-              <td className="p-2">
-                <Link href={`/tasks/${task.id}`}>{task.title}</Link>
-              </td>
-              <td className="p-2">{task.executor || '-'}</td>
-              <td className="p-2">
-                {new Date(task.deadline).toLocaleDateString()}
-              </td>
-              <td className="p-2">{task.priority}</td>
-              <td className="p-2">{task.status}</td>
-              <td className="p-2">
-                <Button
-                  className="bg-error text-white px-4 py-1"
-                  onClick={() => handleDelete(task.id)}
+          {filtered.map(task => {
+            const deadlineDate = new Date(task.deadline)
+            deadlineDate.setHours(0, 0, 0, 0)
+            const overdue = deadlineDate < today
+            const todayMatch = deadlineDate.getTime() === today.getTime()
+            const deadlineClasses = overdue
+              ? 'text-error bg-error/5'
+              : todayMatch
+              ? 'text-warning'
+              : ''
+
+            const priorityClasses: Record<TaskPriority, string> = {
+              [TaskPriority.High]: 'bg-error/10 text-error',
+              [TaskPriority.Medium]: 'bg-warning/10 text-warning',
+              [TaskPriority.Low]: 'bg-success/10 text-success',
+            }
+
+            const statusClasses: Record<TaskStatus, string> = {
+              [TaskStatus.InProgress]: 'bg-info/10 text-info',
+              [TaskStatus.Completed]: 'bg-success/10 text-success',
+              [TaskStatus.Pending]: 'bg-neutral-300 text-neutral-900',
+            }
+
+            const initials = task.executor
+              ? task.executor
+                  .split(' ')
+                  .map(w => w[0])
+                  .join('')
+                  .toUpperCase()
+              : ''
+
+            return (
+              <tr
+                key={task.id}
+                className="border-b border-neutral-200 hover:bg-neutral-200/50 transition-colors odd:bg-neutral-100 even:bg-neutral-200"
+              >
+                <td className="p-2 max-w-[32ch] truncate" title={task.title}>
+                  <Link href={`/tasks/${task.id}`}>{task.title}</Link>
+                </td>
+                <td className="p-2">
+                  {task.executor ? (
+                    <div
+                      className="w-6 h-6 rounded-full bg-neutral-300 text-neutral-900 text-xs font-semibold flex items-center justify-center"
+                      title={task.executor}
+                    >
+                      {initials}
+                    </div>
+                  ) : (
+                    '-'
+                  )}
+                </td>
+                <td
+                  className={`p-2 ${deadlineClasses}`}
+                  title={`Дедлайн: ${deadlineDate.toLocaleDateString('ru-RU')}`}
                 >
-                  Удалить
-                </Button>
-              </td>
-            </tr>
-          ))}
+                  {overdue && <span aria-hidden>⚠️</span>}{' '}
+                  {deadlineDate.toLocaleDateString()}
+                </td>
+                <td className="p-2">
+                  <span className={`${chipBase} ${priorityClasses[task.priority]}`}>
+                    {task.priority}
+                  </span>
+                </td>
+                <td className="p-2">
+                  <span className={`${chipBase} ${statusClasses[task.status]}`}>
+                    {task.status}
+                  </span>
+                </td>
+                <td className="p-2 relative" onClick={e => e.stopPropagation()}>
+                  <button
+                    aria-haspopup="menu"
+                    aria-label="Действия"
+                    title="Действия"
+                    onClick={e => {
+                      e.stopPropagation()
+                      setMenuId(task.id)
+                    }}
+                    className="p-1 rounded hover:bg-neutral-200"
+                  >
+                    <HiDotsVertical />
+                  </button>
+                  {menuId === task.id && (
+                    <ul
+                      role="menu"
+                      className="absolute right-0 mt-1 w-32 bg-white border border-neutral-300 rounded shadow-md z-50"
+                      onClick={e => e.stopPropagation()}
+                    >
+                      <li>
+                        <Link
+                          href={`/tasks/${task.id}`}
+                          className="block px-4 py-2 hover:bg-neutral-100"
+                          role="menuitem"
+                        >
+                          Редактировать
+                        </Link>
+                      </li>
+                      <li>
+                        <button
+                          role="menuitem"
+                          onClick={() => {
+                            setMenuId(null)
+                            setConfirmId(task.id)
+                          }}
+                          className="w-full text-left px-4 py-2 hover:bg-neutral-100"
+                        >
+                          Удалить
+                        </button>
+                      </li>
+                    </ul>
+                  )}
+                </td>
+              </tr>
+            )
+          })}
         </tbody>
       </table>
       {error && <p className="text-error mt-2">{error}</p>}
+      {confirmId !== null &&
+        createPortal(
+          <div
+            className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+            onClick={() => setConfirmId(null)}
+            role="dialog"
+            aria-modal
+          >
+            <div
+              className="bg-white p-4 rounded shadow-md"
+              onClick={e => e.stopPropagation()}
+            >
+              <p className="mb-4">Удалить задачу?</p>
+              <div className="flex justify-end gap-2">
+                <button
+                  className="px-3 py-1 border rounded"
+                  onClick={() => setConfirmId(null)}
+                >
+                  Отмена
+                </button>
+                <button
+                  className="px-3 py-1 bg-error text-white rounded"
+                  onClick={async () => {
+                    await handleDelete(confirmId)
+                    setConfirmId(null)
+                  }}
+                >
+                  Удалить
+                </button>
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- style priority and status with color-coded chips
- highlight deadline urgency and show assignee initials
- move row actions into contextual menu with confirmation modal

## Testing
- `yarn test`
- `yarn lint` *(warnings: React Hook useEffect missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_68b0719f08348329a375a211c4a91556