### PR TITLE
Fix metadata export in new task page

### DIFF
--- a/dashboard-ui/app/tasks/new/metadata.ts
+++ b/dashboard-ui/app/tasks/new/metadata.ts
@@ -1,0 +1,5 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'New Task',
+}

--- a/dashboard-ui/app/tasks/new/page.tsx
+++ b/dashboard-ui/app/tasks/new/page.tsx
@@ -4,11 +4,6 @@ import { useRouter } from 'next/navigation'
 import Layout from '@/ui/Layout'
 import TaskForm from '@/components/tasks/TaskForm'
 import Modal from '@/ui/Modal/Modal'
-import type { Metadata } from 'next'
-
-export const metadata: Metadata = {
-  title: 'New Task',
-}
 
 export default function NewTaskPage() {
   const router = useRouter()


### PR DESCRIPTION
## Summary
- move New Task page metadata into separate metadata.ts to satisfy use client restrictions

## Testing
- `yarn --cwd dashboard-ui lint`
- `yarn --cwd dashboard-ui test`


------
https://chatgpt.com/codex/tasks/task_e_68b07e29ebfc832981f1027255f8b00f