### PR TITLE
Redirect to new Reports page

### DIFF
--- a/dashboard-ui/app/components/dashboard/KpiCards.tsx
+++ b/dashboard-ui/app/components/dashboard/KpiCards.tsx
@@ -53,7 +53,7 @@ const KpiCards: React.FC = () => {
     {
       label: "Выручка",
       value: currency.format(revenue),
-      href: "/reports",
+      href: "/reports/new",
       text: "text-success",
       bg: "bg-success/20",
       Icon: FaRubleSign,
@@ -61,7 +61,7 @@ const KpiCards: React.FC = () => {
     {
       label: "Кол-во продаж",
       value: salesCount.toLocaleString("ru-RU"),
-      href: "/reports",
+      href: "/reports/new",
       text: "text-info",
       bg: "bg-info/20",
       Icon: FaShoppingCart,
@@ -69,7 +69,7 @@ const KpiCards: React.FC = () => {
     {
       label: "Средний чек",
       value: currency.format(avgCheck),
-      href: "/reports",
+      href: "/reports/new",
       text: "text-secondary-700",
       bg: "bg-secondary-300/40",
       Icon: FaReceipt,

--- a/dashboard-ui/app/components/ui/header/Header.tsx
+++ b/dashboard-ui/app/components/ui/header/Header.tsx
@@ -23,7 +23,7 @@ const Header: FC = () => {
           <Link href='/tasks' className={styles.link}>
             Задачи
           </Link>
-          <Link href='/reports' className={styles.link}>
+          <Link href='/reports/new' className={styles.link}>
             Отчёты
           </Link>
         </>

--- a/dashboard-ui/next.config.ts
+++ b/dashboard-ui/next.config.ts
@@ -11,6 +11,15 @@ const nextConfig: NextConfig = {
   images: {
     domains: ['localhost'],
   },
+  async redirects() {
+    return [
+      {
+        source: '/reports',
+        destination: '/reports/new',
+        permanent: false,
+      },
+    ]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- Link navigation components to the revamped Reports page
- Redirect `/reports` to `/reports/new` to surface the new view

## Testing
- `yarn --cwd dashboard-ui lint`
- `yarn --cwd dashboard-ui test`
- `yarn --cwd server lint` *(fails: Key "rules": Key "@typescript-eslint/no-extraneous-class": Unexpected property "allowEmptyCase".)*
- `yarn --cwd server test`


------
https://chatgpt.com/codex/tasks/task_e_68b08eabc5688329b14a5c2531df4bbf