### PR TITLE
style: expand KPI cards width on reports page

### DIFF
--- a/dashboard-ui/app/reports/page.tsx
+++ b/dashboard-ui/app/reports/page.tsx
@@ -396,7 +396,7 @@ export default function ReportsPage() {
 
         {active === 'sales' && (
           <>
-            <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 mb-6'>
+            <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6'>
               {kpisLoading ? (
                 Array.from({ length: 4 }).map((_, i) => (
                   <div


### PR DESCRIPTION
## Summary
- spread KPI cards across full width of the sales reports tab

## Testing
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68b4460e8e1c8329930cd07036f65a2b