### PR TITLE
feat: unify fab and search components

### DIFF
--- a/dashboard-ui/app/components/products/ProductsTable.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.tsx
@@ -3,9 +3,15 @@
 import { useEffect, useRef, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Button from '@/ui/Button/Button'
-import { FaEdit, FaTrash, FaPrint, FaFileExport, FaSearch } from 'react-icons/fa'
-import { MdRemoveShoppingCart } from 'react-icons/md'
-import { HiOutlineArchiveBoxArrowDown } from 'react-icons/hi2'
+import SearchInput from '@/components/ui/SearchInput'
+import {
+  Pencil,
+  Trash2,
+  Printer,
+  Download,
+  PackageX,
+  Archive,
+} from 'lucide-react'
 import { createPortal } from 'react-dom'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from '@/utils/toast'
@@ -313,16 +319,10 @@ const ProductsTable = ({ isAddOpen, onCloseAdd }: ProductsTableProps) => {
         <h2 className="text-lg mb-2">Фильтры и поиск</h2>
         <div className="flex flex-wrap items-center gap-2">
           <div className="relative flex-1 min-w-[10rem]">
-            <FaSearch
-              className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
-              aria-hidden="true"
-            />
-            <input
-              type="text"
+            <SearchInput
               placeholder="Поиск..."
               value={searchTerm}
               onChange={e => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-3 h-11 rounded-xl border border-gray-300 focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
             />
           </div>
           {stockOptions.map(opt => {
@@ -377,7 +377,7 @@ const ProductsTable = ({ isAddOpen, onCloseAdd }: ProductsTableProps) => {
           <div className="grid grid-cols-2 gap-4">
             <div className="rounded-2xl p-4 md:p-5 shadow-sm border border-red-100 bg-red-50 text-red-700 flex flex-col justify-center">
               <div className="flex items-center gap-2">
-                <MdRemoveShoppingCart className="w-5 h-5 text-red-600" aria-hidden="true" />
+                <PackageX className="w-5 h-5 text-red-600" aria-hidden="true" />
                 <span className="text-sm text-gray-600">Нет в наличии</span>
               </div>
               {isInitialLoading ? (
@@ -388,7 +388,7 @@ const ProductsTable = ({ isAddOpen, onCloseAdd }: ProductsTableProps) => {
             </div>
             <div className="rounded-2xl p-4 md:p-5 shadow-sm border border-orange-100 bg-orange-50 text-orange-700 flex flex-col justify-center">
               <div className="flex items-center gap-2">
-                <HiOutlineArchiveBoxArrowDown className="w-5 h-5 text-orange-600" aria-hidden="true" />
+                <Archive className="w-5 h-5 text-orange-600" aria-hidden="true" />
                 <span className="text-sm text-gray-600">Мало на складе</span>
               </div>
               {isInitialLoading ? (
@@ -411,7 +411,7 @@ const ProductsTable = ({ isAddOpen, onCloseAdd }: ProductsTableProps) => {
               title="Экспорт CSV"
               aria-label="Экспорт CSV"
             >
-              <FaFileExport aria-hidden="true" />
+              <Download aria-hidden="true" className="w-4 h-4" />
             </Button>
             <Button
               className="bg-neutral-200 px-2 py-1"
@@ -419,7 +419,7 @@ const ProductsTable = ({ isAddOpen, onCloseAdd }: ProductsTableProps) => {
               title="Печать"
               aria-label="Печать"
             >
-              <FaPrint aria-hidden="true" />
+              <Printer aria-hidden="true" className="w-4 h-4" />
             </Button>
           </div>
       </>
@@ -615,7 +615,7 @@ const ProductsTable = ({ isAddOpen, onCloseAdd }: ProductsTableProps) => {
                             title="Редактировать"
                             disabled={deletingId === prod.id}
                           >
-                            <FaEdit aria-hidden="true" />
+                            <Pencil aria-hidden="true" className="w-4 h-4" />
                             <span>Редактировать</span>
                           </button>
                           <button
@@ -628,7 +628,7 @@ const ProductsTable = ({ isAddOpen, onCloseAdd }: ProductsTableProps) => {
                             title="Удалить"
                             disabled={deletingId === prod.id}
                           >
-                            <FaTrash aria-hidden="true" />
+                            <Trash2 aria-hidden="true" className="w-4 h-4" />
                             <span>Удалить</span>
                           </button>
                         </div>,

--- a/dashboard-ui/app/components/products/WarehouseKpiCards.tsx
+++ b/dashboard-ui/app/components/products/WarehouseKpiCards.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+import KpiCard from '@/components/ui/KpiCard'
+import { Package, CircleDollarSign, DollarSign } from 'lucide-react'
+
 interface WarehouseKpiCardsProps {
   totalCount: number
   purchaseValue: number
@@ -22,23 +25,20 @@ export default function WarehouseKpiCards({
   const cards = [
     {
       label: 'Товаров',
-      icon: '📦',
+      icon: <Package className="w-5 h-5 text-info" />, 
       value: numberFormatter.format(totalCount),
-      circle: 'bg-info/10 text-info',
       valueClass: 'text-info',
     },
     {
       label: 'Закупочная стоимость',
-      icon: '💰',
+      icon: <CircleDollarSign className="w-5 h-5 text-neutral-900" />, 
       value: currencyFormatter.format(purchaseValue),
-      circle: 'bg-primary-300 text-neutral-900',
       valueClass: 'text-neutral-900',
     },
     {
       label: 'Продажная стоимость',
-      icon: '💵',
+      icon: <DollarSign className="w-5 h-5 text-success" />, 
       value: currencyFormatter.format(saleValue),
-      circle: 'bg-success/10 text-success',
       valueClass: 'text-success',
     },
   ]
@@ -46,30 +46,14 @@ export default function WarehouseKpiCards({
   return (
     <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 md:gap-4">
       {cards.map(card => (
-        <div
+        <KpiCard
           key={card.label}
-          role="region"
-          aria-label={card.label}
-          className="rounded-2xl shadow-card p-4 md:p-5 flex items-center gap-3 bg-neutral-200"
-        >
-          <div
-            className={`w-10 h-10 rounded-full flex items-center justify-center ${card.circle}`}
-          >
-            <span aria-hidden="true">{card.icon}</span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-sm text-neutral-800">{card.label}</span>
-            {isLoading ? (
-              <div className="mt-1 h-7 w-20 bg-neutral-300 rounded animate-pulse" />
-            ) : (
-              <span
-                className={`text-2xl md:text-3xl font-semibold tabular-nums ${card.valueClass}`}
-              >
-                {card.value}
-              </span>
-            )}
-          </div>
-        </div>
+          icon={card.icon}
+          label={card.label}
+          value={card.value}
+          valueClassName={card.valueClass}
+          isLoading={isLoading}
+        />
       ))}
     </div>
   )

--- a/dashboard-ui/app/components/tasks/TaskFiltersToolbar.tsx
+++ b/dashboard-ui/app/components/tasks/TaskFiltersToolbar.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef, useState } from 'react'
 import useDebounce from '@/hooks/useDebounce'
 import { TaskFilters } from '@/hooks/useTaskFilters'
+import SearchInput from '@/components/ui/SearchInput'
+import { Calendar, Zap, RotateCcw } from 'lucide-react'
 
 interface Props {
   filters: TaskFilters
@@ -58,7 +60,7 @@ const TaskFiltersToolbar = ({ filters, setFilters }: Props) => {
           title={rangeDisplay}
           onClick={() => setDateOpen(o => !o)}
         >
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none">📅</span>
+          <Calendar className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-800 pointer-events-none" />
           {rangeDisplay}
         </button>
         {dateOpen && (
@@ -84,7 +86,7 @@ const TaskFiltersToolbar = ({ filters, setFilters }: Props) => {
         )}
       </div>
       <div className="flex items-center">
-        <span className="mr-1.5">⚡</span>
+        <Zap className="w-4 h-4 mr-1.5 text-neutral-800" />
         <select
           value={filters.priority}
           onChange={e => setFilters({ priority: e.target.value })}
@@ -99,7 +101,7 @@ const TaskFiltersToolbar = ({ filters, setFilters }: Props) => {
         </select>
       </div>
       <div className="flex items-center">
-        <span className="mr-1.5">🔄</span>
+        <RotateCcw className="w-4 h-4 mr-1.5 text-neutral-800" />
         <select
           value={filters.status}
           onChange={e => setFilters({ status: e.target.value })}
@@ -114,14 +116,11 @@ const TaskFiltersToolbar = ({ filters, setFilters }: Props) => {
           <option value="Просроченные">Просроченные</option>
         </select>
       </div>
-      <div className="flex items-center flex-1 min-w-[200px]">
-        <span className="mr-1.5">🔍</span>
-        <input
-          type="text"
+      <div className="flex-1 min-w-[200px]">
+        <SearchInput
           value={searchInput}
           onChange={e => setSearchInput(e.target.value)}
           placeholder="Поиск…"
-          className="h-10 flex-1 min-w-[200px] rounded-xl border border-neutral-300 bg-neutral-100 px-3 cursor-pointer focus:ring-2 focus:ring-primary-300"
           aria-label="Поиск"
           title="Поиск"
         />

--- a/dashboard-ui/app/components/ui/Fab.tsx
+++ b/dashboard-ui/app/components/ui/Fab.tsx
@@ -1,0 +1,25 @@
+import { forwardRef, ButtonHTMLAttributes } from 'react'
+import clsx from 'classnames'
+import { Plus } from 'lucide-react'
+
+interface FabProps extends ButtonHTMLAttributes<HTMLButtonElement> {}
+
+const Fab = forwardRef<HTMLButtonElement, FabProps>(({ className, children, ...props }, ref) => {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      className={clsx(
+        'fixed bottom-6 right-6 z-50 h-14 w-14 rounded-full flex items-center justify-center shadow-card bg-success text-neutral-50 hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-success',
+        className,
+      )}
+      {...props}
+    >
+      {children ?? <Plus className="w-6 h-6" />}
+    </button>
+  )
+})
+
+Fab.displayName = 'Fab'
+
+export default Fab

--- a/dashboard-ui/app/components/ui/KpiCard.tsx
+++ b/dashboard-ui/app/components/ui/KpiCard.tsx
@@ -1,0 +1,37 @@
+import clsx from 'classnames'
+import { ReactNode } from 'react'
+
+interface KpiCardProps {
+  icon: ReactNode
+  label: string
+  value: ReactNode
+  valueClassName?: string
+  isLoading?: boolean
+}
+
+const KpiCard = ({ icon, label, value, valueClassName, isLoading }: KpiCardProps) => {
+  return (
+    <div className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 flex items-center gap-3">
+      <div className="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 bg-neutral-100">
+        {icon}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="text-sm text-neutral-800 truncate">{label}</div>
+        {isLoading ? (
+          <div className="mt-1 h-7 w-20 bg-neutral-300 rounded animate-pulse" />
+        ) : (
+          <div
+            className={clsx(
+              'text-2xl md:text-3xl font-semibold tabular-nums whitespace-nowrap overflow-hidden text-ellipsis',
+              valueClassName,
+            )}
+          >
+            {value}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default KpiCard

--- a/dashboard-ui/app/components/ui/SearchInput.tsx
+++ b/dashboard-ui/app/components/ui/SearchInput.tsx
@@ -1,0 +1,26 @@
+import { forwardRef, InputHTMLAttributes } from 'react'
+import clsx from 'classnames'
+import { Search } from 'lucide-react'
+
+interface SearchInputProps extends InputHTMLAttributes<HTMLInputElement> {}
+
+const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(({ className, ...props }, ref) => {
+  return (
+    <div className="relative">
+      <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-neutral-800" />
+      <input
+        ref={ref}
+        type="search"
+        className={clsx(
+          'h-10 w-full rounded-xl border border-neutral-300 bg-neutral-100 pl-9 pr-3 placeholder:text-neutral-800 focus:outline-none focus:ring-2 focus:ring-primary-300',
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  )
+})
+
+SearchInput.displayName = 'SearchInput'
+
+export default SearchInput

--- a/dashboard-ui/app/products/ProductsPageClient.tsx
+++ b/dashboard-ui/app/products/ProductsPageClient.tsx
@@ -2,6 +2,7 @@
 
 import ProductsTable from '@/components/products/ProductsTable'
 import { useState } from 'react'
+import Fab from '@/components/ui/Fab'
 
 export default function ProductsPageClient() {
   const [isAddOpen, setIsAddOpen] = useState(false)
@@ -10,16 +11,11 @@ export default function ProductsPageClient() {
     <>
       <ProductsTable isAddOpen={isAddOpen} onCloseAdd={() => setIsAddOpen(false)} />
       {!isAddOpen && (
-        <div className="fixed z-50 bottom-6 right-6 md:bottom-8 md:right-8 pb-[env(safe-area-inset-bottom)]">
-          <button
-            aria-label="Добавить товар"
-            title="Добавить товар"
-            onClick={() => setIsAddOpen(true)}
-            className="rounded-full w-14 h-14 md:w-16 md:h-16 flex items-center justify-center bg-primary-500 hover:bg-primary-400 text-neutral-50 shadow-lg focus:outline-none focus:ring-2 focus:ring-primary-300 transition-transform hover:scale-105 active:scale-95"
-          >
-            +
-          </button>
-        </div>
+        <Fab
+          aria-label="Добавить товар"
+          title="Добавить товар"
+          onClick={() => setIsAddOpen(true)}
+        />
       )}
     </>
   )

--- a/dashboard-ui/app/tasks/TasksContent.tsx
+++ b/dashboard-ui/app/tasks/TasksContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRef, useState } from 'react'
-import { Plus } from 'lucide-react'
+import Fab from '@/components/ui/Fab'
 
 import TaskFiltersToolbar from '@/components/tasks/TaskFiltersToolbar'
 import TasksTable from '@/components/tasks/TasksTable'
@@ -27,16 +27,12 @@ const TasksContent = () => {
         onCloseAdd={closeAddTaskModal}
       />
       {!isAddOpen && (
-        <button
-          type="button"
+        <Fab
+          ref={fabRef}
           aria-label="Добавить задачу"
           title="Добавить задачу"
           onClick={openAddTaskModal}
-          ref={fabRef}
-          className="fixed bottom-6 right-6 z-50 h-14 w-14 rounded-full shadow-card flex items-center justify-center cursor-pointer bg-success text-neutral-50 hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-success"
-        >
-          <Plus className="h-6 w-6" />
-        </button>
+        />
       )}
     </>
   )


### PR DESCRIPTION
## Summary
- add reusable Fab, SearchInput and KpiCard components
- replace old icons in products and tasks sections
- switch warehouse KPI cards to new component

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b48eccfe8083298eb4c440846794ac