### PR TITLE
feat(tasks): add floating action button for new tasks

### DIFF
--- a/dashboard-ui/app/components/tasks/TaskFiltersToolbar.tsx
+++ b/dashboard-ui/app/components/tasks/TaskFiltersToolbar.tsx
@@ -49,7 +49,7 @@ const TaskFiltersToolbar = ({ filters, setFilters }: Props) => {
   )}`
 
   return (
-    <div className="flex flex-wrap items-center gap-2 md:gap-3 rounded-2xl bg-neutral-200 shadow-card px-3 py-2 mb-4">
+    <div className="flex flex-wrap items-center gap-2 md:gap-3 rounded-2xl bg-neutral-200 shadow-card px-3 py-2 mb-3">
       <div className="relative" ref={dateRef}>
         <button
           type="button"

--- a/dashboard-ui/app/components/tasks/TasksTable.tsx
+++ b/dashboard-ui/app/components/tasks/TasksTable.tsx
@@ -6,7 +6,6 @@ import { createPortal } from 'react-dom'
 import { HiDotsVertical } from 'react-icons/hi'
 import { useQuery } from '@tanstack/react-query'
 
-import Button from '@/ui/Button/Button'
 import Modal from '@/ui/Modal/Modal'
 import { TaskService } from '@/services/task/task.service'
 import {
@@ -23,9 +22,11 @@ const chipBase =
 
 interface TasksTableProps {
   filters: TaskFilters
+  isAddOpen: boolean
+  onCloseAdd: () => void
 }
 
-const TasksTable = ({ filters }: TasksTableProps) => {
+const TasksTable = ({ filters, isAddOpen, onCloseAdd }: TasksTableProps) => {
   const [tasks, setTasks] = useState<ITask[]>([])
 
   const { data, error } = useQuery<ITask[], Error>({
@@ -48,15 +49,9 @@ const TasksTable = ({ filters }: TasksTableProps) => {
   const menuItemsRef = useRef<HTMLElement[]>([])
   const [confirmId, setConfirmId] = useState<number | null>(null)
   const [viewTask, setViewTask] = useState<ITask | null>(null)
-  const [isAddOpen, setIsAddOpen] = useState(false)
   const [editingTask, setEditingTask] = useState<ITask | null>(null)
   const returnFocusRef = useRef<HTMLElement | null>(null)
   const pathname = usePathname()
-
-  const closeAdd = () => {
-    setIsAddOpen(false)
-    returnFocusRef.current?.focus()
-  }
   const closeEdit = () => {
     setEditingTask(null)
     returnFocusRef.current?.focus()
@@ -183,18 +178,6 @@ const TasksTable = ({ filters }: TasksTableProps) => {
 
   return (
     <div>
-      <div className="flex justify-end mb-4">
-        <Button
-          className="rounded-2xl px-4 py-2 shadow-card bg-info text-neutral-50 hover:brightness-95 focus:ring-2 focus:ring-info"
-          onClick={e => {
-            returnFocusRef.current = e.currentTarget
-            setIsAddOpen(true)
-          }}
-        >
-          Добавить задачу
-        </Button>
-      </div>
-
       <table className="min-w-full bg-neutral-100 rounded shadow-md">
         <thead>
           <tr className="text-left border-b border-neutral-300">
@@ -401,13 +384,13 @@ const TasksTable = ({ filters }: TasksTableProps) => {
         />
       )}
       {isAddOpen && (
-        <Modal isOpen onClose={closeAdd} ariaLabelledby="task-form-title">
+        <Modal isOpen onClose={onCloseAdd} ariaLabelledby="task-form-title">
           <TaskForm
             onSuccess={task => {
               setTasks(prev => [...prev, task])
-              closeAdd()
+              onCloseAdd()
             }}
-            onCancel={closeAdd}
+            onCancel={onCloseAdd}
           />
         </Modal>
       )}

--- a/dashboard-ui/app/tasks/TasksContent.tsx
+++ b/dashboard-ui/app/tasks/TasksContent.tsx
@@ -1,15 +1,43 @@
 'use client'
 
+import { useRef, useState } from 'react'
+import { Plus } from 'lucide-react'
+
 import TaskFiltersToolbar from '@/components/tasks/TaskFiltersToolbar'
 import TasksTable from '@/components/tasks/TasksTable'
 import { useTaskFilters } from '@/hooks/useTaskFilters'
 
 const TasksContent = () => {
   const { filters, setFilters } = useTaskFilters()
+  const [isAddOpen, setIsAddOpen] = useState(false)
+  const fabRef = useRef<HTMLButtonElement | null>(null)
+
+  const openAddTaskModal = () => setIsAddOpen(true)
+  const closeAddTaskModal = () => {
+    setIsAddOpen(false)
+    fabRef.current?.focus()
+  }
+
   return (
     <>
       <TaskFiltersToolbar filters={filters} setFilters={setFilters} />
-      <TasksTable filters={filters} />
+      <TasksTable
+        filters={filters}
+        isAddOpen={isAddOpen}
+        onCloseAdd={closeAddTaskModal}
+      />
+      {!isAddOpen && (
+        <button
+          type="button"
+          aria-label="Добавить задачу"
+          title="Добавить задачу"
+          onClick={openAddTaskModal}
+          ref={fabRef}
+          className="fixed bottom-6 right-6 z-50 h-14 w-14 rounded-full shadow-card flex items-center justify-center cursor-pointer bg-success text-neutral-50 hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-success"
+        >
+          <Plus className="h-6 w-6" />
+        </button>
+      )}
     </>
   )
 }


### PR DESCRIPTION
## Summary
- add floating action button to open new task modal
- reduce gap between task filters and list
- move add-task modal control to parent component

## Testing
- `yarn lint app/tasks/TasksContent.tsx app/components/tasks/TasksTable.tsx app/components/tasks/TaskFiltersToolbar.tsx`
- `yarn test app/tasks/TasksContent.test.tsx` *(fails: Cannot find package 'vite')*
- `npx -y vitest run app/tasks/TasksContent.test.tsx` *(fails: Cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_e_68b489c2b7e4832988f95a0181887045