### PR TITLE
Fix broken reports route

### DIFF
--- a/dashboard-ui/app/components/dashboard/KpiCards.tsx
+++ b/dashboard-ui/app/components/dashboard/KpiCards.tsx
@@ -53,7 +53,7 @@ const KpiCards: React.FC = () => {
     {
       label: "Выручка",
       value: currency.format(revenue),
-      href: "/reports/new",
+      href: "/reports",
       text: "text-success",
       bg: "bg-success/20",
       Icon: FaRubleSign,
@@ -61,7 +61,7 @@ const KpiCards: React.FC = () => {
     {
       label: "Кол-во продаж",
       value: salesCount.toLocaleString("ru-RU"),
-      href: "/reports/new",
+      href: "/reports",
       text: "text-info",
       bg: "bg-info/20",
       Icon: FaShoppingCart,
@@ -69,7 +69,7 @@ const KpiCards: React.FC = () => {
     {
       label: "Средний чек",
       value: currency.format(avgCheck),
-      href: "/reports/new",
+      href: "/reports",
       text: "text-secondary-700",
       bg: "bg-secondary-300/40",
       Icon: FaReceipt,

--- a/dashboard-ui/app/components/ui/header/Header.tsx
+++ b/dashboard-ui/app/components/ui/header/Header.tsx
@@ -23,7 +23,7 @@ const Header: FC = () => {
           <Link href='/tasks' className={styles.link}>
             Задачи
           </Link>
-          <Link href='/reports/new' className={styles.link}>
+          <Link href='/reports' className={styles.link}>
             Отчёты
           </Link>
         </>

--- a/dashboard-ui/next.config.ts
+++ b/dashboard-ui/next.config.ts
@@ -14,8 +14,8 @@ const nextConfig: NextConfig = {
   async redirects() {
     return [
       {
-        source: '/reports',
-        destination: '/reports/new',
+        source: '/reports/new',
+        destination: '/reports',
         permanent: false,
       },
     ]


### PR DESCRIPTION
## Summary
- redirect `/reports/new` to `/reports`
- update navigation links to `/reports`

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b40adabcfc8329b0708f9009bf1987