### PR TITLE
feat(tasks): make rows clickable

### DIFF
--- a/dashboard-ui/app/components/tasks/TasksTable.tsx
+++ b/dashboard-ui/app/components/tasks/TasksTable.tsx
@@ -248,7 +248,7 @@ const TasksTable = () => {
               <tr
                 key={task.id}
                 tabIndex={-1}
-                className="border-b border-neutral-200 hover:bg-neutral-200/50 transition-colors odd:bg-neutral-100 even:bg-neutral-200"
+                className="cursor-pointer border-b border-neutral-200 hover:bg-neutral-200/60 transition-colors odd:bg-neutral-100 even:bg-neutral-200"
                 onClick={e => {
                   if ((e.target as HTMLElement).closest('button')) return
                   returnFocusRef.current = e.currentTarget as HTMLElement
@@ -259,21 +259,7 @@ const TasksTable = () => {
                   className="p-2 max-w-[32ch] truncate"
                   title={task.title}
                 >
-                  <div className="flex items-center gap-1">
-                    <button
-                      type="button"
-                      aria-label="Информация"
-                      className="shrink-0"
-                      onClick={e => {
-                        e.stopPropagation()
-                        returnFocusRef.current = e.currentTarget as HTMLElement
-                        setViewTask(task)
-                      }}
-                    >
-                      <span aria-hidden>ℹ️</span>
-                    </button>
-                    <span>{task.title}</span>
-                  </div>
+                  {task.title}
                 </td>
                 <td className="p-2">
                   {task.executor ? (
@@ -323,7 +309,7 @@ const TasksTable = () => {
                       anchorRef.current = e.currentTarget
                       setOpenMenuTaskId(task.id)
                     }}
-                    className="p-1 rounded hover:bg-neutral-200"
+                    className="p-1 rounded hover:bg-neutral-200 cursor-default"
                   >
                     <HiDotsVertical />
                   </button>


### PR DESCRIPTION
## Summary
- make task rows appear clickable by adding pointer and hover background
- keep action menu button with default cursor and remove per-row info icon

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b082c23f208329869e8184c548351b