### PR TITLE
feat(tasks): redesign task form modal

### DIFF
--- a/dashboard-ui/app/components/tasks/TaskForm.tsx
+++ b/dashboard-ui/app/components/tasks/TaskForm.tsx
@@ -1,28 +1,56 @@
 'use client'
 
+import { useEffect, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
-import Field from '@/ui/Field/Field'
-import TextArea from '@/ui/TextArea/TextArea'
-import Button from '@/ui/Button/Button'
+import cn from 'classnames'
 import {
   ITask,
   TaskPriority,
   TaskStatus,
 } from '@/shared/interfaces/task.interface'
 import { TaskService } from '@/services/task/task.service'
+import { toast } from '@/utils/toast'
 
 interface Props {
   task?: ITask
 }
 
+const inputClasses =
+  'w-full rounded-2xl border border-neutral-300 bg-neutral-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-300 focus:border-primary-400'
+
+const priorityClasses: Record<TaskPriority, string> = {
+  [TaskPriority.High]: 'bg-error/10 text-error',
+  [TaskPriority.Medium]: 'bg-warning/10 text-warning',
+  [TaskPriority.Low]: 'bg-success/10 text-success',
+}
+
+const statusClasses: Record<TaskStatus, string> = {
+  [TaskStatus.InProgress]: 'bg-info/10 text-info',
+  [TaskStatus.Completed]: 'bg-success/10 text-success',
+  [TaskStatus.Pending]: 'bg-neutral-300 text-neutral-900',
+}
+
 const TaskForm = ({ task }: Props) => {
+  const router = useRouter()
+  const [executors, setExecutors] = useState<string[]>([])
+
+  useEffect(() => {
+    TaskService.getAll().then(tasks => {
+      const list = Array.from(
+        new Set(tasks.map(t => t.executor).filter(Boolean) as string[]),
+      )
+      setExecutors(list)
+    })
+  }, [])
+
   const {
     register,
     handleSubmit,
-    formState: { errors },
+    watch,
+    formState: { errors, isValid, isSubmitting },
   } = useForm<ITask>({
+    mode: 'onChange',
     defaultValues: {
       title: task?.title || '',
       description: task?.description || '',
@@ -33,84 +61,206 @@ const TaskForm = ({ task }: Props) => {
     },
   })
 
-  const router = useRouter()
-  const [error, setError] = useState<string | null>(null)
-
-  const onSubmit = (data: ITask) => {
-    const method = task
-      ? TaskService.update(task.id, data)
-      : TaskService.create(data)
-    method
-      .then(() => router.push('/tasks'))
-      .catch(e => setError(e.message))
+  const descriptionRef = useRef<HTMLTextAreaElement>(null)
+  const autoResize = () => {
+    const el = descriptionRef.current
+    if (el) {
+      el.style.height = 'auto'
+      el.style.height = `${el.scrollHeight}px`
+    }
   }
 
+  const onSubmit = async (data: ITask) => {
+    const payload = {
+      ...data,
+      title: data.title.trim(),
+      description: data.description?.trim() || '',
+    }
+    try {
+      if (task) await TaskService.update(task.id, payload)
+      else await TaskService.create(payload as Omit<ITask, 'id'>)
+      toast.success('Сохранено')
+      router.push('/tasks')
+    } catch (e) {
+      toast.error('Проверьте поля')
+    }
+  }
+
+  const currentPriority = watch('priority')
+  const currentStatus = watch('status')
+
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 max-w-md">
-      <Field
-        {...register('title', { required: 'Введите заголовок' })}
-        placeholder="Заголовок"
-        error={errors.title}
-      />
-      <TextArea
-        {...register('description')}
-        placeholder="Описание"
-      />
-      <Field
-        {...register('executor')}
-        placeholder="Исполнитель"
-      />
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-3 md:space-y-4">
+      <h2
+        id="task-form-title"
+        className="text-lg md:text-xl font-semibold text-neutral-900 mb-3 md:mb-4"
+      >
+        {task ? 'Редактирование задачи' : 'Новая задача'}
+      </h2>
+
       <div>
-        <label className="block mb-1">Дедлайн</label>
-        <Field
+        <label htmlFor="title" className="block text-sm font-medium text-neutral-900">
+          Название задачи
+        </label>
+        <input
+          id="title"
+          type="text"
+          placeholder="Введите название задачи…"
+          aria-invalid={errors.title ? 'true' : 'false'}
+          aria-describedby={errors.title ? 'title-error' : undefined}
+          className={inputClasses}
+          {...register('title', {
+            required: 'Название задачи должно содержать от 2 до 150 символов',
+            minLength: {
+              value: 2,
+              message: 'Название задачи должно содержать от 2 до 150 символов',
+            },
+            maxLength: {
+              value: 150,
+              message: 'Название задачи должно содержать от 2 до 150 символов',
+            },
+            validate: value =>
+              value.trim().length >= 2 ||
+              'Название задачи должно содержать от 2 до 150 символов',
+          })}
+        />
+        <p id="title-error" className="text-xs text-error mt-1 min-h-[1rem]">
+          {errors.title?.message}
+        </p>
+      </div>
+
+      <div>
+        <label
+          htmlFor="description"
+          className="block text-sm font-medium text-neutral-900"
+        >
+          Описание
+        </label>
+        <textarea
+          id="description"
+          placeholder="Опишите задачу (необязательно)…"
+          className={cn(inputClasses, 'resize-none overflow-hidden')}
+          rows={2}
+          ref={e => {
+            descriptionRef.current = e
+          }}
+          onInput={autoResize}
+          {...register('description')}
+        />
+        <p className="text-xs text-error mt-1 min-h-[1rem]" />
+      </div>
+
+      <div>
+        <label htmlFor="executor" className="block text-sm font-medium text-neutral-900">
+          Исполнитель
+        </label>
+        <input
+          id="executor"
+          list="executor-list"
+          className={inputClasses}
+          {...register('executor')}
+        />
+        <datalist id="executor-list">
+          {executors.map(ex => (
+            <option key={ex} value={ex} />
+          ))}
+        </datalist>
+        <p className="text-xs text-error mt-1 min-h-[1rem]" />
+      </div>
+
+      <div>
+        <label htmlFor="deadline" className="block text-sm font-medium text-neutral-900">
+          Дедлайн
+        </label>
+        <input
+          id="deadline"
           type="date"
+          lang="ru"
           min={new Date().toISOString().split('T')[0]}
+          aria-invalid={errors.deadline ? 'true' : 'false'}
+          aria-describedby={errors.deadline ? 'deadline-error' : undefined}
+          className={inputClasses}
           {...register('deadline', {
-            required: 'Укажите дату',
             validate: value => {
+              if (!value) return true
               const today = new Date()
               today.setHours(0, 0, 0, 0)
-              return new Date(value) >= today || 'Дата не может быть в прошлом'
+              return (
+                new Date(value) >= today || 'Дата не может быть в прошлом'
+              )
             },
           })}
-          error={errors.deadline}
         />
+        <p id="deadline-error" className="text-xs text-error mt-1 min-h-[1rem]">
+          {errors.deadline?.message}
+        </p>
       </div>
+
       <div>
-        <label className="block mb-1">Приоритет</label>
+        <label htmlFor="priority" className="block text-sm font-medium text-neutral-900">
+          Приоритет
+        </label>
         <select
+          id="priority"
+          className={cn(inputClasses, priorityClasses[currentPriority])}
           {...register('priority')}
-          className="border border-neutral-300 rounded px-2 py-1 w-full"
         >
-          {Object.values(TaskPriority).map(p => (
-            <option key={p} value={p}>
-              {p}
-            </option>
-          ))}
+          <option value={TaskPriority.High} className="bg-error/10 text-error">
+            Высокий 🔴
+          </option>
+          <option value={TaskPriority.Medium} className="bg-warning/10 text-warning">
+            Средний 🟡
+          </option>
+          <option value={TaskPriority.Low} className="bg-success/10 text-success">
+            Низкий 🟢
+          </option>
         </select>
+        <p className="text-xs text-error mt-1 min-h-[1rem]" />
       </div>
+
       <div>
-        <label className="block mb-1">Статус</label>
+        <label htmlFor="status" className="block text-sm font-medium text-neutral-900">
+          Статус
+        </label>
         <select
+          id="status"
+          className={cn(inputClasses, statusClasses[currentStatus])}
           {...register('status')}
-          className="border border-neutral-300 rounded px-2 py-1 w-full"
         >
-          {Object.values(TaskStatus).map(s => (
-            <option key={s} value={s}>
-              {s}
-            </option>
-          ))}
+          <option value={TaskStatus.InProgress} className="bg-info/10 text-info">
+            Выполняется 🔵
+          </option>
+          <option value={TaskStatus.Completed} className="bg-success/10 text-success">
+            Готово 🟢
+          </option>
+          <option value={TaskStatus.Pending} className="bg-neutral-300 text-neutral-900">
+            Ожидает ⚪
+          </option>
         </select>
+        <p className="text-xs text-error mt-1 min-h-[1rem]" />
       </div>
-      <Button
-        type="submit"
-        className="bg-primary-500 text-white px-4 py-1"
-      >
-        Сохранить
-      </Button>
-      {error && <p className="text-error">{error}</p>}
+
+      <div className="flex gap-2 justify-end mt-4 md:mt-6">
+        <button
+          type="button"
+          onClick={() => router.push('/tasks')}
+          className="rounded-2xl px-4 py-2 bg-neutral-200 text-neutral-900 hover:bg-neutral-300"
+          aria-label="Отмена"
+        >
+          Отмена
+        </button>
+        <button
+          type="submit"
+          disabled={!isValid || isSubmitting}
+          className="rounded-2xl px-4 py-2 bg-success text-neutral-50 hover:brightness-95 focus:ring-2 focus:ring-success shadow-card disabled:opacity-50"
+          aria-label="Сохранить"
+        >
+          {isSubmitting ? '...' : 'Сохранить'}
+        </button>
+      </div>
     </form>
   )
 }
 
 export default TaskForm
+

--- a/dashboard-ui/app/components/ui/Modal/Modal.tsx
+++ b/dashboard-ui/app/components/ui/Modal/Modal.tsx
@@ -60,15 +60,16 @@ const Modal = ({ isOpen, onClose, children, className, ariaLabelledby }: Props) 
     <AnimatePresence>
       {isOpen && (
         <motion.div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
           onClick={handleClick}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
         >
+          <div className="absolute inset-0 bg-neutral-950/40 pointer-events-none" />
           <motion.div
             ref={ref}
-            className={`bg-white rounded p-4 max-w-lg w-full ${className ?? ''}`}
+            className={`relative w-full max-w-xl rounded-3xl bg-neutral-200 p-5 md:p-6 shadow-card ${className ?? ''}`}
             initial={{ scale: 0.9, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             exit={{ scale: 0.9, opacity: 0 }}

--- a/dashboard-ui/app/tasks/[id]/page.tsx
+++ b/dashboard-ui/app/tasks/[id]/page.tsx
@@ -1,8 +1,10 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import Layout from '@/ui/Layout'
 import TaskForm from '@/components/tasks/TaskForm'
+import Modal from '@/ui/Modal/Modal'
 import { TaskService } from '@/services/task/task.service'
 import { ITask } from '@/shared/interfaces/task.interface'
 
@@ -12,21 +14,19 @@ interface Props {
 
 export default function TaskPage({ params }: Props) {
   const [task, setTask] = useState<ITask | null>(null)
+  const router = useRouter()
 
   useEffect(() => {
     TaskService.getById(params.id).then(setTask)
   }, [params.id])
 
-  if (!task)
-    return (
-      <Layout>
-        <div>Загрузка...</div>
-      </Layout>
-    )
+  const onClose = () => router.push('/tasks')
 
   return (
     <Layout>
-      <TaskForm task={task} />
+      <Modal isOpen onClose={onClose} ariaLabelledby="task-form-title">
+        {task ? <TaskForm task={task} /> : <div>Загрузка...</div>}
+      </Modal>
     </Layout>
   )
 }

--- a/dashboard-ui/app/tasks/new/page.tsx
+++ b/dashboard-ui/app/tasks/new/page.tsx
@@ -1,5 +1,9 @@
+"use client"
+
+import { useRouter } from 'next/navigation'
 import Layout from '@/ui/Layout'
 import TaskForm from '@/components/tasks/TaskForm'
+import Modal from '@/ui/Modal/Modal'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -7,9 +11,12 @@ export const metadata: Metadata = {
 }
 
 export default function NewTaskPage() {
+  const router = useRouter()
   return (
     <Layout>
-      <TaskForm />
+      <Modal isOpen onClose={() => router.push('/tasks')} ariaLabelledby="task-form-title">
+        <TaskForm />
+      </Modal>
     </Layout>
   )
 }


### PR DESCRIPTION
## Summary
- redesign task form with labeled fields, placeholders, validation and color-coded priority/status
- show task form in accessible modal for new and existing tasks
- style modal overlay and actions buttons to match design

## Testing
- `npx vitest run`
- `npx vitest run app/components/tasks/TaskForm.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b07b5147448329bd6e9b81a07abcf1