### PR TITLE
feat: add task info modal

### DIFF
--- a/dashboard-ui/app/components/tasks/TaskInfoModal.tsx
+++ b/dashboard-ui/app/components/tasks/TaskInfoModal.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useRef, useState, useId } from 'react'
+import { createPortal } from 'react-dom'
+import {
+  ITask,
+  TaskPriority,
+  TaskStatus,
+} from '@/shared/interfaces/task.interface'
+
+const chipBase =
+  'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium whitespace-nowrap'
+
+interface Props {
+  task: ITask
+  onClose: () => void
+}
+
+const TaskInfoModal = ({ task, onClose }: Props) => {
+  const [open, setOpen] = useState(false)
+  const closeRef = useRef<HTMLButtonElement | null>(null)
+  const titleId = useId()
+
+  useEffect(() => {
+    setOpen(true)
+    closeRef.current?.focus()
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const deadlineDate = new Date(task.deadline)
+  deadlineDate.setHours(0, 0, 0, 0)
+  const overdue = deadlineDate < today
+  const todayMatch = deadlineDate.getTime() === today.getTime()
+  const deadlineColor = overdue
+    ? 'text-error'
+    : todayMatch
+    ? 'text-warning'
+    : 'text-neutral-900'
+
+  const priorityClasses: Record<TaskPriority, string> = {
+    [TaskPriority.High]: 'bg-error/10 text-error',
+    [TaskPriority.Medium]: 'bg-warning/10 text-warning',
+    [TaskPriority.Low]: 'bg-success/10 text-success',
+  }
+
+  const statusClasses: Record<TaskStatus, string> = {
+    [TaskStatus.InProgress]: 'bg-info/10 text-info',
+    [TaskStatus.Completed]: 'bg-success/10 text-success',
+    [TaskStatus.Pending]: 'bg-neutral-300 text-neutral-900',
+  }
+
+  const initials = task.executor
+    ? task.executor
+        .split(' ')
+        .map(w => w[0])
+        .join('')
+        .toUpperCase()
+    : ''
+
+  return createPortal(
+    <>
+      <div className="fixed inset-0 bg-neutral-950/40 z-40" onClick={onClose} />
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+        <div
+          role="dialog"
+          aria-modal
+          aria-labelledby={titleId}
+          className={`relative rounded-3xl bg-neutral-200 p-5 md:p-6 shadow-card max-w-lg w-full transition-transform duration-200 ${open ? 'scale-100 opacity-100' : 'scale-95 opacity-0'}`}
+        >
+          <button
+            ref={closeRef}
+            aria-label="Закрыть"
+            onClick={onClose}
+            type="button"
+            className="absolute top-4 right-4 p-1 rounded hover:bg-neutral-300"
+          >
+            ✕
+          </button>
+          <h2 id={titleId} className="text-lg md:text-xl font-semibold mb-4">
+            {task.title}
+          </h2>
+          <div className="space-y-3">
+            <div>
+              <p className="text-sm text-neutral-800">Описание</p>
+              <p className="text-base text-neutral-900">{task.description || '-'}</p>
+            </div>
+            <div>
+              <p className="text-sm text-neutral-800">Исполнитель</p>
+              {task.executor ? (
+                <div className="flex items-center gap-2">
+                  <div className="w-8 h-8 rounded-full bg-neutral-300 text-neutral-900 text-sm font-semibold flex items-center justify-center">
+                    {initials}
+                  </div>
+                  <span className="text-base text-neutral-900">{task.executor}</span>
+                </div>
+              ) : (
+                <p className="text-base text-neutral-900">-</p>
+              )}
+            </div>
+            <div>
+              <p className="text-sm text-neutral-800">Дедлайн</p>
+              <p className={`text-base ${deadlineColor}`}>
+                {deadlineDate.toLocaleDateString('ru-RU')}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm text-neutral-800">Приоритет</p>
+              <span className={`${chipBase} ${priorityClasses[task.priority]}`}>
+                {task.priority}
+              </span>
+            </div>
+            <div>
+              <p className="text-sm text-neutral-800">Статус</p>
+              <span className={`${chipBase} ${statusClasses[task.status]}`}>
+                {task.status}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>,
+    document.body
+  )
+}
+
+export default TaskInfoModal
+

--- a/dashboard-ui/app/components/tasks/TasksTable.test.tsx
+++ b/dashboard-ui/app/components/tasks/TasksTable.test.tsx
@@ -51,4 +51,16 @@ describe('TasksTable', () => {
       expect(screen.queryByText('Task 1')).not.toBeInTheDocument()
     })
   })
+
+  it('opens task info modal on row click and closes with ESC', async () => {
+    render(<TasksTable />)
+    const cell = await screen.findByText('Task 1')
+    await userEvent.click(cell)
+    const dialog = await screen.findByRole('dialog', { name: /task 1/i })
+    expect(dialog).toBeInTheDocument()
+    await userEvent.keyboard('{Escape}')
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/dashboard-ui/app/components/tasks/TasksTable.tsx
+++ b/dashboard-ui/app/components/tasks/TasksTable.tsx
@@ -13,6 +13,7 @@ import {
   TaskPriority,
   TaskStatus,
 } from '@/shared/interfaces/task.interface'
+import TaskInfoModal from './TaskInfoModal'
 
 const chipBase =
   'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium whitespace-nowrap'
@@ -32,6 +33,8 @@ const TasksTable = () => {
   const menuItemsRef = useRef<HTMLElement[]>([])
   const [confirmId, setConfirmId] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [viewTask, setViewTask] = useState<ITask | null>(null)
+  const returnFocusRef = useRef<HTMLElement | null>(null)
   const pathname = usePathname()
 
   useEffect(() => {
@@ -244,10 +247,33 @@ const TasksTable = () => {
             return (
               <tr
                 key={task.id}
+                tabIndex={-1}
                 className="border-b border-neutral-200 hover:bg-neutral-200/50 transition-colors odd:bg-neutral-100 even:bg-neutral-200"
+                onClick={e => {
+                  if ((e.target as HTMLElement).closest('button')) return
+                  returnFocusRef.current = e.currentTarget as HTMLElement
+                  setViewTask(task)
+                }}
               >
-                <td className="p-2 max-w-[32ch] truncate" title={task.title}>
-                  <Link href={`/tasks/${task.id}`}>{task.title}</Link>
+                <td
+                  className="p-2 max-w-[32ch] truncate"
+                  title={task.title}
+                >
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      aria-label="Информация"
+                      className="shrink-0"
+                      onClick={e => {
+                        e.stopPropagation()
+                        returnFocusRef.current = e.currentTarget as HTMLElement
+                        setViewTask(task)
+                      }}
+                    >
+                      <span aria-hidden>ℹ️</span>
+                    </button>
+                    <span>{task.title}</span>
+                  </div>
                 </td>
                 <td className="p-2">
                   {task.executor ? (
@@ -378,6 +404,15 @@ const TasksTable = () => {
           </div>,
           document.body
         )}
+      {viewTask && (
+        <TaskInfoModal
+          task={viewTask}
+          onClose={() => {
+            setViewTask(null)
+            returnFocusRef.current?.focus()
+          }}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- open task info modal from tasks table
- show task details in non-editable modal
- add tests for info modal

## Testing
- `yarn test`
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_68b08069aa0c83298f1fee3d71a83057