### PR TITLE
feat(tasks): extract filter toolbar

### DIFF
--- a/dashboard-ui/app/components/tasks/TaskFiltersToolbar.tsx
+++ b/dashboard-ui/app/components/tasks/TaskFiltersToolbar.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import useDebounce from '@/hooks/useDebounce'
+import { TaskFilters } from '@/hooks/useTaskFilters'
+
+interface Props {
+  filters: TaskFilters
+  setFilters: (changes: Partial<TaskFilters>) => void
+}
+
+const TaskFiltersToolbar = ({ filters, setFilters }: Props) => {
+  const [searchInput, setSearchInput] = useState(filters.search)
+  const debouncedSearch = useDebounce(searchInput, 350)
+  const [dateOpen, setDateOpen] = useState(false)
+  const dateRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    setFilters({ search: debouncedSearch })
+  }, [debouncedSearch, setFilters])
+
+  useEffect(() => {
+    setSearchInput(filters.search)
+  }, [filters.search])
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (dateRef.current && !dateRef.current.contains(e.target as Node))
+        setDateOpen(false)
+    }
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setDateOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [])
+
+  function formatDisplay(date: string) {
+    if (!date) return ''
+    return date.split('-').reverse().join('.')
+  }
+
+  const rangeDisplay = `${formatDisplay(filters.from)} — ${formatDisplay(
+    filters.to,
+  )}`
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 md:gap-3 rounded-2xl bg-neutral-200 shadow-card px-3 py-2 mb-4">
+      <div className="relative" ref={dateRef}>
+        <button
+          type="button"
+          className="h-10 pl-9 pr-3 rounded-xl border border-neutral-300 bg-neutral-100 focus:ring-2 focus:ring-primary-300 cursor-pointer"
+          aria-label="Дата"
+          title={rangeDisplay}
+          onClick={() => setDateOpen(o => !o)}
+        >
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none">📅</span>
+          {rangeDisplay}
+        </button>
+        {dateOpen && (
+          <div className="absolute z-10 mt-1 p-2 bg-white shadow-lg rounded-xl border border-neutral-300 flex items-center gap-2">
+            <input
+              type="date"
+              value={filters.from}
+              onChange={e => setFilters({ from: e.target.value })}
+              className="h-8 border border-neutral-300 rounded px-2 focus:ring-2 focus:ring-primary-300"
+              aria-label="Дата начала"
+              title="Дата начала"
+            />
+            <span aria-hidden>—</span>
+            <input
+              type="date"
+              value={filters.to}
+              onChange={e => setFilters({ to: e.target.value })}
+              className="h-8 border border-neutral-300 rounded px-2 focus:ring-2 focus:ring-primary-300"
+              aria-label="Дата окончания"
+              title="Дата окончания"
+            />
+          </div>
+        )}
+      </div>
+      <div className="flex items-center">
+        <span className="mr-1.5">⚡</span>
+        <select
+          value={filters.priority}
+          onChange={e => setFilters({ priority: e.target.value })}
+          className="h-10 px-3 rounded-xl border border-neutral-300 bg-neutral-100 cursor-pointer focus:ring-2 focus:ring-primary-300"
+          aria-label="Приоритет"
+          title="Приоритет"
+        >
+          <option value="">Все</option>
+          <option value="Высокий">Высокий</option>
+          <option value="Средний">Средний</option>
+          <option value="Низкий">Низкий</option>
+        </select>
+      </div>
+      <div className="flex items-center">
+        <span className="mr-1.5">🔄</span>
+        <select
+          value={filters.status}
+          onChange={e => setFilters({ status: e.target.value })}
+          className="h-10 px-3 rounded-xl border border-neutral-300 bg-neutral-100 cursor-pointer focus:ring-2 focus:ring-primary-300"
+          aria-label="Статус"
+          title="Статус"
+        >
+          <option value="">Все</option>
+          <option value="Выполняется">Выполняется</option>
+          <option value="Ожидает">Ожидает</option>
+          <option value="Готово">Готово</option>
+          <option value="Просроченные">Просроченные</option>
+        </select>
+      </div>
+      <div className="flex items-center flex-1 min-w-[200px]">
+        <span className="mr-1.5">🔍</span>
+        <input
+          type="text"
+          value={searchInput}
+          onChange={e => setSearchInput(e.target.value)}
+          placeholder="Поиск…"
+          className="h-10 flex-1 min-w-[200px] rounded-xl border border-neutral-300 bg-neutral-100 px-3 cursor-pointer focus:ring-2 focus:ring-primary-300"
+          aria-label="Поиск"
+          title="Поиск"
+        />
+      </div>
+    </div>
+  )
+}
+
+export default TaskFiltersToolbar

--- a/dashboard-ui/app/components/tasks/TasksTable.tsx
+++ b/dashboard-ui/app/components/tasks/TasksTable.tsx
@@ -14,26 +14,20 @@ import {
   TaskPriority,
   TaskStatus,
 } from '@/shared/interfaces/task.interface'
