### PR TITLE
feat: replace text filter controls with icon buttons

### DIFF
--- a/dashboard-ui/app/reports/page.tsx
+++ b/dashboard-ui/app/reports/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState, useRef, KeyboardEvent } from 'react'
+import { CheckCircle2, RotateCcw, Download } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
 
@@ -163,6 +164,15 @@ export default function ReportsPage() {
     localStorage.removeItem(STORAGE_KEY)
   }
 
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' && (e.target as HTMLElement).tagName !== 'BUTTON') {
+      applyFilters()
+    }
+    if (e.key === 'Escape') {
+      resetFilters()
+    }
+  }
+
   const {
     data: kpis,
     isLoading: kpisLoading,
@@ -260,7 +270,10 @@ export default function ReportsPage() {
   return (
     <Layout>
       <div className='flex flex-col gap-6 md:gap-8'>
-        <div className='flex flex-wrap items-center gap-2 md:gap-3 px-2 md:px-0 mb-4'>
+      <div
+        className='flex flex-wrap items-center gap-2 md:gap-3 px-2 md:px-0 mb-4'
+        onKeyDown={handleKeyDown}
+      >
           <div className='flex items-center gap-1'>
             <span aria-hidden>🎯</span>
             {presets.map(p => (
@@ -346,27 +359,36 @@ export default function ReportsPage() {
               </div>
             )}
           </div>
-          <div className='flex gap-2 ml-auto'>
+          <div className='ml-auto flex items-center gap-2'>
             <button
               type='button'
-              onClick={handleExport}
-              className='h-10 px-3 rounded-xl bg-info text-neutral-50 hover:brightness-95 focus:ring-2 focus:ring-info cursor-pointer disabled:opacity-50'
-              disabled={exporting || kpisLoading}
-            >
-              Экспорт
-            </button>
-            <button
+              aria-label='Применить фильтры'
+              title='Применить фильтры'
+              className='h-10 w-10 flex items-center justify-center rounded-xl bg-primary-500 text-neutral-50 hover:bg-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
               onClick={applyFilters}
-              className='h-10 px-3 rounded-xl bg-primary-500 text-neutral-50 hover:bg-primary-400 focus:ring-2 focus:ring-primary-300 cursor-pointer disabled:opacity-50'
               disabled={kpisLoading}
             >
-              Применить
+              <CheckCircle2 className='w-5 h-5' />
             </button>
             <button
+              type='button'
+              aria-label='Сбросить фильтры'
+              title='Сбросить фильтры'
+              className='h-10 w-10 flex items-center justify-center rounded-xl bg-neutral-100 text-neutral-900 hover:bg-neutral-300 focus:outline-none focus:ring-2 focus:ring-primary-300 disabled:opacity-50 disabled:cursor-not-allowed'
               onClick={resetFilters}
-              className='h-10 px-3 rounded-xl bg-neutral-100 text-neutral-900 hover:bg-neutral-300 cursor-pointer'
+              disabled={kpisLoading}
             >
-              Сбросить
+              <RotateCcw className='w-5 h-5' />
+            </button>
+            <button
+              type='button'
+              aria-label='Экспорт отчёта'
+              title='Экспорт отчёта'
+              className='h-10 w-10 flex items-center justify-center rounded-xl bg-info text-neutral-50 hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-info disabled:opacity-50 disabled:cursor-not-allowed'
+              onClick={handleExport}
+              disabled={exporting || kpisLoading}
+            >
+              <Download className='w-5 h-5' />
             </button>
           </div>
         </div>

--- a/dashboard-ui/package.json
+++ b/dashboard-ui/package.json
@@ -19,6 +19,7 @@
     "framer-motion": "^12.23.12",
     "js-cookie": "^3.0.5",
     "jspdf": "^2.5.1",
+    "lucide-react": "^0.542.0",
     "next": "^15.4.5",
     "next-seo": "^6.8.0",
     "react": "18.2.0",
@@ -31,6 +32,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@next/eslint-plugin-next": "^15.5.2",
     "@playwright/test": "^1.54.2",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
@@ -44,12 +46,14 @@
     "autoprefixer": "^10.4.21",
     "eslint": "^8.56.0",
     "eslint-config-next": "14.2.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "jsdom": "^26.1.0",
     "msw": "^2.10.4",
     "postcss": "^8.4.38",
     "prettier": "^3.6.2",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.3.3",
+    "vite": "^7.1.3",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.2.4"
   }

--- a/dashboard-ui/yarn.lock
+++ b/dashboard-ui/yarn.lock
@@ -998,6 +998,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/eslint-plugin-next@npm:^15.5.2":
+  version: 15.5.2
+  resolution: "@next/eslint-plugin-next@npm:15.5.2"
+  dependencies:
+    fast-glob: "npm:3.3.1"
+  checksum: 10c0/5bafb42b15c23f8a1c5460e4eda4cb45b7c07832f80ce734cad138781606cd9c954ee37b93fd2a973b064ea39469dfc1409301cb2c90995ce5226a3b2b07a891
+  languageName: node
+  linkType: hard
+
 "@next/swc-darwin-arm64@npm:15.4.6":
   version: 15.4.6
   resolution: "@next/swc-darwin-arm64@npm:15.4.6"
@@ -3125,6 +3134,7 @@ __metadata:
   resolution: "dashboard-ui@workspace:."
   dependencies:
     "@eslint/eslintrc": "npm:^3"
+    "@next/eslint-plugin-next": "npm:^15.5.2"
     "@playwright/test": "npm:^1.54.2"
     "@tanstack/react-query": "npm:^5.84.1"
     "@testing-library/dom": "npm:^10.4.1"
@@ -3143,10 +3153,12 @@ __metadata:
     classnames: "npm:^2.5.1"
     eslint: "npm:^8.56.0"
     eslint-config-next: "npm:14.2.0"
+    eslint-plugin-react-hooks: "npm:^5.2.0"
     framer-motion: "npm:^12.23.12"
     js-cookie: "npm:^3.0.5"
     jsdom: "npm:^26.1.0"
     jspdf: "npm:^2.5.1"
+    lucide-react: "npm:^0.542.0"
     msw: "npm:^2.10.4"
     next: "npm:^15.4.5"
     next-seo: "npm:^6.8.0"
@@ -3161,6 +3173,7 @@ __metadata:
     styled-components: "npm:^6.1.19"
     tailwindcss: "npm:^3.4.3"
     typescript: "npm:^5.3.3"
+    vite: "npm:^7.1.3"
     vite-tsconfig-paths: "npm:^5.1.4"
     vitest: "npm:^3.2.4"
   languageName: unknown
@@ -3837,6 +3850,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-react-hooks@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "eslint-plugin-react-hooks@npm:5.2.0"
+  peerDependencies:
+    eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+  checksum: 10c0/1c8d50fa5984c6dea32470651807d2922cc3934cf3425e78f84a24c2dfd972e7f019bee84aefb27e0cf2c13fea0ac1d4473267727408feeb1c56333ca1489385
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-react@npm:^7.33.2":
   version: 7.37.5
   resolution: "eslint-plugin-react@npm:7.37.5"
@@ -4028,6 +4050,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-glob@npm:3.3.1":
+  version: 3.3.1
+  resolution: "fast-glob@npm:3.3.1"
+  dependencies:
+    "@nodelib/fs.stat": "npm:^2.0.2"
+    "@nodelib/fs.walk": "npm:^1.2.3"
+    glob-parent: "npm:^5.1.2"
+    merge2: "npm:^1.3.0"
+    micromatch: "npm:^4.0.4"
+  checksum: 10c0/b68431128fb6ce4b804c5f9622628426d990b66c75b21c0d16e3d80e2d1398bf33f7e1724e66a2e3f299285dcf5b8d745b122d0304e7dd66f5231081f33ec67c
+  languageName: node
+  linkType: hard
+
 "fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.2":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
@@ -4064,7 +4099,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fdir@npm:^6.4.4, fdir@npm:^6.4.6":
+"fdir@npm:^6.4.4, fdir@npm:^6.4.6, fdir@npm:^6.5.0":
   version: 6.5.0
   resolution: "fdir@npm:6.5.0"
   peerDependencies:
@@ -5308,6 +5343,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lucide-react@npm:^0.542.0":
+  version: 0.542.0
+  resolution: "lucide-react@npm:0.542.0"
+  peerDependencies:
+    react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/3ccdb898a480f0194f93abef0b6f0347bc2647db24051e65a17c1dbd22ca0d10a7636d9af68c92665b42b6c9e761567a0d65944fe8568fb0e30a7ea57281ccec
+  languageName: node
+  linkType: hard
+
 "lz-string@npm:^1.5.0":
   version: 1.5.0
   resolution: "lz-string@npm:1.5.0"
@@ -5359,7 +5403,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.5, micromatch@npm:^4.0.8":
+"micromatch@npm:^4.0.4, micromatch@npm:^4.0.5, micromatch@npm:^4.0.8":
   version: 4.0.8
   resolution: "micromatch@npm:4.0.8"
   dependencies:
@@ -7950,6 +7994,61 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10c0/4ed825b20bc0f49db99cd382de9506b2721ccd47dcebd4a68e0ef65e3cdd2347fded52b306c34178308e0fd7fe78fd5ff517623002cb00710182ad3012c92ced
+  languageName: node
+  linkType: hard
+
+"vite@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "vite@npm:7.1.3"
+  dependencies:
+    esbuild: "npm:^0.25.0"
+    fdir: "npm:^6.5.0"
+    fsevents: "npm:~2.3.3"
+    picomatch: "npm:^4.0.3"
+    postcss: "npm:^8.5.6"
+    rollup: "npm:^4.43.0"
+    tinyglobby: "npm:^0.2.14"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    lightningcss: ^1.21.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/a0aa418beab80673dc9a3e9d1fa49472955d6ef9d41a4c9c6bd402953f411346f612864dae267adfb2bb8ceeb894482369316ffae5816c84fd45990e352b727d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- use CheckCircle2, RotateCcw and Download icons for filter actions
- wire up Enter/Escape shortcuts on the reports filter bar
- add lucide-react and lint/test dev dependencies

## Testing
- `yarn lint`
- `yarn test` *(fails: Cannot find package 'vite' imported from @vitejs/plugin-react/dist/index.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b4830c29f88329865817750c139909