### PR TITLE
feat: revamp reports page with filterable data

### DIFF
--- a/dashboard-ui/app/components/ui/Select/Select.tsx
+++ b/dashboard-ui/app/components/ui/Select/Select.tsx
@@ -13,6 +13,7 @@ export default function Select({
   loading,
   error,
   onRetry,
+  dropdownClassName,
 }: ISelectProps) {
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
@@ -65,7 +66,11 @@ export default function Select({
         )}
       </div>
       {open && (
-        <div className='absolute z-10 mt-1 max-h-60 overflow-auto bg-white border border-neutral-300 rounded shadow w-full'>
+        <div
+          className={`absolute z-10 mt-1 overflow-auto bg-white border border-neutral-300 rounded shadow w-full ${
+            dropdownClassName || 'max-h-60'
+          }`}
+        >
           {loading ? (
             <div className='p-2 text-sm text-neutral-500'>Loading...</div>
           ) : error ? (

--- a/dashboard-ui/app/components/ui/Select/select.interface.ts
+++ b/dashboard-ui/app/components/ui/Select/select.interface.ts
@@ -11,4 +11,9 @@ export interface ISelectProps {
   loading?: boolean
   error?: string
   onRetry?: () => void
+  /**
+   * Additional classes for the dropdown menu. Allows
+   * consumers to control max height/overflow behaviour.
+   */
+  dropdownClassName?: string
 }

--- a/dashboard-ui/app/reports/SalesTab.tsx
+++ b/dashboard-ui/app/reports/SalesTab.tsx
@@ -1,83 +1,190 @@
 'use client'
 
-import { FC } from 'react'
+import { FC, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  Legend,
+  ReferenceLine,
+} from 'recharts'
+
+import { AnalyticsService } from '@/services/analytics/analytics.service'
 import { formatCurrency } from '@/utils/formatCurrency'
+import { ISalesStat } from '@/shared/interfaces/sales-stat.interface'
+import { ITopProduct } from '@/shared/interfaces/top-product.interface'
 
-interface RevenueItem {
-  date: string
-  value: number
+interface Filters {
+  from: string
+  to: string
+  categories: number[]
 }
 
-interface TopProduct {
-  name: string
-  revenue: number
+interface Props {
+  filters: Filters
 }
 
-interface SalesTabProps {
-  revenueData: RevenueItem[]
-  topProducts: TopProduct[]
-  totalRevenue: number
-}
+const SalesTab: FC<Props> = ({ filters }) => {
+  const [metric, setMetric] = useState<'revenue' | 'count'>('revenue')
 
-const SalesTab: FC<SalesTabProps> = ({ revenueData, topProducts, totalRevenue }) => {
-  const topRevenue = topProducts.reduce((sum, p) => sum + p.revenue, 0)
-  const share = totalRevenue ? (topRevenue / totalRevenue) * 100 : 0
-  const maxRevenue = Math.max(0, ...topProducts.map(p => p.revenue))
-  const maxValue = Math.max(0, ...revenueData.map(r => r.value))
+  const {
+    data: sales,
+    isLoading: salesLoading,
+    error: salesError,
+    refetch: refetchSales,
+  } = useQuery<ISalesStat[], Error>({
+    queryKey: ['reports', 'sales-chart', metric, filters],
+    queryFn: () =>
+      metric === 'revenue'
+        ? AnalyticsService.getDailyRevenue(
+            filters.from,
+            filters.to,
+            filters.categories,
+          )
+        : AnalyticsService.getSales(
+            filters.from,
+            filters.to,
+            filters.categories,
+          ),
+    enabled: Boolean(filters.from && filters.to),
+  })
 
-  const linePoints = revenueData
-    .map((r, idx) => {
-      const x = (idx / Math.max(1, revenueData.length - 1)) * 100
-      const y = maxValue ? 100 - (r.value / maxValue) * 100 : 100
-      return `${x},${y}`
-    })
-    .join(' ')
+  const {
+    data: topProducts,
+    isLoading: topLoading,
+    error: topError,
+    refetch: refetchTop,
+  } = useQuery<ITopProduct[], Error>({
+    queryKey: ['reports', 'top-products', filters],
+    queryFn: () =>
+      AnalyticsService.getTopProducts(
+        10,
+        filters.from,
+        filters.to,
+        filters.categories,
+      ),
+    enabled: Boolean(filters.from && filters.to),
+  })
+
+  const chartData = (sales ?? []).map(s => ({ date: s.date, value: s.total }))
+  const allZero = chartData.length === 0 || chartData.every(d => d.value === 0)
 
   return (
     <div className='space-y-6'>
-      <div
-        className='p-4 bg-white rounded shadow cursor-pointer'
-        onClick={() => alert('Открыть детали выручки')}
-      >
-        <div className='font-medium mb-2'>Выручка по дням</div>
-        <svg viewBox='0 0 100 100' className='w-full h-24'>
-          <polyline
-            fill='none'
-            stroke='currentColor'
-            strokeWidth='2'
-            points={linePoints}
-            className='text-primary-500'
-          />
-        </svg>
+      <div className='rounded-2xl bg-neutral-200 p-4 shadow-card'>
+        <div className='flex items-center justify-between mb-3'>
+          <h3 className='font-medium'>График продаж</h3>
+          <div className='flex gap-2'>
+            <button
+              className={`px-2 py-1 text-sm rounded transition-colors cursor-pointer ${
+                metric === 'revenue'
+                  ? 'bg-primary-500 text-white'
+                  : 'bg-white'
+              }`}
+              onClick={() => setMetric('revenue')}
+              aria-pressed={metric === 'revenue'}
+            >
+              Выручка
+            </button>
+            <button
+              className={`px-2 py-1 text-sm rounded transition-colors cursor-pointer ${
+                metric === 'count'
+                  ? 'bg-primary-500 text-white'
+                  : 'bg-white'
+              }`}
+              onClick={() => setMetric('count')}
+              aria-pressed={metric === 'count'}
+            >
+              Кол-во
+            </button>
+          </div>
+        </div>
+        <div className='h-64 relative'>
+          {salesLoading ? (
+            <div className='absolute inset-0 flex items-center justify-center text-sm text-neutral-500'>
+              Загрузка...
+            </div>
+          ) : salesError ? (
+            <div className='absolute inset-0 flex items-center justify-center text-sm text-red-600'>
+              Ошибка{' '}
+              <button className='underline' onClick={() => refetchSales()}>
+                Повторить
+              </button>
+            </div>
+          ) : (
+            <ResponsiveContainer width='100%' height='100%'>
+              <LineChart data={chartData} margin={{ left: 8, right: 8 }}>
+                <CartesianGrid strokeDasharray='3 3' stroke='#e5e7eb' />
+                <XAxis dataKey='date' tick={{ fontSize: 12 }} tickLine={false} axisLine={false} />
+                <YAxis
+                  tick={{ fontSize: 12 }}
+                  tickFormatter={v =>
+                    metric === 'revenue' ? formatCurrency(v as number) : String(v)
+                  }
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <Tooltip
+                  formatter={value =>
+                    metric === 'revenue'
+                      ? formatCurrency(value as number)
+                      : (value as number).toLocaleString('ru-RU')
+                  }
+                  labelFormatter={label => label}
+                />
+                <Legend wrapperStyle={{ fontSize: 12 }} />
+                <Line
+                  type='monotone'
+                  dataKey='value'
+                  stroke={metric === 'revenue' ? '#3B82F6' : '#10B981'}
+                  strokeWidth={2}
+                  dot={false}
+                  name={metric === 'revenue' ? 'Выручка' : 'Количество'}
+                />
+                {allZero && <ReferenceLine y={0} stroke='#EF4444' strokeWidth={1} />}
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+          {allZero && !salesLoading && !salesError && (
+            <div className='absolute inset-0 flex items-center justify-center text-neutral-500'>
+              Нет данных
+            </div>
+          )}
+        </div>
       </div>
 
-      <div className='p-4 bg-white rounded shadow space-y-2'>
-        <div className='font-medium'>Топ-10 товаров по выручке</div>
-        {topProducts.map(p => (
-          <div
-            key={p.name}
-            className='flex items-center cursor-pointer'
-            onClick={() => alert(`Открыть детали ${p.name}`)}
-          >
-            <span className='w-32 text-sm'>{p.name}</span>
-            <div className='flex-1 bg-neutral-200 h-2 mr-2'>
-              <div
-                className='bg-primary-500 h-2'
-                style={{ width: `${maxRevenue ? (p.revenue / maxRevenue) * 100 : 0}%` }}
-              />
-            </div>
-            <span className='text-sm'>{formatCurrency(p.revenue)}</span>
+      <div className='rounded-2xl bg-neutral-200 p-4 shadow-card'>
+        <h3 className='font-medium mb-2'>Топ-10 товаров</h3>
+        {topLoading ? (
+          <div className='text-sm text-neutral-500'>Загрузка...</div>
+        ) : topError ? (
+          <div className='text-sm text-red-600'>
+            Ошибка{' '}
+            <button className='underline' onClick={() => refetchTop()}>
+              Повторить
+            </button>
           </div>
-        ))}
-        <div
-          className='text-sm mt-2 cursor-pointer'
-          onClick={() => alert('Открыть долю топовых товаров')}
-        >
-          Доля топ-10 товаров: {share.toFixed(1)}%
-        </div>
+        ) : topProducts && topProducts.length > 0 ? (
+          <ul className='space-y-1'>
+            {topProducts.map(p => (
+              <li key={p.productId} className='flex justify-between text-sm'>
+                <span>{p.productName}</span>
+                <span>{formatCurrency(p.totalRevenue)}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className='text-sm text-neutral-500'>Нет данных</div>
+        )}
       </div>
     </div>
   )
 }
 
 export default SalesTab
+

--- a/dashboard-ui/app/reports/TasksTab.tsx
+++ b/dashboard-ui/app/reports/TasksTab.tsx
@@ -1,28 +1,65 @@
 'use client'
 
 import { FC } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { TaskService } from '@/services/task/task.service'
+import { ITask, TaskStatus } from '@/shared/interfaces/task.interface'
 
-interface TasksTabProps {
-  completed: number
-  prevCompleted: number
+interface Filters {
+  from: string
+  to: string
 }
 
-const TasksTab: FC<TasksTabProps> = ({ completed, prevCompleted }) => {
-  const diff = completed - prevCompleted
-  const isGrowth = diff >= 0
+interface Props {
+  filters: Filters
+}
+
+const TasksTab: FC<Props> = ({ filters }) => {
+  const {
+    data: tasks,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery<ITask[], Error>({
+    queryKey: ['reports', 'tasks', filters],
+    queryFn: () => TaskService.getAll({ start: filters.from, end: filters.to }),
+    enabled: Boolean(filters.from && filters.to),
+  })
+
+  const completed = tasks?.filter(t => t.status === TaskStatus.Completed).length ?? 0
+  const overdue =
+    tasks?.filter(
+      t =>
+        t.status !== TaskStatus.Completed &&
+        new Date(t.deadline) < new Date(),
+    ).length ?? 0
 
   return (
-    <div
-      className='p-4 bg-white rounded shadow cursor-pointer'
-      onClick={() => alert('Открыть задачи')}
-    >
-      <div className='font-medium'>Выполненные задачи</div>
-      <div className='text-3xl font-semibold'>{completed}</div>
-      <div className={`text-sm ${isGrowth ? 'text-green-600' : 'text-red-600'}`}>
-        {isGrowth ? '+' : ''}{diff} от предыдущего периода
-      </div>
+    <div className='space-y-6'>
+      {isLoading ? (
+        <div className='text-sm text-neutral-500'>Загрузка...</div>
+      ) : error ? (
+        <div className='text-sm text-red-600'>
+          Ошибка{' '}
+          <button className='underline' onClick={() => refetch()}>
+            Повторить
+          </button>
+        </div>
+      ) : (
+        <div className='flex gap-4'>
+          <div className='rounded-2xl bg-neutral-200 p-4 shadow-card'>
+            <div className='text-sm'>Выполненные</div>
+            <div className='text-2xl font-semibold'>{completed}</div>
+          </div>
+          <div className='rounded-2xl bg-neutral-200 p-4 shadow-card'>
+            <div className='text-sm'>Просроченные</div>
+            <div className='text-2xl font-semibold'>{overdue}</div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }
 
 export default TasksTab
+

--- a/dashboard-ui/app/reports/WarehouseTab.tsx
+++ b/dashboard-ui/app/reports/WarehouseTab.tsx
@@ -1,95 +1,91 @@
 'use client'
 
 import { FC } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { AnalyticsService } from '@/services/analytics/analytics.service'
+import { IProduct } from '@/shared/interfaces/product.interface'
 
-interface Stats {
-  initial: number
-  arrival: number
-  departure: number
-  final: number
+interface Filters {
+  categories: number[]
 }
 
-interface MovementItem {
-  date: string
-  direction: 'arrival' | 'departure'
-  product: string
-  article: string
-  quantity: number
-  reason: string
+interface Props {
+  filters: Filters
 }
 
-interface WarehouseTabProps {
-  stats: Stats
-  movements: MovementItem[]
-}
+const WarehouseTab: FC<Props> = ({ filters }) => {
+  const {
+    data: remains,
+    isLoading: remainsLoading,
+    error: remainsError,
+    refetch: refetchRemains,
+  } = useQuery<number, Error>({
+    queryKey: ['reports', 'warehouse', 'remains', filters],
+    queryFn: () => AnalyticsService.getProductRemains(),
+  })
 
-const WarehouseTab: FC<WarehouseTabProps> = ({ stats, movements }) => {
+  const {
+    data: lowStock,
+    isLoading: lowLoading,
+    error: lowError,
+    refetch: refetchLow,
+  } = useQuery<IProduct[], Error>({
+    queryKey: ['reports', 'warehouse', 'low', filters],
+    queryFn: () => AnalyticsService.getLowStock(10, filters.categories),
+  })
+
   return (
     <div className='space-y-6'>
-      <div className='grid grid-cols-2 md:grid-cols-4 gap-4'>
-        <div
-          className='p-4 bg-white rounded shadow cursor-pointer'
-          onClick={() => alert('Открыть начальный остаток')}
-        >
-          <div className='text-sm'>Начальный остаток на складе</div>
-          <div className='text-xl font-semibold'>{stats.initial}</div>
-        </div>
-        <div
-          className='p-4 bg-white rounded shadow cursor-pointer'
-          onClick={() => alert('Открыть поступления')}
-        >
-          <div className='text-sm'>Поступление товара</div>
-          <div className='text-xl font-semibold text-green-600'>{stats.arrival}</div>
-        </div>
-        <div
-          className='p-4 bg-white rounded shadow cursor-pointer'
-          onClick={() => alert('Открыть расход')}
-        >
-          <div className='text-sm'>Списание товара</div>
-          <div className='text-xl font-semibold text-red-600'>{stats.departure}</div>
-        </div>
-        <div
-          className='p-4 bg-white rounded shadow cursor-pointer'
-          onClick={() => alert('Открыть конечный остаток')}
-        >
-          <div className='text-sm'>Конечный остаток на складе</div>
-          <div className='text-xl font-semibold'>{stats.final}</div>
-        </div>
+      <div className='rounded-2xl bg-neutral-200 p-4 shadow-card'>
+        {remainsLoading ? (
+          <div className='text-sm text-neutral-500'>Загрузка...</div>
+        ) : remainsError ? (
+          <div className='text-sm text-red-600'>
+            Ошибка{' '}
+            <button className='underline' onClick={() => refetchRemains()}>
+              Повторить
+            </button>
+          </div>
+        ) : (
+          <div className='text-sm'>Общий остаток: {remains}</div>
+        )}
       </div>
 
-      <div className='p-4 bg-white rounded shadow overflow-x-auto'>
-        <div className='font-medium mb-2'>Движение товара</div>
-        <table className='w-full text-sm'>
-          <thead>
-            <tr className='text-left'>
-              <th className='py-1 pr-2'>Дата</th>
-              <th className='py-1 pr-2'>Товар</th>
-              <th className='py-1 pr-2'>Артикул</th>
-              <th className='py-1 pr-2 text-right'>Приход</th>
-              <th className='py-1 pr-2 text-right'>Расход</th>
-              <th className='py-1 pr-2'>Причина</th>
-            </tr>
-          </thead>
-          <tbody>
-            {movements.map(m => (
-              <tr key={`${m.date}-${m.article}`} className='border-t'>
-                <td className='py-1 pr-2'>{m.date}</td>
-                <td className='py-1 pr-2'>{m.product}</td>
-                <td className='py-1 pr-2'>{m.article}</td>
-                <td className='py-1 pr-2 text-right text-green-600'>
-                  {m.direction === 'arrival' ? m.quantity : ''}
-                </td>
-                <td className='py-1 pr-2 text-right text-red-600'>
-                  {m.direction === 'departure' ? m.quantity : ''}
-                </td>
-                <td className='py-1 pr-2'>{m.reason}</td>
+      <div className='rounded-2xl bg-neutral-200 p-4 shadow-card'>
+        <h3 className='font-medium mb-2'>Мало/нет на складе</h3>
+        {lowLoading ? (
+          <div className='text-sm text-neutral-500'>Загрузка...</div>
+        ) : lowError ? (
+          <div className='text-sm text-red-600'>
+            Ошибка{' '}
+            <button className='underline' onClick={() => refetchLow()}>
+              Повторить
+            </button>
+          </div>
+        ) : lowStock && lowStock.length > 0 ? (
+          <table className='w-full text-sm'>
+            <thead>
+              <tr className='text-left'>
+                <th className='py-1 pr-2'>Товар</th>
+                <th className='py-1 pr-2 text-right'>Остаток</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {lowStock.map(p => (
+                <tr key={p.id} className='border-t'>
+                  <td className='py-1 pr-2'>{p.name}</td>
+                  <td className='py-1 pr-2 text-right'>{p.remains}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <div className='text-sm text-neutral-500'>Нет данных</div>
+        )}
       </div>
     </div>
   )
 }
 
 export default WarehouseTab
+

--- a/dashboard-ui/app/reports/page.tsx
+++ b/dashboard-ui/app/reports/page.tsx
@@ -1,251 +1,289 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
-import classNames from 'classnames'
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useQuery } from '@tanstack/react-query'
+
 import Layout from '@/ui/Layout'
+import Select from '@/ui/Select/Select'
+import { CategoryService } from '@/services/category/category.service'
+import { AnalyticsService } from '@/services/analytics/analytics.service'
 import SalesTab from './SalesTab'
 import WarehouseTab from './WarehouseTab'
 import TasksTab from './TasksTab'
-import { formatCurrency } from '@/utils/formatCurrency'
-import { CategoryService } from '@/services/category/category.service'
-import { AnalyticsService } from '@/services/analytics/analytics.service'
 import { ICategory } from '@/shared/interfaces/category.interface'
-import Select from '@/ui/Select/Select'
+import { formatCurrency } from '@/utils/formatCurrency'
 
-const tabs = [
-  { key: 'sales', label: 'Продажи' },
-  { key: 'warehouse', label: 'Склад' },
-  { key: 'tasks', label: 'Задачи' },
+const presets = [
+  { label: 'Сегодня', value: 'today' },
+  { label: '7 дней', value: '7d' },
+  { label: '30 дней', value: '30d' },
+  { label: 'Этот месяц', value: 'month' },
+  { label: 'Произвольный', value: 'custom' },
 ] as const
 
-type TabKey = (typeof tabs)[number]['key']
+type Preset = (typeof presets)[number]['value']
 
 function formatDate(d: Date) {
   return d.toISOString().split('T')[0]
 }
 
-function toCsv(rows: any[]): string {
-  if (!rows.length) return ''
-  const headers = Object.keys(rows[0])
-  const csv = [headers.join(',')]
-  rows.forEach(r => {
-    csv.push(headers.map(h => JSON.stringify((r as any)[h] ?? '')).join(','))
-  })
-  return csv.join('\n')
+function getRange(preset: Preset) {
+  const now = new Date()
+  let start = new Date(now)
+  let end = new Date(now)
+  switch (preset) {
+    case '7d':
+      start.setDate(now.getDate() - 6)
+      break
+    case '30d':
+      start.setDate(now.getDate() - 29)
+      break
+    case 'month':
+      start = new Date(now.getFullYear(), now.getMonth(), 1)
+      end = new Date(now.getFullYear(), now.getMonth() + 1, 0)
+      break
+    default:
+      break
+  }
+  return { from: formatDate(start), to: formatDate(end) }
 }
 
-const warehouseStats = { initial: 1200, arrival: 300, departure: 200, final: 1300 }
-const warehouseMovement = [
-  {
-    date: '2025-08-05',
-    direction: 'arrival' as const,
-    product: 'Ноутбук',
-    article: 'NB-01',
-    quantity: 30,
-    reason: 'Поставка',
-  },
-  {
-    date: '2025-08-06',
-    direction: 'departure' as const,
-    product: 'Телефон',
-    article: 'PH-02',
-    quantity: 12,
-    reason: 'Продажа',
-  },
-  {
-    date: '2025-08-07',
-    direction: 'arrival' as const,
-    product: 'Стол',
-    article: 'ST-01',
-    quantity: 5,
-    reason: 'Возврат',
-  },
-  {
-    date: '2025-08-08',
-    direction: 'departure' as const,
-    product: 'Диван',
-    article: 'DV-05',
-    quantity: 2,
-    reason: 'Списание',
-  },
-  {
-    date: '2025-08-09',
-    direction: 'arrival' as const,
-    product: 'Куртка',
-    article: 'KT-03',
-    quantity: 20,
-    reason: 'Поставка',
-  },
-]
-
-const tasksStats = { current: 42, previous: 35 }
+interface Filters {
+  from: string
+  to: string
+  preset: Preset
+  categories: number[]
+}
 
 export default function ReportsPage() {
-  const [active, setActive] = useState<TabKey>('sales')
-  const [period, setPeriod] = useState<'day' | 'week' | 'month' | 'custom'>('week')
-  const [start, setStart] = useState('')
-  const [end, setEnd] = useState('')
-  const [categories, setCategories] = useState<ICategory[]>([])
-  const [selectedCategories, setSelectedCategories] = useState<number[]>([])
-  const [catLoading, setCatLoading] = useState(false)
-  const [catError, setCatError] = useState(false)
-  const [revenueData, setRevenueData] = useState<{ date: string; value: number }[]>([])
-  const [topProducts, setTopProducts] = useState<{ name: string; revenue: number }[]>([])
+  const router = useRouter()
+  const STORAGE_KEY = 'reports.filters'
 
-  const loadCategories = () => {
-    setCatLoading(true)
-    setCatError(false)
-    CategoryService.getAll()
-      .then(data => {
-        setCategories(data)
-      })
-      .catch(() => setCatError(true))
-      .finally(() => setCatLoading(false))
-  }
+  const [preset, setPreset] = useState<Preset>('today')
+  const [from, setFrom] = useState('')
+  const [to, setTo] = useState('')
+  const [categories, setCategories] = useState<number[]>([])
+  const [appliedFilters, setAppliedFilters] = useState<Filters>({
+    from: '',
+    to: '',
+    preset: 'today',
+    categories: [],
+  })
+  const [active, setActive] = useState<'sales' | 'warehouse' | 'tasks'>('sales')
+  const [categoryOptions, setCategoryOptions] = useState<ICategory[]>([])
+  const [exporting, setExporting] = useState(false)
 
   useEffect(() => {
-    loadCategories()
+    CategoryService.getAll().then(setCategoryOptions)
   }, [])
 
   useEffect(() => {
-    const today = new Date()
-    let s = formatDate(today)
-    let e = formatDate(today)
-    if (period === 'week') {
-      const sDate = new Date(today)
-      sDate.setDate(sDate.getDate() - 6)
-      s = formatDate(sDate)
-    } else if (period === 'month') {
-      const sDate = new Date(today)
-      sDate.setDate(sDate.getDate() - 29)
-      s = formatDate(sDate)
-    }
-    if (period !== 'custom') {
-      setStart(s)
-      setEnd(e)
-    }
-  }, [period])
+    const params = new URLSearchParams(window.location.search)
+    const stored = localStorage.getItem(STORAGE_KEY)
+    const parsed = stored ? JSON.parse(stored) : null
+    const pr = (params.get('preset') as Preset) || parsed?.preset || 'today'
+    const range = getRange(pr)
+    const f = params.get('from') || parsed?.from || range.from
+    const t = params.get('to') || parsed?.to || range.to
+    const cats = params.getAll('categories').map(Number)
+    const catArr = cats.length ? cats : parsed?.categories || []
+    setPreset(pr)
+    setFrom(f)
+    setTo(t)
+    setCategories(catArr)
+    setAppliedFilters({ from: f, to: t, preset: pr, categories: catArr })
+  }, [])
 
   useEffect(() => {
-    if (!start || !end) return
-    AnalyticsService.getDailyRevenue(start, end, selectedCategories).then(data => {
-      setRevenueData(data.map(r => ({ date: r.date, value: r.total })))
-    })
-    AnalyticsService.getTopProducts(10, start, end, selectedCategories).then(data => {
-      setTopProducts(data.map(p => ({ name: p.productName, revenue: p.totalRevenue })))
-    })
-  }, [start, end, selectedCategories])
+    if (preset !== 'custom') {
+      const range = getRange(preset)
+      setFrom(range.from)
+      setTo(range.to)
+    }
+  }, [preset])
 
-  const totalRevenue = useMemo(
-    () => revenueData.reduce((s, r) => s + r.value, 0),
-    [revenueData]
-  )
-
-  const handleExport = () => {
-    let data: any[] = []
-    if (active === 'sales') data = revenueData
-    else if (active === 'warehouse') data = warehouseMovement
-    else if (active === 'tasks') data = [{ date: start, completed: tasksStats.current }]
-
-    const csv = toCsv(data)
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement('a')
-    link.href = url
-    link.download = `${active}-${start}-${end}.csv`
-    link.click()
-    URL.revokeObjectURL(url)
+  const applyFilters = () => {
+    const filters = { from, to, preset, categories }
+    setAppliedFilters(filters)
+    const params = new URLSearchParams()
+    params.set('from', from)
+    params.set('to', to)
+    params.set('preset', preset)
+    categories.forEach(c => params.append('categories', String(c)))
+    router.replace(`?${params.toString()}`, { scroll: false })
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(filters))
   }
 
-  const kpis = [
-    { label: 'Выручка', value: totalRevenue, change: 0, currency: true },
-  ]
+  const resetFilters = () => {
+    const range = getRange('today')
+    setPreset('today')
+    setFrom(range.from)
+    setTo(range.to)
+    setCategories([])
+    const filters = { from: range.from, to: range.to, preset: 'today', categories: [] }
+    setAppliedFilters(filters)
+    router.replace('', { scroll: false })
+    localStorage.removeItem(STORAGE_KEY)
+  }
+
+  const {
+    data: kpis,
+    isLoading: kpisLoading,
+    error: kpisError,
+    refetch: refetchKpis,
+  } = useQuery({
+    queryKey: ['reports', 'kpis', appliedFilters],
+    queryFn: () =>
+      AnalyticsService.getKpis(
+        appliedFilters.from,
+        appliedFilters.to,
+        appliedFilters.categories,
+      ),
+    enabled: Boolean(appliedFilters.from && appliedFilters.to),
+  })
+
+  const kpiCards = kpis
+    ? [
+        { label: 'Выручка', value: kpis.revenue, currency: true },
+        { label: 'Количество заказов', value: kpis.orders },
+        { label: 'Проданные единицы', value: kpis.unitsSold },
+        { label: 'Средний чек', value: kpis.avgCheck, currency: true },
+        { label: 'Маржа', value: kpis.margin, currency: true },
+        { label: 'Выполненные задачи', value: kpis.completedTasks },
+      ]
+    : []
+
+  const handleExport = async () => {
+    if (!appliedFilters.from || !appliedFilters.to) return
+    setExporting(true)
+    try {
+      const [sales, top] = await Promise.all([
+        AnalyticsService.getDailyRevenue(
+          appliedFilters.from,
+          appliedFilters.to,
+          appliedFilters.categories,
+        ),
+        AnalyticsService.getTopProducts(
+          10,
+          appliedFilters.from,
+          appliedFilters.to,
+          appliedFilters.categories,
+        ),
+      ])
+      const rows: string[][] = []
+      rows.push(['Период', `${appliedFilters.from} - ${appliedFilters.to}`])
+      if (appliedFilters.categories.length) {
+        const names = categoryOptions
+          .filter(c => appliedFilters.categories.includes(c.id))
+          .map(c => c.name)
+          .join('; ')
+        rows.push(['Категории', names])
+      }
+      rows.push([])
+      rows.push(['Дата', 'Значение'])
+      sales.forEach(s => rows.push([s.date, String(s.total)]))
+      rows.push([])
+      rows.push(['Товар', 'Выручка'])
+      top.forEach(t => rows.push([t.productName, String(t.totalRevenue)]))
+      const csv = rows.map(r => r.join(',')).join('\n')
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+      const link = document.createElement('a')
+      link.href = URL.createObjectURL(blob)
+      link.download = `report-${appliedFilters.from}-${appliedFilters.to}.csv`
+      link.click()
+    } finally {
+      setExporting(false)
+    }
+  }
 
   return (
     <Layout>
       <div className='space-y-6'>
-        <div className='flex flex-wrap items-end gap-4'>
-          <div className='flex flex-col'>
-            <span className='text-sm'>Период</span>
-            <select
-              value={period}
-              onChange={e => setPeriod(e.target.value as any)}
-              className='border border-neutral-300 rounded px-2 py-1'
+        <div className='rounded-2xl bg-neutral-200 p-4 shadow-card'>
+          <div className='grid grid-cols-1 md:grid-cols-12 gap-3'>
+            <div className='md:col-span-6 flex flex-wrap gap-2'>
+              {presets.map(p => (
+                <button
+                  key={p.value}
+                  className={`px-3 py-1 text-sm rounded-full border cursor-pointer transition-colors ${
+                    preset === p.value
+                      ? 'bg-primary-500 text-white border-primary-500'
+                      : 'bg-white border-neutral-300'
+                  }`}
+                  onClick={() => setPreset(p.value)}
+                  aria-pressed={preset === p.value}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+            <div className='md:col-span-3 flex gap-2'>
+              <input
+                type='date'
+                value={from}
+                onChange={e => setFrom(e.target.value)}
+                className='border border-neutral-300 rounded px-2 py-1 w-full'
+              />
+              <input
+                type='date'
+                value={to}
+                onChange={e => setTo(e.target.value)}
+                className='border border-neutral-300 rounded px-2 py-1 w-full'
+              />
+            </div>
+            <div className='md:col-span-3'>
+              <Select
+                options={categoryOptions.map(c => ({ value: c.id, label: c.name }))}
+                value={categories}
+                onChange={setCategories}
+                placeholder='Категории'
+                dropdownClassName='max-h-40'
+              />
+            </div>
+          </div>
+          <div className='flex justify-end gap-2 mt-3'>
+            <button
+              onClick={applyFilters}
+              className='px-4 py-2 bg-primary-500 text-white rounded disabled:opacity-50'
+              disabled={kpisLoading}
             >
-              <option value='day'>День</option>
-              <option value='week'>Неделя</option>
-              <option value='month'>Месяц</option>
-              <option value='custom'>Произвольный</option>
-            </select>
+              Применить
+            </button>
+            <button
+              onClick={resetFilters}
+              className='px-4 py-2 border border-neutral-300 rounded'
+            >
+              Сбросить
+            </button>
           </div>
-          {period === 'custom' && (
-            <>
-              <label className='flex flex-col'>
-                <span className='text-sm'>Дата начала</span>
-                <input
-                  type='date'
-                  value={start}
-                  onChange={e => setStart(e.target.value)}
-                  className='border border-neutral-300 rounded px-2 py-1'
-                />
-              </label>
-              <label className='flex flex-col'>
-                <span className='text-sm'>Дата окончания</span>
-                <input
-                  type='date'
-                  value={end}
-                  onChange={e => setEnd(e.target.value)}
-                  className='border border-neutral-300 rounded px-2 py-1'
-                />
-              </label>
-            </>
-          )}
-          <div className='flex flex-col'>
-            <span className='text-sm'>Категории</span>
-            <Select
-              options={categories.map(c => ({ value: c.id, label: c.name }))}
-              value={selectedCategories}
-              onChange={setSelectedCategories}
-              placeholder='Select a category'
-              loading={catLoading}
-              error={catError ? 'Failed to load categories' : undefined}
-              onRetry={loadCategories}
-            />
-          </div>
+        </div>
+
+        <div className='flex justify-end'>
           <button
             onClick={handleExport}
-            className='ml-auto px-4 py-2 bg-primary-500 text-white rounded'
+            className='px-4 py-2 bg-primary-500 text-white rounded disabled:opacity-50'
+            disabled={exporting || kpisLoading}
           >
             Экспорт CSV
           </button>
         </div>
 
-        <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4'>
-          {kpis.map(k => (
-            <div key={k.label} className='p-4 bg-white rounded shadow'>
-              <div className='text-sm'>{k.label}</div>
-              <div className='text-2xl font-semibold'>
-                {k.currency
-                  ? formatCurrency(k.value)
-                  : k.value.toLocaleString(undefined, { maximumFractionDigits: 2 })}
-              </div>
-              <div
-                className={`text-sm ${k.change >= 0 ? 'text-green-600' : 'text-red-600'}`}
-              >
-                {k.change >= 0 ? '+' : ''}{k.change.toFixed(1)}%
-              </div>
-            </div>
-          ))}
-        </div>
-
-        <div className='flex space-x-4 border-b'>
-          {tabs.map(t => (
+        <div className='flex gap-3 border-b border-neutral-300 mb-3'>
+          {[
+            { key: 'sales', label: 'Продажи' },
+            { key: 'warehouse', label: 'Склад' },
+            { key: 'tasks', label: 'Задачи' },
+          ].map(t => (
             <button
               key={t.key}
-              onClick={() => setActive(t.key)}
-              className={classNames('py-2 px-4 -mb-px', {
-                'border-b-2 border-primary-500 font-medium': active === t.key,
-              })}
+              onClick={() => setActive(t.key as any)}
+              className={`px-3 py-2 rounded-t-lg text-sm font-medium cursor-pointer transition-colors ${
+                active === t.key
+                  ? 'bg-neutral-200 text-neutral-900 border border-neutral-300 border-b-transparent'
+                  : 'text-neutral-800 hover:bg-neutral-100'
+              }`}
+              aria-current={active === t.key ? 'page' : undefined}
             >
               {t.label}
             </button>
@@ -253,21 +291,40 @@ export default function ReportsPage() {
         </div>
 
         {active === 'sales' && (
-          <SalesTab
-            revenueData={revenueData}
-            topProducts={topProducts}
-            totalRevenue={totalRevenue}
-          />
+          <>
+            <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4 mb-6'>
+              {kpisLoading ? (
+                Array.from({ length: 6 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className='rounded-2xl bg-neutral-200 p-4 shadow-card animate-pulse h-20'
+                  />
+                ))
+              ) : kpisError ? (
+                <div className='col-span-full text-red-600 text-sm'>
+                  Ошибка загрузки{' '}
+                  <button className='underline' onClick={() => refetchKpis()}>
+                    Повторить
+                  </button>
+                </div>
+              ) : (
+                kpiCards.map(k => (
+                  <div key={k.label} className='rounded-2xl bg-neutral-200 p-4 shadow-card'>
+                    <div className='text-2xl font-semibold'>
+                      {k.currency ? formatCurrency(k.value) : k.value}
+                    </div>
+                    <div className='text-sm'>{k.label}</div>
+                  </div>
+                ))
+              )}
+            </div>
+            <SalesTab filters={appliedFilters} />
+          </>
         )}
-        {active === 'warehouse' && (
-          <WarehouseTab stats={warehouseStats} movements={warehouseMovement} />
-        )}
-        {active === 'tasks' && (
-          <TasksTab
-            completed={tasksStats.current}
-            prevCompleted={tasksStats.previous}
-          />
-        )}
+
+        {active === 'warehouse' && <WarehouseTab filters={appliedFilters} />}
+
+        {active === 'tasks' && <TasksTab filters={appliedFilters} />}
       </div>
     </Layout>
   )

--- a/dashboard-ui/app/services/analytics/analytics.service.ts
+++ b/dashboard-ui/app/services/analytics/analytics.service.ts
@@ -83,6 +83,13 @@ export const AnalyticsService = {
     const res = await axios.get<number>(`/analytics/product-remains`)
     return res.data
   },
+  async getLowStock(threshold?: number, categories?: number[]) {
+    const params: any = {}
+    if (threshold) params.threshold = threshold
+    if (categories && categories.length) params.categories = categories.join(',')
+    const res = await axios.get(`/analytics/low-stock`, { params })
+    return res.data
+  },
   async getOpenTasks() {
     const res = await axios.get<number>(`/analytics/open-tasks`)
     return res.data


### PR DESCRIPTION
## Summary
- redesign Reports page with compact filter panel synced to URL and storage
- fetch KPIs, charts and tab content from server APIs using React Query
- add warehouse low stock stats and task summaries

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0926a8f6c83298e811ced398f3ef8