### PR TITLE
feat: enhance reports visuals

### DIFF
--- a/dashboard-ui/app/reports/SalesTab.tsx
+++ b/dashboard-ui/app/reports/SalesTab.tsx
@@ -1,17 +1,19 @@
 'use client'
 
-import { FC, useState } from 'react'
+import { FC, useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import {
-  LineChart,
+  Bar,
+  ComposedChart,
   Line,
   XAxis,
   YAxis,
   Tooltip,
   ResponsiveContainer,
   CartesianGrid,
-  Legend,
   ReferenceLine,
+  BarChart,
+  LabelList,
 } from 'recharts'
 
 import { AnalyticsService } from '@/services/analytics/analytics.service'
@@ -29,28 +31,40 @@ interface Props {
   filters: Filters
 }
 
+const intervals = [
+  { label: 'День', value: 'day' },
+  { label: 'Неделя', value: 'week' },
+  { label: 'Месяц', value: 'month' },
+  { label: 'Год', value: 'year' },
+] as const
+
+type Interval = (typeof intervals)[number]['value']
+
 const SalesTab: FC<Props> = ({ filters }) => {
-  const [metric, setMetric] = useState<'revenue' | 'count'>('revenue')
+  const [interval, setInterval] = useState<Interval>('day')
 
   const {
-    data: sales,
+    data: salesData,
     isLoading: salesLoading,
     error: salesError,
     refetch: refetchSales,
-  } = useQuery<ISalesStat[], Error>({
-    queryKey: ['reports', 'sales-chart', metric, filters],
-    queryFn: () =>
-      metric === 'revenue'
-        ? AnalyticsService.getDailyRevenue(
-            filters.from,
-            filters.to,
-            filters.categories,
-          )
-        : AnalyticsService.getSales(
-            filters.from,
-            filters.to,
-            filters.categories,
-          ),
+  } = useQuery<{ revenue: ISalesStat[]; count: ISalesStat[] }, Error>({
+    queryKey: ['reports', 'sales-chart', filters],
+    queryFn: async () => {
+      const [revenue, count] = await Promise.all([
+        AnalyticsService.getDailyRevenue(
+          filters.from,
+          filters.to,
+          filters.categories,
+        ),
+        AnalyticsService.getSales(
+          filters.from,
+          filters.to,
+          filters.categories,
+        ),
+      ])
+      return { revenue, count }
+    },
     enabled: Boolean(filters.from && filters.to),
   })
 
@@ -70,38 +84,96 @@ const SalesTab: FC<Props> = ({ filters }) => {
       ),
     enabled: Boolean(filters.from && filters.to),
   })
+  const chartData = useMemo(() => {
+    if (!salesData) return []
+    const map = new Map<string, { revenue: number; count: number }>()
+    const add = (dateStr: string, field: 'revenue' | 'count', value: number) => {
+      const date = new Date(dateStr)
+      let key = dateStr
+      switch (interval) {
+        case 'week': {
+          const d = new Date(date)
+          const day = (d.getDay() + 6) % 7
+          d.setDate(d.getDate() - day)
+          key = d.toISOString().split('T')[0]
+          break
+        }
+        case 'month':
+          key = `${date.getFullYear()}-${date.getMonth()}`
+          break
+        case 'year':
+          key = `${date.getFullYear()}`
+          break
+        default:
+          key = date.toISOString().split('T')[0]
+      }
+      const item = map.get(key) || { revenue: 0, count: 0 }
+      item[field] += value
+      map.set(key, item)
+    }
+    salesData.revenue.forEach(r => add(r.date, 'revenue', r.total))
+    salesData.count.forEach(c => add(c.date, 'count', c.total))
+    return Array.from(map.entries())
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([key, val]) => ({
+        label:
+          interval === 'month'
+            ? new Intl.DateTimeFormat('ru-RU', {
+                month: 'short',
+                year: 'numeric',
+              }).format(new Date(`${key}-01`))
+            : interval === 'year'
+            ? key
+            : new Intl.DateTimeFormat('ru-RU', {
+                day: '2-digit',
+                month: '2-digit',
+              }).format(new Date(key)),
+        revenue: val.revenue,
+        count: val.count,
+      }))
+  }, [salesData, interval])
 