-import useDebounce from '@/hooks/useDebounce'
-import { useTaskFilters } from '@/hooks/useTaskFilters'
+import { TaskFilters } from '@/hooks/useTaskFilters'
+import TaskFiltersToolbar from './TaskFiltersToolbar'
 import TaskInfoModal from './TaskInfoModal'
 import TaskForm from './TaskForm'
 
 const chipBase =
   'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium whitespace-nowrap'
 
-function formatDisplay(date: string) {
-  if (!date) return ''
-  return date.split('-').reverse().join('.')
+interface TasksTableProps {
+  filters: TaskFilters
 }
 
-const TasksTable = () => {
-  const { filters, setFilters } = useTaskFilters()
+const TasksTable = ({ filters }: TasksTableProps) => {
   const [tasks, setTasks] = useState<ITask[]>([])
-  const [searchInput, setSearchInput] = useState(filters.search)
-  const debouncedSearch = useDebounce(searchInput, 350)
-  const [dateOpen, setDateOpen] = useState(false)
-  const dateRef = useRef<HTMLDivElement | null>(null)
 
   const { data, error } = useQuery<ITask[], Error>({
     queryKey: ['tasks', filters],
@@ -44,30 +38,6 @@ const TasksTable = () => {
   useEffect(() => {
     if (data) setTasks(data)
   }, [data])
-
-  useEffect(() => {
-    setFilters({ search: debouncedSearch })
-  }, [debouncedSearch, setFilters])
-
-  useEffect(() => {
-    setSearchInput(filters.search)
-  }, [filters.search])
-
-  useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
-      if (dateRef.current && !dateRef.current.contains(e.target as Node))
-        setDateOpen(false)
-    }
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setDateOpen(false)
-    }
-    document.addEventListener('mousedown', handleClick)
-    document.addEventListener('keydown', handleKey)
-    return () => {
-      document.removeEventListener('mousedown', handleClick)
-      document.removeEventListener('keydown', handleKey)
-    }
-  }, [])
 
   const [openMenuTaskId, setOpenMenuTaskId] = useState<number | null>(null)
   const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null)
@@ -212,92 +182,9 @@ const TasksTable = () => {
     }
   }
 
