### PR TITLE
refactor: compact filter toolbar

### DIFF
--- a/dashboard-ui/app/utils/formatCurrency.test.ts
+++ b/dashboard-ui/app/utils/formatCurrency.test.ts
@@ -11,4 +11,14 @@ describe('formatCurrency', () => {
       }).format(value),
     )
   })
+
+  it('formats number to compact RUB currency', () => {
+    const value = 1234.5
+    expect(formatCurrency(value, { compact: true })).toBe(
+      new Intl.NumberFormat('ru-RU', {
+        notation: 'compact',
+        compactDisplay: 'short',
+      }).format(value) + ' ₽',
+    )
+  })
 })

--- a/dashboard-ui/app/utils/formatCurrency.ts
+++ b/dashboard-ui/app/utils/formatCurrency.ts
@@ -1,4 +1,21 @@
-export const formatCurrency = (value: number) =>
-  new Intl.NumberFormat('ru-RU', { style: 'currency', currency: 'RUB' }).format(value)
+interface Options {
+  compact?: boolean
+}
+
+export const formatCurrency = (value: number, options: Options = {}) => {
+  if (options.compact) {
+    return (
+      new Intl.NumberFormat('ru-RU', {
+        notation: 'compact',
+        compactDisplay: 'short',
+      }).format(value) + ' ₽'
+    )
+  }
+
+  return new Intl.NumberFormat('ru-RU', {
+    style: 'currency',
+    currency: 'RUB',
+  }).format(value)
+}
 
 export default formatCurrency


### PR DESCRIPTION
## Summary
- streamline report filters and tab navigation
- add compact currency formatting with tests
## Testing
- `npx eslint .` *(fails: Need to install the following packages: eslint@9.34.0)*
- `npx vitest run` *(fails: Need to install the following packages: vitest@3.2.4)*

------
https://chatgpt.com/codex/tasks/task_e_68b43fd550a48329a5cd3d7c0e533226