-  const chartData = (sales ?? []).map(s => ({ date: s.date, value: s.total }))
-  const allZero = chartData.length === 0 || chartData.every(d => d.value === 0)
+  const allZero =
+    chartData.length === 0 ||
+    chartData.every(d => d.revenue === 0 && d.count === 0)
+
+  const topChartData = useMemo(() => {
+    if (!topProducts) return []
+    const total = topProducts.reduce((sum, p) => sum + p.totalRevenue, 0)
+    return topProducts
+      .sort((a, b) => b.totalRevenue - a.totalRevenue)
+      .map(p => ({
+        name: p.productName,
+        revenue: p.totalRevenue,
+        percent: total ? +((p.totalRevenue / total) * 100).toFixed(1) : 0,
+      }))
+  }, [topProducts])
+
+  const truncate = (s: string) => (s.length > 16 ? `${s.slice(0, 16)}…` : s)
 
   return (
-    <div className='space-y-6'>
-      <div className='rounded-2xl bg-neutral-200 p-4 shadow-card'>
-        <div className='flex items-center justify-between mb-3'>
-          <h3 className='font-medium'>График продаж</h3>
+    <div className='flex flex-col gap-6 md:gap-8'>
+      <div className='rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5'>
+        <div className='flex items-center justify-between mb-4'>
+          <h3 className='flex items-center gap-2 text-base md:text-lg font-semibold text-neutral-900'>
+            <span>📈</span>
+            <span>График продаж</span>
+          </h3>
           <div className='flex gap-2'>
-            <button
-              className={`px-2 py-1 text-sm rounded transition-colors cursor-pointer ${
-                metric === 'revenue'
-                  ? 'bg-primary-500 text-white'
-                  : 'bg-white'
-              }`}
-              onClick={() => setMetric('revenue')}
-              aria-pressed={metric === 'revenue'}
-            >
-              Выручка
-            </button>
-            <button
-              className={`px-2 py-1 text-sm rounded transition-colors cursor-pointer ${
-                metric === 'count'
-                  ? 'bg-primary-500 text-white'
-                  : 'bg-white'
-              }`}
-              onClick={() => setMetric('count')}
-              aria-pressed={metric === 'count'}
-            >
-              Кол-во
-            </button>
+            {intervals.map(i => (
+              <button
+                key={i.value}
+                className={`px-3 py-1 text-sm rounded-full cursor-pointer ${
+                  interval === i.value
+                    ? 'bg-primary-500 text-neutral-50'
+                    : 'bg-neutral-200 text-neutral-900'
+                }`}
+                onClick={() => setInterval(i.value)}
+                aria-pressed={interval === i.value}
+              >
+                {i.label}
+              </button>
+            ))}
           </div>
         </div>
         <div className='h-64 relative'>
@@ -110,7 +182,7 @@ const SalesTab: FC<Props> = ({ filters }) => {
               Загрузка...
             </div>
           ) : salesError ? (
-            <div className='absolute inset-0 flex items-center justify-center text-sm text-red-600'>
+            <div className='absolute inset-0 flex items-center justify-center text-sm text-error'>
               Ошибка{' '}
               <button className='underline' onClick={() => refetchSales()}>
                 Повторить
@@ -118,66 +190,104 @@ const SalesTab: FC<Props> = ({ filters }) => {
             </div>
           ) : (
             <ResponsiveContainer width='100%' height='100%'>
-              <LineChart data={chartData} margin={{ left: 8, right: 8 }}>
+              <ComposedChart data={chartData} margin={{ left: 16, right: 16 }}>
                 <CartesianGrid strokeDasharray='3 3' stroke='#e5e7eb' />
-                <XAxis dataKey='date' tick={{ fontSize: 12 }} tickLine={false} axisLine={false} />
+                <XAxis dataKey='label' tick={{ fontSize: 12 }} />
                 <YAxis
+                  yAxisId='left'
+                  tick={{ fontSize: 12 }}
+                  tickFormatter={v => formatCurrency(v as number)}
+                />
+                <YAxis
+                  yAxisId='right'
+                  orientation='right'
                   tick={{ fontSize: 12 }}
                   tickFormatter={v =>
-                    metric === 'revenue' ? formatCurrency(v as number) : String(v)
+                    new Intl.NumberFormat('ru-RU').format(v as number)
                   }
-                  tickLine={false}
-                  axisLine={false}
                 />
                 <Tooltip
-                  formatter={value =>
-                    metric === 'revenue'
+                  formatter={(value, name) =>
+                    name === 'Выручка, ₽'
                       ? formatCurrency(value as number)
-                      : (value as number).toLocaleString('ru-RU')
+                      : new Intl.NumberFormat('ru-RU').format(value as number)
                   }
                   labelFormatter={label => label}
                 />
-                <Legend wrapperStyle={{ fontSize: 12 }} />
+                <Bar yAxisId='left' dataKey='revenue' name='Выручка, ₽' fill='#10b981' />
                 <Line
+                  yAxisId='right'
                   type='monotone'
-                  dataKey='value'
-                  stroke={metric === 'revenue' ? '#3B82F6' : '#10B981'}
+                  dataKey='count'
+                  name='Количество, шт'
+                  stroke='#3b82f6'
                   strokeWidth={2}
-                  dot={false}
-                  name={metric === 'revenue' ? 'Выручка' : 'Количество'}
+                  dot
                 />
-                {allZero && <ReferenceLine y={0} stroke='#EF4444' strokeWidth={1} />}
-              </LineChart>
+                {allZero && (
+                  <ReferenceLine
+                    y={0}
+                    yAxisId='left'
+                    stroke='#ef4444'
+                    strokeWidth={1}
+                  />
+                )}
+              </ComposedChart>
             </ResponsiveContainer>
           )}
           {allZero && !salesLoading && !salesError && (
             <div className='absolute inset-0 flex items-center justify-center text-neutral-500'>
-              Нет данных
+              Нет данных за выбранный период
             </div>
           )}
         </div>
       </div>
 
-      <div className='rounded-2xl bg-neutral-200 p-4 shadow-card'>
-        <h3 className='font-medium mb-2'>Топ-10 товаров</h3>
+      <div className='rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5'>
+        <h3 className='flex items-center gap-2 text-base md:text-lg font-semibold text-neutral-900 mb-4'>
+          <span>🏆</span>
+          <span>Топ-10 товаров</span>
+        </h3>
         {topLoading ? (
           <div className='text-sm text-neutral-500'>Загрузка...</div>
         ) : topError ? (
-          <div className='text-sm text-red-600'>
+          <div className='text-sm text-error'>
             Ошибка{' '}
             <button className='underline' onClick={() => refetchTop()}>
               Повторить
             </button>
           </div>
-        ) : topProducts && topProducts.length > 0 ? (
-          <ul className='space-y-1'>
-            {topProducts.map(p => (
-              <li key={p.productId} className='flex justify-between text-sm'>
-                <span>{p.productName}</span>
-                <span>{formatCurrency(p.totalRevenue)}</span>
-              </li>
-            ))}
-          </ul>
+        ) : topChartData.length > 0 ? (
+          <div className='h-96'>
+            <ResponsiveContainer width='100%' height='100%'>
+              <BarChart layout='vertical' data={topChartData} margin={{ left: 16, right: 16 }}>
+                <CartesianGrid strokeDasharray='3 3' stroke='#e5e7eb' />
+                <XAxis
+                  type='number'
+                  tick={{ fontSize: 12 }}
+                  tickFormatter={v => formatCurrency(v as number)}
+                />
+                <YAxis
+                  dataKey='name'
+                  type='category'
+                  width={150}
+                  tick={{ fontSize: 12 }}
+                  tickFormatter={v => truncate(v as string)}
+                />
+                <Tooltip
+                  formatter={value => formatCurrency(value as number)}
+                  labelFormatter={label => label as string}
+                />
+                <Bar dataKey='revenue' fill='#3b82f6'>
+                  <LabelList
+                    dataKey='percent'
+                    position='right'
+                    formatter={v => `${v}%`}
+                  />
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
         ) : (
           <div className='text-sm text-neutral-500'>Нет данных</div>
         )}

--- a/dashboard-ui/app/reports/page.tsx
+++ b/dashboard-ui/app/reports/page.tsx
@@ -145,12 +145,44 @@ export default function ReportsPage() {
 
   const kpiCards = kpis
     ? [
-        { label: 'Выручка', value: kpis.revenue, currency: true },
-        { label: 'Количество заказов', value: kpis.orders },
-        { label: 'Проданные единицы', value: kpis.unitsSold },
-        { label: 'Средний чек', value: kpis.avgCheck, currency: true },
-        { label: 'Маржа', value: kpis.margin, currency: true },
-        { label: 'Выполненные задачи', value: kpis.completedTasks },
+        {
+          label: 'Выручка',
+          value: kpis.revenue,
+          currency: true,
+          icon: '💰',
+          iconClass: 'bg-success/10 text-success',
+          valueClass: 'text-success',
+        },
+        {
+          label: 'Количество заказов',
+          value: kpis.orders,
+          icon: '📦',
+          iconClass: 'bg-primary-300 text-neutral-900',
+          valueClass: 'text-neutral-900',
+        },
+        {
+          label: 'Средний чек',
+          value: kpis.avgCheck,
+          currency: true,
+          icon: '🛒',
+          iconClass: 'bg-warning/10 text-warning',
+          valueClass: 'text-warning',
+        },
+        {
+          label: 'Маржа',
+          value: kpis.margin,
+          currency: true,
+          icon: '📊',
+          iconClass: 'bg-success/10 text-success',
+          valueClass: kpis.margin >= 0 ? 'text-success' : 'text-error',
+        },
+        {
+          label: 'Выполненные задачи',
+          value: kpis.completedTasks,
+          icon: '✅',
+          iconClass: 'bg-info/10 text-info',
+          valueClass: 'text-info',
+        },
       ]
     : []
 
@@ -199,17 +231,17 @@ export default function ReportsPage() {
 
   return (
     <Layout>
-      <div className='space-y-6'>
-        <div className='rounded-2xl bg-neutral-200 p-4 shadow-card'>
+      <div className='flex flex-col gap-6 md:gap-8'>
+        <div className='rounded-2xl bg-neutral-200 p-4 shadow-card mb-6'>
           <div className='grid grid-cols-1 md:grid-cols-12 gap-3'>
             <div className='md:col-span-6 flex flex-wrap gap-2'>
               {presets.map(p => (
                 <button
                   key={p.value}
-                  className={`px-3 py-1 text-sm rounded-full border cursor-pointer transition-colors ${
+                  className={`px-3 py-1 text-sm rounded-full cursor-pointer transition-colors ${
                     preset === p.value
-                      ? 'bg-primary-500 text-white border-primary-500'
-                      : 'bg-white border-neutral-300'
+                      ? 'bg-primary-500 text-neutral-50'
+                      : 'bg-neutral-200 text-neutral-900'
                   }`}
                   onClick={() => setPreset(p.value)}
                   aria-pressed={preset === p.value}
@@ -245,7 +277,7 @@ export default function ReportsPage() {
           <div className='flex justify-end gap-2 mt-3'>
             <button
               onClick={applyFilters}
-              className='px-4 py-2 bg-primary-500 text-white rounded disabled:opacity-50'
+              className='px-4 py-2 bg-primary-500 text-neutral-50 rounded disabled:opacity-50'
               disabled={kpisLoading}
             >
               Применить
@@ -262,7 +294,7 @@ export default function ReportsPage() {
         <div className='flex justify-end'>
           <button
             onClick={handleExport}
-            className='px-4 py-2 bg-primary-500 text-white rounded disabled:opacity-50'
+            className='px-4 py-2 bg-primary-500 text-neutral-50 rounded disabled:opacity-50'
             disabled={exporting || kpisLoading}
           >
             Экспорт CSV
@@ -292,16 +324,16 @@ export default function ReportsPage() {
 
         {active === 'sales' && (
           <>
-            <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4 mb-6'>
+            <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 mb-6'>
               {kpisLoading ? (
-                Array.from({ length: 6 }).map((_, i) => (
+                Array.from({ length: 5 }).map((_, i) => (
                   <div
                     key={i}
                     className='rounded-2xl bg-neutral-200 p-4 shadow-card animate-pulse h-20'
                   />
                 ))
               ) : kpisError ? (
-                <div className='col-span-full text-red-600 text-sm'>
+                <div className='col-span-full text-error text-sm'>
                   Ошибка загрузки{' '}
                   <button className='underline' onClick={() => refetchKpis()}>
                     Повторить
@@ -309,11 +341,21 @@ export default function ReportsPage() {
                 </div>
               ) : (
                 kpiCards.map(k => (
-                  <div key={k.label} className='rounded-2xl bg-neutral-200 p-4 shadow-card'>
-                    <div className='text-2xl font-semibold'>
-                      {k.currency ? formatCurrency(k.value) : k.value}
+                  <div
+                    key={k.label}
+                    className='rounded-2xl shadow-card p-4 md:p-5 flex items-center gap-3 bg-neutral-200'
+                  >
+                    <div className={`w-10 h-10 rounded-full flex items-center justify-center ${k.iconClass}`}>
+                      {k.icon}
                     </div>
-                    <div className='text-sm'>{k.label}</div>
+                    <div className='flex flex-col'>
+                      <span className={`text-2xl md:text-3xl font-semibold tabular-nums ${k.valueClass}`}>
+                        {k.currency
+                          ? formatCurrency(k.value)
+                          : new Intl.NumberFormat('ru-RU').format(k.value)}
+                      </span>
+                      <span className='text-sm text-neutral-800'>{k.label}</span>
+                    </div>
                   </div>
                 ))
               )}


### PR DESCRIPTION
## Summary
- add iconized KPI cards with color accents
- implement dual sales chart with interval switch and top products bar chart

## Testing
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68b4192fed3c83298a624caf738133fc