-  const rangeDisplay = `${formatDisplay(filters.from)} — ${formatDisplay(
-    filters.to,
-  )}`
-
   return (
     <div>
-      <div className="flex flex-wrap items-center gap-2 md:gap-3 rounded-2xl bg-neutral-200 shadow-card px-3 py-2 mb-4">
-        <div className="relative" ref={dateRef}>
-          <button
-            type="button"
-            className="h-10 pl-9 pr-3 rounded-xl border border-neutral-300 bg-neutral-100 focus:ring-2 focus:ring-primary-300 cursor-pointer"
-            aria-label="Дата"
-            title={rangeDisplay}
-            onClick={() => setDateOpen(o => !o)}
-          >
-            <span className="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none">
-              📅
-            </span>
-            {rangeDisplay}
-          </button>
-          {dateOpen && (
-            <div className="absolute z-10 mt-1 p-2 bg-white shadow-lg rounded-xl border border-neutral-300 flex items-center gap-2">
-              <input
-                type="date"
-                value={filters.from}
-                onChange={e => setFilters({ from: e.target.value })}
-                className="h-8 border border-neutral-300 rounded px-2 focus:ring-2 focus:ring-primary-300"
-                aria-label="Дата начала"
-                title="Дата начала"
-              />
-              <span aria-hidden>—</span>
-              <input
-                type="date"
-                value={filters.to}
-                onChange={e => setFilters({ to: e.target.value })}
-                className="h-8 border border-neutral-300 rounded px-2 focus:ring-2 focus:ring-primary-300"
-                aria-label="Дата окончания"
-                title="Дата окончания"
-              />
-            </div>
-          )}
-        </div>
-        <div className="flex items-center">
-          <span className="mr-1.5">⚡</span>
-          <select
-            value={filters.priority}
-            onChange={e => setFilters({ priority: e.target.value })}
-            className="h-10 px-3 rounded-xl border border-neutral-300 bg-neutral-100 cursor-pointer focus:ring-2 focus:ring-primary-300"
-            aria-label="Приоритет"
-            title="Приоритет"
-          >
-            <option value="">Все</option>
-            <option value="Высокий">Высокий</option>
-            <option value="Средний">Средний</option>
-            <option value="Низкий">Низкий</option>
-          </select>
-        </div>
-        <div className="flex items-center">
-          <span className="mr-1.5">🔄</span>
-          <select
-            value={filters.status}
-            onChange={e => setFilters({ status: e.target.value })}
-            className="h-10 px-3 rounded-xl border border-neutral-300 bg-neutral-100 cursor-pointer focus:ring-2 focus:ring-primary-300"
-            aria-label="Статус"
-            title="Статус"
-          >
-            <option value="">Все</option>
-            <option value="Выполняется">Выполняется</option>
-            <option value="Ожидает">Ожидает</option>
-            <option value="Готово">Готово</option>
-            <option value="Просроченные">Просроченные</option>
-          </select>
-        </div>
-        <div className="flex items-center flex-1 min-w-[200px]">
-          <span className="mr-1.5">🔍</span>
-          <input
-            type="text"
-            value={searchInput}
-            onChange={e => setSearchInput(e.target.value)}
-            placeholder="Поиск…"
-            className="h-10 flex-1 min-w-[200px] rounded-xl border border-neutral-300 bg-neutral-100 px-3 cursor-pointer focus:ring-2 focus:ring-primary-300"
-            aria-label="Поиск"
-            title="Поиск"
-          />
-        </div>
-      </div>
+      <TaskFiltersToolbar />
       <div className="flex justify-end mb-4">
         <Button
           className="rounded-2xl px-4 py-2 shadow-card bg-info text-neutral-50 hover:brightness-95 focus:ring-2 focus:ring-info"

--- a/dashboard-ui/app/tasks/TasksContent.test.tsx
+++ b/dashboard-ui/app/tasks/TasksContent.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 import { vi } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import TasksTable from './TasksTable'
+import TasksContent from './TasksContent'
 import { server } from '@/tests/mocks/server'
 
 const renderWithClient = (ui: React.ReactElement) => {
@@ -13,7 +13,7 @@ const renderWithClient = (ui: React.ReactElement) => {
   )
 }
 
-describe('TasksTable', () => {
+describe('TasksContent', () => {
   beforeAll(() => {
     vi.setSystemTime(new Date('2024-01-05'))
   })
@@ -23,7 +23,7 @@ describe('TasksTable', () => {
   })
 
   it('renders tasks from API (happy path)', async () => {
-    renderWithClient(<TasksTable />)
+    renderWithClient(<TasksContent />)
     expect(await screen.findByText('Task 1')).toBeInTheDocument()
   })
 
@@ -31,7 +31,7 @@ describe('TasksTable', () => {
     server.use(
       http.get('http://localhost:4000/api/task', () => HttpResponse.error())
     )
-    renderWithClient(<TasksTable />)
+    renderWithClient(<TasksContent />)
     await waitFor(() => expect(screen.getByText(/error/i)).toBeInTheDocument())
   })
 
@@ -39,7 +39,7 @@ describe('TasksTable', () => {
     server.use(
       http.get('http://localhost:4000/api/task', () => HttpResponse.json([]))
     )
-    renderWithClient(<TasksTable />)
+    renderWithClient(<TasksContent />)
     await waitFor(() => {
       const rows = screen.queryAllByRole('row')
       // header + no data
@@ -48,7 +48,7 @@ describe('TasksTable', () => {
   })
 
   it('filters by priority', async () => {
-    renderWithClient(<TasksTable />)
+    renderWithClient(<TasksContent />)
     await screen.findByText('Task 1')
     const select = screen.getByRole('combobox', { name: /приоритет/i })
     await userEvent.selectOptions(select, 'Высокий')
@@ -56,7 +56,7 @@ describe('TasksTable', () => {
   })
 
   it('deletes a task', async () => {
-    renderWithClient(<TasksTable />)
+    renderWithClient(<TasksContent />)
     const menuBtn = await screen.findByRole('button', { name: /действия/i })
     await userEvent.click(menuBtn)
     const deleteItem = await screen.findByRole('menuitem', { name: /удалить/i })
@@ -70,7 +70,7 @@ describe('TasksTable', () => {
   })
 
   it('opens task info modal on row click and closes with ESC', async () => {
-    renderWithClient(<TasksTable />)
+    renderWithClient(<TasksContent />)
     const cell = await screen.findByText('Task 1')
     await userEvent.click(cell)
     const dialog = await screen.findByRole('dialog', { name: /task 1/i })

--- a/dashboard-ui/app/tasks/TasksContent.tsx
+++ b/dashboard-ui/app/tasks/TasksContent.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import TaskFiltersToolbar from '@/components/tasks/TaskFiltersToolbar'
+import TasksTable from '@/components/tasks/TasksTable'
+import { useTaskFilters } from '@/hooks/useTaskFilters'
+
+const TasksContent = () => {
+  const { filters, setFilters } = useTaskFilters()
+  return (
+    <>
+      <TaskFiltersToolbar filters={filters} setFilters={setFilters} />
+      <TasksTable filters={filters} />
+    </>
+  )
+}
+
+export default TasksContent

--- a/dashboard-ui/app/tasks/page.tsx
+++ b/dashboard-ui/app/tasks/page.tsx
@@ -1,5 +1,5 @@
 import Layout from '@/ui/Layout'
-import TasksTable from '@/components/tasks/TasksTable'
+import TasksContent from './TasksContent'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 export default function TasksPage() {
   return (
     <Layout>
-      <TasksTable />
+      <TasksContent />
     </Layout>
   )
 }


### PR DESCRIPTION
## Summary
- extract task filter controls into `TaskFiltersToolbar`
- share filter state via new `TasksContent` wrapper and update table
- adjust tasks page and tests for new structure

## Testing
- `yarn test` *(fails: Cannot find package 'vite' imported from @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68b4788a8e088329b3013918c4d4ad14