### PR TITLE
feat: enhance dashboard metrics and charts

### DIFF
--- a/dashboard-ui/app/components/dashboard/KpiCards.test.tsx
+++ b/dashboard-ui/app/components/dashboard/KpiCards.test.tsx
@@ -9,11 +9,14 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(),
 }))
 
+const getKpisMock = vi.fn()
+;(getKpisMock as any)
+  .mockResolvedValueOnce({ revenue: 1000, orders: 2, avgCheck: 500, margin: 400 })
+  .mockResolvedValueOnce({ revenue: 800, orders: 1, avgCheck: 800, margin: 200 })
+
 vi.mock('@/services/analytics/analytics.service', () => ({
   AnalyticsService: {
-    getKpis: vi.fn(() =>
-      Promise.resolve({ revenue: 1000, orders: 2, avgCheck: 500 })
-    ),
+    getKpis: (...args: any[]) => getKpisMock(...args),
   },
 }))
 
@@ -24,15 +27,15 @@ const renderKpis = () => {
       <PeriodProvider>
         <KpiCards />
       </PeriodProvider>
-    </QueryClientProvider>
+    </QueryClientProvider>,
   )
 }
 
 describe('KpiCards', () => {
-  it('aggregates KPIs', async () => {
+  it('renders KPI groups', async () => {
     renderKpis()
-    expect(await screen.findByText('2')).toBeInTheDocument()
-    expect(await screen.findByText(/1[\s\u00A0]?000,00/)).toBeInTheDocument()
-    expect(await screen.findByText(/500,00/)).toBeInTheDocument()
+    expect(await screen.findByText('Выручка')).toBeInTheDocument()
+    expect(screen.getByText('Кол-во продаж')).toBeInTheDocument()
+    expect(screen.getByText('📦 Операционные')).toBeInTheDocument()
   })
 })

--- a/dashboard-ui/app/components/dashboard/KpiCards.tsx
+++ b/dashboard-ui/app/components/dashboard/KpiCards.tsx
@@ -1,34 +1,94 @@
 "use client";
 
 import React from "react";
-import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
-import { FaReceipt, FaRubleSign, FaShoppingCart } from "react-icons/fa";
+import { FaBriefcase, FaPercent, FaReceipt, FaRubleSign, FaShoppingCart } from "react-icons/fa";
+import KpiCard from "@/components/ui/KpiCard";
 import { AnalyticsService } from "@/services/analytics/analytics.service";
 import { getPeriodRange } from "@/utils/buckets";
 import { usePeriod } from "@/store/period";
 
-const currency = new Intl.NumberFormat("ru-RU", {
+type KpiData = {
+  revenue: number;
+  orders: number;
+  avgCheck: number;
+  margin: number;
+};
+
+function getPrevRange(period: any) {
+  const { start, end } = getPeriodRange(period);
+  switch (period) {
+    case "day": {
+      const prev = new Date(start);
+      prev.setDate(prev.getDate() - 1);
+      return { start: prev, end: prev };
+    }
+    case "week": {
+      const prevEnd = new Date(start);
+      prevEnd.setDate(prevEnd.getDate() - 1);
+      const prevStart = new Date(prevEnd);
+      prevStart.setDate(prevStart.getDate() - 6);
+      return { start: prevStart, end: prevEnd };
+    }
+    case "month": {
+      const prevStart = new Date(start.getFullYear(), start.getMonth() - 1, 1);
+      const prevEnd = new Date(start.getFullYear(), start.getMonth(), 0);
+      return { start: prevStart, end: prevEnd };
+    }
+    case "year": {
+      const prevStart = new Date(start.getFullYear() - 1, 0, 1);
+      const prevEnd = new Date(start.getFullYear() - 1, 11, 31);
+      return { start: prevStart, end: prevEnd };
+    }
+    default:
+      return { start, end };
+  }
+}
+
+const numberCompact = new Intl.NumberFormat("ru-RU", {
+  notation: "compact",
+  compactDisplay: "short",
+});
+const numberFull = new Intl.NumberFormat("ru-RU");
+const currencyCompact = new Intl.NumberFormat("ru-RU", {
+  style: "currency",
+  currency: "RUB",
+  notation: "compact",
+  compactDisplay: "short",
+});
+const currencyFull = new Intl.NumberFormat("ru-RU", {
   style: "currency",
   currency: "RUB",
 });
 
+function delta(curr: number, prev: number) {
+  return ((curr - prev) / Math.max(prev, 1e-9)) * 100;
+}
+
 const KpiCards: React.FC = () => {
   const { period } = usePeriod();
   const { start, end } = getPeriodRange(period);
+  const prevRange = getPrevRange(period);
+
+  const startStr = start.toISOString().slice(0, 10);
+  const endStr = end.toISOString().slice(0, 10);
+  const prevStartStr = prevRange.start.toISOString().slice(0, 10);
+  const prevEndStr = prevRange.end.toISOString().slice(0, 10);
+
   const {
-    data,
+    data: curr,
     isLoading,
     isFetching,
     error,
     refetch,
-  } = useQuery({
-    queryKey: ["kpi", period, start.toISOString(), end.toISOString()],
-    queryFn: async () =>
-      AnalyticsService.getKpis(
-        start.toISOString().slice(0, 10),
-        end.toISOString().slice(0, 10)
-      ),
+  } = useQuery<KpiData>({
+    queryKey: ["kpi", period, startStr, endStr],
+    queryFn: () => AnalyticsService.getKpis(startStr, endStr),
+    keepPreviousData: true,
+  });
+  const { data: prev } = useQuery<KpiData>({
+    queryKey: ["kpi", period, prevStartStr, prevEndStr],
+    queryFn: () => AnalyticsService.getKpis(prevStartStr, prevEndStr),
     keepPreviousData: true,
   });
 
@@ -36,79 +96,106 @@ const KpiCards: React.FC = () => {
     return (
       <div className="text-error flex items-center gap-2">
         Ошибка загрузки
-        <button
-          className="underline"
-          onClick={() => refetch()}
-        >
+        <button className="underline" onClick={() => refetch()}>
           Повторить
         </button>
       </div>
     );
   }
-  const revenue = data?.revenue ?? 0;
-  const salesCount = data?.orders ?? 0;
-  const avgCheck = data?.avgCheck ?? (salesCount ? revenue / salesCount : 0);
 
-  const kpis = [
+  const revenue = curr?.revenue ?? 0;
+  const prevRevenue = prev?.revenue ?? 0;
+  const profit = curr?.margin ?? 0;
+  const prevProfit = prev?.margin ?? 0;
+  const marginPct = revenue ? (profit / revenue) * 100 : 0;
+  const prevMarginPct = prevRevenue ? (prevProfit / prevRevenue) * 100 : 0;
+  const orders = curr?.orders ?? 0;
+  const prevOrders = prev?.orders ?? 0;
+  const avg = curr?.avgCheck ?? (orders ? revenue / orders : 0);
+  const prevAvg = prev?.avgCheck ?? (prevOrders ? prevRevenue / prevOrders : 0);
+
+  const groups = [
     {
-      label: "Выручка",
-      value: currency.format(revenue),
-      href: "/reports",
-      text: "text-success",
-      bg: "bg-success/20",
-      Icon: FaRubleSign,
+      title: "💰 Финансовые",
+      items: [
+        {
+          label: "Выручка",
+          value: currencyCompact.format(revenue),
+          valueTitle: currencyFull.format(revenue),
+          valueClass: "text-success",
+          delta: delta(revenue, prevRevenue),
+          icon: <FaRubleSign className="text-success" />,
+        },
+        {
+          label: "Фин. итог",
+          value: currencyCompact.format(profit),
+          valueTitle: currencyFull.format(profit),
+          valueClass: profit >= 0 ? "text-success" : "text-error",
+          delta: delta(profit, prevProfit),
+          icon: <FaBriefcase className={profit >= 0 ? "text-success" : "text-error"} />,
+        },
+        {
+          label: "Маржа",
+          value: `${marginPct.toFixed(1).replace('.', ',')}%`,
+          valueTitle: `${marginPct.toFixed(2).replace('.', ',')}%`,
+          valueClass: marginPct >= 0 ? "text-success" : "text-error",
+          delta: delta(marginPct, prevMarginPct),
+          icon: <FaPercent className={marginPct >= 0 ? "text-success" : "text-error"} />,
+        },
+      ],
     },
     {
-      label: "Кол-во продаж",
-      value: salesCount.toLocaleString("ru-RU"),
-      href: "/reports",
-      text: "text-info",
-      bg: "bg-info/20",
-      Icon: FaShoppingCart,
-    },
-    {
-      label: "Средний чек",
-      value: currency.format(avgCheck),
-      href: "/reports",
-      text: "text-secondary-700",
-      bg: "bg-secondary-300/40",
-      Icon: FaReceipt,
+      title: "📦 Операционные",
+      items: [
+        {
+          label: "Кол-во продаж",
+          value: numberCompact.format(orders),
+          valueTitle: numberFull.format(orders),
+          valueClass: "text-info",
+          delta: delta(orders, prevOrders),
+          icon: <FaShoppingCart className="text-info" />,
+        },
+        {
+          label: "Средний чек",
+          value: currencyCompact.format(avg),
+          valueTitle: currencyFull.format(avg),
+          valueClass: "text-warning",
+          delta: delta(avg, prevAvg),
+          icon: <FaReceipt className="text-warning" />,
+        },
+      ],
     },
   ];
 
   return (
-    <div className="relative">
-      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-        {isLoading && !data
-          ? Array.from({ length: 3 }).map((_, i) => (
-              <div
-                key={i}
-                className="h-24 bg-neutral-200 rounded-2xl animate-pulse"
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      {groups.map((g) => (
+        <div
+          key={g.title}
+          className="rounded-2xl bg-neutral-200 shadow-card p-4 relative"
+        >
+          <h3 className="text-lg font-semibold mb-4">{g.title}</h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {g.items.map((item) => (
+              <KpiCard
+                key={item.label}
+                icon={item.icon}
+                label={item.label}
+                value={item.value}
+                valueTitle={item.valueTitle}
+                valueClassName={item.valueClass}
+                isLoading={isLoading && !curr}
+                deltaPct={item.delta}
               />
-            ))
-          : kpis.map(({ label, value, href, text, bg, Icon }) => (
-              <Link
-                key={label}
-                href={href}
-                className="bg-neutral-200 p-4 md:p-5 rounded-2xl shadow-card flex items-center gap-4"
-              >
-                <span
-                  className={`w-10 h-10 rounded-full flex items-center justify-center ${bg} ${text}`}
-                >
-                  <Icon />
-                </span>
-                <span className="flex flex-col">
-                  <span className="text-sm text-neutral-600">{label}</span>
-                  <span className={`text-2xl md:text-3xl font-semibold tabular-nums ${text}`}>{value}</span>
-                </span>
-              </Link>
             ))}
-      </div>
-      {isFetching && data && (
-        <div className="absolute inset-0 flex items-center justify-center bg-white/50">
-          <div className="w-6 h-6 border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
+          </div>
+          {isFetching && curr && (
+            <div className="absolute inset-0 flex items-center justify-center bg-white/50">
+              <div className="w-6 h-6 border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
+            </div>
+          )}
         </div>
-      )}
+      ))}
     </div>
   );
 };

--- a/dashboard-ui/app/components/dashboard/SalesChart.tsx
+++ b/dashboard-ui/app/components/dashboard/SalesChart.tsx
@@ -1,15 +1,15 @@
 "use client";
 
-import React, { useState } from "react";
+import React from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
-  LineChart,
+  ResponsiveContainer,
+  ComposedChart,
+  Bar,
   Line,
   XAxis,
   YAxis,
   Tooltip,
-  Legend,
-  ResponsiveContainer,
   CartesianGrid,
   ReferenceLine,
 } from "recharts";
@@ -17,81 +17,75 @@ import { AnalyticsService } from "@/services/analytics/analytics.service";
 import { buildBuckets, getPeriodRange } from "@/utils/buckets";
 import { usePeriod } from "@/store/period";
 
-const metricOptions = [
-  { value: "revenue", label: "Выручка" },
-  { value: "sales", label: "Количество" },
-] as const;
+const currency = new Intl.NumberFormat("ru-RU", {
+  style: "currency",
+  currency: "RUB",
+});
+const intFmt = new Intl.NumberFormat("ru-RU");
+
+const formatDate = (date: Date) =>
+  new Date(date.getTime() - date.getTimezoneOffset() * 60000)
+    .toISOString()
+    .slice(0, 10);
 
 const SalesChart: React.FC = () => {
   const { period } = usePeriod();
-  const [metric, setMetric] = useState<(typeof metricOptions)[number]["value"]>(
-    "revenue"
-  );
   const { start, end } = getPeriodRange(period);
-
-  const formatDate = (date: Date) => {
-    return new Date(date.getTime() - date.getTimezoneOffset() * 60000)
-      .toISOString()
-      .slice(0, 10);
-  };
+  const s = formatDate(start);
+  const e = formatDate(end);
 
   const {
-    data,
-    isFetching,
-    isLoading,
-    error,
-    refetch,
+    data: revenueData,
+    isLoading: revLoading,
+    isFetching: revFetching,
+    error: revError,
+    refetch: refetchRev,
   } = useQuery({
-    queryKey: [
-      "sales-chart",
-      metric,
-      period,
-      formatDate(start),
-      formatDate(end),
-    ],
-    queryFn: async () => {
-      const s = formatDate(start);
-      const e = formatDate(end);
-      if (metric === "revenue") {
-        return AnalyticsService.getDailyRevenue(s, e);
-      }
-      return AnalyticsService.getSales(s, e);
-    },
+    queryKey: ["daily-revenue", period, s, e],
+    queryFn: () => AnalyticsService.getDailyRevenue(s, e),
     keepPreviousData: true,
   });
 
+  const {
+    data: qtyData,
+    isLoading: qtyLoading,
+    isFetching: qtyFetching,
+    error: qtyError,
+    refetch: refetchQty,
+  } = useQuery({
+    queryKey: ["sales", period, s, e],
+    queryFn: () => AnalyticsService.getSales(s, e),
+    keepPreviousData: true,
+  });
+
+  const loading = revLoading || qtyLoading;
+  const fetching = revFetching || qtyFetching;
+  const error = revError || qtyError;
+
   const buckets = buildBuckets({ start, end }, period);
-  const map = new Map<string, number>();
-  (data ?? []).forEach((d) => {
+  const mapRev = new Map<string, number>();
+  (revenueData ?? []).forEach((d: any) => {
     const key = period === "year" ? d.date.slice(0, 7) : d.date.slice(0, 10);
-    map.set(key, (map.get(key) ?? 0) + d.total);
+    mapRev.set(key, (mapRev.get(key) ?? 0) + d.total);
   });
-  const chartData = buckets.map((b) => ({ ...b, value: map.get(b.key) ?? 0 }));
-  const allZero = chartData.every((d) => d.value === 0);
-  const maxValue = Math.max(...chartData.map((d) => d.value), 0);
-  const step =
-    metric === "revenue"
-      ? Math.max(1, Math.round(maxValue / 5 / 100000)) * 100000
-      : Math.max(1, Math.round(maxValue / 5));
-  const ticks = Array.from(
-    { length: Math.floor(maxValue / step) + 1 },
-    (_, i) => i * step
-  );
-
-  const currency = new Intl.NumberFormat("ru-RU", {
-    style: "currency",
-    currency: "RUB",
-    maximumFractionDigits: 0,
+  const mapQty = new Map<string, number>();
+  (qtyData ?? []).forEach((d: any) => {
+    const key = period === "year" ? d.date.slice(0, 7) : d.date.slice(0, 10);
+    mapQty.set(key, (mapQty.get(key) ?? 0) + d.total);
   });
+  const chartData = buckets.map((b) => ({
+    ...b,
+    revenue: mapRev.get(b.key) ?? 0,
+    quantity: mapQty.get(b.key) ?? 0,
+  }));
 
-  const formatValue = (v: number) =>
-    metric === "revenue" ? currency.format(v) : v.toLocaleString("ru-RU");
+  const allZero = chartData.every((d) => d.revenue === 0 && d.quantity === 0);
 
   if (error) {
     return (
-      <div className="bg-neutral-200 p-4 md:p-5 rounded-2xl shadow-card text-error flex items-center gap-2">
+      <div className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 text-error flex items-center gap-2">
         Ошибка загрузки
-        <button className="underline" onClick={() => refetch()}>
+        <button className="underline" onClick={() => { refetchRev(); refetchQty(); }}>
           Повторить
         </button>
       </div>
@@ -99,27 +93,10 @@ const SalesChart: React.FC = () => {
   }
 
   return (
-    <div className="bg-neutral-200 p-4 md:p-5 rounded-2xl shadow-card">
-      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 mb-4">
-        <h3 className="text-lg font-semibold flex items-center gap-2">📊 Продажи</h3>
-        <div className="flex gap-2">
-          {metricOptions.map((m) => (
-            <button
-              key={m.value}
-              className={`px-2 py-1 text-sm rounded border ${
-                metric === m.value
-                  ? "bg-primary-500 text-white border-primary-500"
-                  : "border-neutral-300"
-              }`}
-              onClick={() => setMetric(m.value)}
-            >
-              {m.label}
-            </button>
-          ))}
-        </div>
-      </div>
-      <div className="h-64 relative">
-        {isLoading ? (
+    <div className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5">
+      <h3 className="text-lg font-semibold mb-4">📊 Продажи</h3>
+      <div className="relative" style={{ height: 360 }}>
+        {loading ? (
           <div className="absolute inset-0 flex items-end space-x-2">
             {buckets.map((_, idx) => (
               <div key={idx} className="flex-1 animate-pulse bg-neutral-300" />
@@ -127,7 +104,7 @@ const SalesChart: React.FC = () => {
           </div>
         ) : (
           <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={chartData} margin={{ left: 8, right: 8, top: 5, bottom: 5 }}>
+            <ComposedChart data={chartData} margin={{ top: 5, right: 8, bottom: 5, left: 8 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
               <XAxis
                 dataKey="label"
@@ -136,37 +113,47 @@ const SalesChart: React.FC = () => {
                 tick={{ fontSize: 14 }}
               />
               <YAxis
-                tickFormatter={formatValue}
-                ticks={ticks}
+                yAxisId="left"
+                tickFormatter={(v) => currency.format(Number(v))}
+                width={72}
                 tickLine={false}
                 axisLine={false}
-                width={80}
+              />
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                tickFormatter={(v) => intFmt.format(Number(v))}
+                width={48}
+                tickLine={false}
+                axisLine={false}
               />
               <Tooltip
-                formatter={(value: number) => formatValue(Number(value))}
+                formatter={(value: any, name) =>
+                  name === "revenue"
+                    ? currency.format(Number(value))
+                    : `${intFmt.format(Number(value))} шт`}
                 labelFormatter={(label) => label}
                 contentStyle={{ fontSize: 12 }}
               />
-              <Legend wrapperStyle={{ fontSize: 12 }} />
+              <Bar dataKey="quantity" yAxisId="right" barSize={20} fill="#3B82F6" />
               <Line
                 type="monotone"
-                dataKey="value"
-                stroke={metric === "revenue" ? "#3B82F6" : "#10B981"}
+                dataKey="revenue"
+                yAxisId="left"
+                stroke="#10B981"
                 strokeWidth={2}
-                dot={false}
-                name={metricOptions.find((m) => m.value === metric)?.label}
-                isAnimationActive
+                dot
               />
               {allZero && <ReferenceLine y={0} stroke="#EF4444" strokeWidth={1} />}
-            </LineChart>
+            </ComposedChart>
           </ResponsiveContainer>
         )}
-        {allZero && (
+        {allZero && !loading && (
           <div className="absolute inset-0 flex items-center justify-center text-neutral-500">
             Нет данных
           </div>
         )}
-        {isFetching && data && (
+        {fetching && !loading && (
           <div className="absolute inset-0 flex items-center justify-center bg-white/50">
             <div className="w-6 h-6 border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
           </div>

--- a/dashboard-ui/app/components/dashboard/TopProducts.test.tsx
+++ b/dashboard-ui/app/components/dashboard/TopProducts.test.tsx
@@ -8,13 +8,8 @@ vi.mock('@/services/analytics/analytics.service', () => ({
   AnalyticsService: {
     getTopProducts: vi.fn(() =>
       Promise.resolve([
-        { productId: 1, productName: 'Prod1', categoryName: 'Cat1', totalUnits: 10, totalRevenue: 1000 },
-      ])
-    ),
-    getCategorySales: vi.fn(() =>
-      Promise.resolve([
-        { categoryId: 1, categoryName: 'Cat1', totalUnits: 10, totalRevenue: 1000 },
-      ])
+        { productId: 1, productName: 'Prod1', totalUnits: 10, totalRevenue: 1000, purchaseCostPortion: 400 },
+      ]),
     ),
   },
 }))
@@ -31,15 +26,14 @@ const renderWidget = () => {
       <PeriodProvider>
         <TopProducts />
       </PeriodProvider>
-    </QueryClientProvider>
+    </QueryClientProvider>,
   )
 }
 
-describe('TopProducts charts', () => {
-  it('renders headings', async () => {
+describe('TopProducts', () => {
+  it('renders header and select', async () => {
     renderWidget()
-    expect(await screen.findByText('🏆 Топ товаров')).toBeInTheDocument()
-    expect(screen.getByText('Товары')).toBeInTheDocument()
-    expect(screen.getByText('Категории')).toBeInTheDocument()
+    expect(await screen.findByText(/Топ товаров/)).toBeInTheDocument()
+    expect(screen.getByRole('combobox')).toBeInTheDocument()
   })
 })

--- a/dashboard-ui/app/components/dashboard/TopProducts.tsx
+++ b/dashboard-ui/app/components/dashboard/TopProducts.tsx
@@ -1,528 +1,166 @@
-"use client"
+"use client";
 
-import React, { useEffect, useMemo, useState } from "react"
-import { useRouter } from "next/navigation"
-import { useQuery } from "@tanstack/react-query"
+import React, { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import {
+  ResponsiveContainer,
   BarChart,
   Bar,
   XAxis,
   YAxis,
   Tooltip,
-  ResponsiveContainer,
-  PieChart,
-  Pie,
-  Cell,
-} from "recharts"
-import { AnalyticsService } from "@/services/analytics/analytics.service"
-import { getPeriodRange } from "@/utils/buckets"
-import { usePeriod } from "@/store/period"
-
-const metricOptions = [
-  { value: "revenue", label: "Выручка" },
-  { value: "quantity", label: "Количество" },
-] as const
-
-const limitOptions = [5, 10, 15] as const
-
-const COLORS = [
-  "#3B82F6",
-  "#10B981",
-  "#F59E0B",
-  "#EF4444",
-  "#8B5CF6",
-  "#6366F1",
-  "#EC4899",
-  "#14B8A6",
-  "#F97316",
-  "#84CC16",
-  "#D946EF",
-  "#0EA5E9",
-  "#F43F5E",
-  "#22C55E",
-  "#A855F7",
-]
-
-const rubFormatter = new Intl.NumberFormat("ru-RU", {
-  style: "currency",
-  currency: "RUB",
-})
-const intFormatter = new Intl.NumberFormat("ru-RU")
-const formatRub = (v: number) => rubFormatter.format(v)
-const formatInt = (v: number) => intFormatter.format(v)
-const round2 = (v: number) => Math.round(v * 100) / 100
+} from "recharts";
+import { AnalyticsService } from "@/services/analytics/analytics.service";
+import { getPeriodRange } from "@/utils/buckets";
+import { usePeriod } from "@/store/period";
 
 const formatDate = (date: Date) =>
   new Date(date.getTime() - date.getTimezoneOffset() * 60000)
     .toISOString()
-    .slice(0, 10)
+    .slice(0, 10);
+
+const currency = new Intl.NumberFormat("ru-RU", {
+  style: "currency",
+  currency: "RUB",
+});
+const intFmt = new Intl.NumberFormat("ru-RU");
+
+const options = [
+  { value: "revenue", label: "Выручка" },
+  { value: "quantity", label: "Количество" },
+  { value: "profit", label: "Прибыль" },
+] as const;
+
+type Metric = (typeof options)[number]["value"];
 
 const TopProducts: React.FC = () => {
-  const router = useRouter()
-  const { period } = usePeriod()
-  const [metric, setMetric] = useState<(typeof metricOptions)[number]["value"]>(
-    "revenue",
-  )
-  const [limit, setLimit] = useState<(typeof limitOptions)[number]>(5)
-  const { start, end } = getPeriodRange(period)
-  const s = formatDate(start)
-  const e = formatDate(end)
+  const { period } = usePeriod();
+  const { start, end } = getPeriodRange(period);
+  const s = formatDate(start);
+  const e = formatDate(end);
+  const [metric, setMetric] = useState<Metric>("revenue");
 
   const {
-    data: products,
-    isLoading: prodLoading,
-    isFetching: prodFetching,
-    error: prodError,
-    refetch: refetchProducts,
+    data,
+    isLoading,
+    isFetching,
+    error,
+    refetch,
   } = useQuery({
-    queryKey: ["top-products", period, s, e, metric, limit],
-    queryFn: () => AnalyticsService.getTopProducts(15, s, e),
+    queryKey: ["top-products", period, s, e, metric],
+    queryFn: () => AnalyticsService.getTopProducts(50, s, e),
     keepPreviousData: true,
-    placeholderData: (prev) => prev,
-  })
+  });
 
-  const {
-    data: categories,
-    isLoading: catLoading,
-    isFetching: catFetching,
-    error: catError,
-    refetch: refetchCategories,
-  } = useQuery({
-    queryKey: ["category-sales", period, s, e, metric, limit],
-    queryFn: () => AnalyticsService.getCategorySales(s, e),
-    keepPreviousData: true,
-    placeholderData: (prev) => prev,
-  })
-
-  const productsAgg = useMemo(() => {
-    const map = new Map<number, { name: string; qty: number; rev: number }>()
-    for (const row of products ?? []) {
-      const productId = Number((row as any).productId)
-      if (!productId) continue
-      const productName = String((row as any).productName ?? "")
-      const qty =
-        Number(
-          (row as any).quantity_sold ??
-            (row as any).unitsSold ??
-            (row as any).totalUnits ??
-            0,
-        ) || 0
-      const rawRev =
-        Number(
-          (row as any).revenue ??
-            (row as any).total_price ??
-            (row as any).totalRevenue ??
-            0,
-        ) || 0
-      const rev =
-        ("revenue" in (row as any) || "total_price" in (row as any))
-          ? rawRev / 100
-          : rawRev
-      const curr = map.get(productId) ?? { name: productName, qty: 0, rev: 0 }
-      curr.name = productName || curr.name
-      curr.qty += qty
-      curr.rev += rev
-      map.set(productId, curr)
-    }
-    return Array.from(map.entries()).map(([productId, v]) => ({
-      productId,
-      productName: v.name,
-      totalUnits: Math.round(Number(v.qty) || 0),
-      totalRevenue: round2(Number(v.rev) || 0),
-    }))
-  }, [products])
-
-  const categoriesAgg = useMemo(() => {
-    const map = new Map<number, { name: string; qty: number; rev: number }>()
-    for (const row of categories ?? []) {
-      const categoryId = Number((row as any).categoryId)
-      if (!categoryId) continue
-      const categoryName = String((row as any).categoryName ?? "")
-      const qty =
-        Number(
-          (row as any).quantity_sold ??
-            (row as any).unitsSold ??
-            (row as any).totalUnits ??
-            0,
-        ) || 0
-      const rawRev =
-        Number(
-          (row as any).revenue ??
-            (row as any).total_price ??
-            (row as any).totalRevenue ??
-            0,
-        ) || 0
-      const rev =
-        ("revenue" in (row as any) || "total_price" in (row as any))
-          ? rawRev / 100
-          : rawRev
-      const curr = map.get(categoryId) ?? { name: categoryName, qty: 0, rev: 0 }
-      curr.name = categoryName || curr.name
-      curr.qty += qty
-      curr.rev += rev
-      map.set(categoryId, curr)
-    }
-    return Array.from(map.entries()).map(([categoryId, v]) => ({
-      categoryId,
-      categoryName: v.name,
-      totalUnits: Math.round(Number(v.qty) || 0),
-      totalRevenue: round2(Number(v.rev) || 0),
-    }))
-  }, [categories])
-
-  const topProductData = useMemo(() => {
-    const truncate = (s: string) => (s.length > 14 ? s.slice(0, 14) + "…" : s)
-    const items = [...productsAgg]
-    items.sort((a, b) =>
-      metric === "revenue"
-        ? b.totalRevenue - a.totalRevenue
-        : b.totalUnits - a.totalUnits,
-    )
-    return items.slice(0, limit).map((p) => {
-      const value =
-        metric === "revenue"
-          ? Number(p.totalRevenue) || 0
-          : Number(p.totalUnits) || 0
+  const items = useMemo(() => {
+    return (data ?? []).map((row: any) => {
+      const revenue = Number(row.totalRevenue ?? row.revenue ?? 0);
+      const quantity = Number(row.totalUnits ?? row.quantity ?? 0);
+      const profit =
+        "profit" in row
+          ? Number(row.profit)
+          : revenue - Number(row.purchaseCostPortion ?? 0);
       return {
-        name: truncate(p.productName),
-        fullName: p.productName,
-        value,
-        productId: p.productId,
-        productName: p.productName,
-      }
-    })
-  }, [productsAgg, metric, limit])
+        name: String(row.productName ?? ""),
+        revenue,
+        quantity,
+        profit,
+      };
+    });
+  }, [data]);
 
-  const pieData = useMemo(() => {
-    const items = [...categoriesAgg]
-    items.sort((a, b) =>
-      metric === "revenue"
-        ? b.totalRevenue - a.totalRevenue
-        : b.totalUnits - a.totalUnits,
-    )
-    const top = items.slice(0, limit)
-    const rest = items.slice(limit)
-    if (rest.length) {
-      const restValue = rest.reduce(
-        (sum, c) =>
-          sum + (metric === "revenue" ? c.totalRevenue : c.totalUnits),
-        0,
-      )
-      if (restValue > 0) {
-        top.push({
-          categoryId: 0,
-          categoryName: "Прочее",
-          totalUnits:
-            metric === "quantity" ? Math.round(restValue) : 0,
-          totalRevenue:
-            metric === "revenue" ? round2(restValue) : 0,
-        })
-      }
-    }
-    const data = top
-      .map((c) => {
-        const value =
-          metric === "revenue"
-            ? Number(c.totalRevenue) || 0
-            : Number(c.totalUnits) || 0
-        if (!isFinite(value)) return null
-        return { name: c.categoryName, value, categoryId: c.categoryId }
-      })
-      .filter(Boolean) as {
-      name: string
-      value: number
-      categoryId: number
-    }[]
+  const top = useMemo(() => {
+    const sorted = [...items].sort((a, b) => b[metric] - a[metric]);
+    return sorted.slice(0, 10).map((it) => ({
+      ...it,
+      short: it.name.length > 18 ? it.name.slice(0, 18) + "…" : it.name,
+    }));
+  }, [items, metric]);
 
-    const total = data.reduce((s, d) => s + (Number(d.value) || 0), 0)
-    return data.map((d) => ({ ...d, __total: total })) as {
-      name: string
-      value: number
-      categoryId: number
-      __total: number
-    }[]
-  }, [categoriesAgg, metric, limit])
+  const formatValue = (v: number) =>
+    metric === "quantity" ? intFmt.format(v) : currency.format(v);
 
-  const labelAngle = topProductData.length > 5 ? -45 : 0
-  const AxisTick = ({ x, y, payload }: any) => (
-    <g transform={`translate(${x},${y})`}>
-      <text
-        dy={16}
-        textAnchor={labelAngle ? "end" : "middle"}
-        transform={labelAngle ? `rotate(${labelAngle})` : undefined}
-        fontSize={12}
-      >
-        <title>{payload?.payload?.fullName ?? payload?.value}</title>
-        {payload?.value}
-      </text>
-    </g>
-  )
-
-  const formatValue = metric === "revenue" ? formatRub : formatInt
-  const total = pieData.length ? Number(pieData[0].__total) : 0
-
-  const productTotalQty = useMemo(
-    () => productsAgg.reduce((s, p) => s + (Number(p.totalUnits) || 0), 0),
-    [productsAgg],
-  )
-  const productTotalRev = useMemo(
-    () => productsAgg.reduce((s, p) => s + (Number(p.totalRevenue) || 0), 0),
-    [productsAgg],
-  )
-  const categoryTotalQty = useMemo(
-    () => categoriesAgg.reduce((s, c) => s + (Number(c.totalUnits) || 0), 0),
-    [categoriesAgg],
-  )
-  const categoryTotalRev = useMemo(
-    () => categoriesAgg.reduce((s, c) => s + (Number(c.totalRevenue) || 0), 0),
-    [categoriesAgg],
-  )
-
-  useEffect(() => {
-    const round = metric === "revenue" ? round2 : Math.round
-    const totalAll = round(
-      metric === "revenue" ? categoryTotalRev : categoryTotalQty,
-    )
-    const totalTopPlusOther = round(total)
-    console.debug({ metric, totalAll, totalTopPlusOther, equal: totalAll === totalTopPlusOther })
-    const prodTotal = round(
-      metric === "revenue" ? productTotalRev : productTotalQty,
-    )
-    const catTotal = round(
-      metric === "revenue" ? categoryTotalRev : categoryTotalQty,
-    )
-    console.debug({ metric, prodTotal, catTotal, equal: prodTotal === catTotal })
-  }, [
-    metric,
-    total,
-    productTotalQty,
-    productTotalRev,
-    categoryTotalQty,
-    categoryTotalRev,
-  ])
-
-  const legendItems = useMemo(
-    () =>
-      pieData.map((d, idx) => ({
-        color: COLORS[idx % COLORS.length],
-        name: d.name,
-      })),
-    [pieData],
-  )
-
-  const renderPieTooltip = ({ active, payload }: any) => {
-    if (!active || !payload?.length) return null
-    const entry = payload[0]
-    const frac = Number(entry.percent ?? 0)
-    const v = Number(entry.value) || 0
-    const total = Number(entry.payload?.__total || 0)
-    const pct =
-      entry.percent != null
-        ? frac * 100
-        : total > 0
-          ? (v / total) * 100
-          : 0
-    const formattedValue =
-      metric === "revenue" ? formatRub(v) : formatInt(Math.round(v))
-    const formattedPercent = `${pct.toFixed(1)}%`
+  if (error) {
     return (
-      <div className="bg-white p-2 border rounded text-sm">
-        <div>{entry.name}</div>
-        <div>
-          {formattedValue} ({formattedPercent})
-        </div>
+      <div className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 text-error flex items-center gap-2">
+        Ошибка загрузки
+        <button className="underline" onClick={() => refetch()}>
+          Повторить
+        </button>
       </div>
-    )
+    );
   }
 
   return (
-    <div className="bg-neutral-200 p-4 md:p-5 rounded-2xl shadow-card">
-      <div className="flex flex-col md:flex-row md:justify-between md:items-center gap-2 mb-4">
-        <h3 className="text-lg font-semibold flex items-center gap-2">🏆 Топ товаров</h3>
-        <div className="flex flex-wrap gap-2">
-          <div className="flex gap-1" aria-label="Метрика">
-            {metricOptions.map((m) => (
-              <button
-                key={m.value}
-                className={`px-2 py-1 text-sm rounded border focus:outline-none focus:ring-2 focus:ring-primary-500 ${
-                  metric === m.value
-                    ? "bg-primary-500 text-white border-primary-500"
-                    : "border-neutral-300"
-                }`}
-                onClick={() => setMetric(m.value)}
-              >
-                {m.label}
-              </button>
+    <div className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5">
+      <div className="flex justify-between items-center mb-4 gap-2 flex-wrap">
+        <h3 className="text-lg font-semibold">🏆 Топ товаров</h3>
+        <div className="flex items-center gap-2">
+          <span className="text-sm">Сортировка:</span>
+          <select
+            className="border border-neutral-300 rounded px-2 py-1 text-sm"
+            value={metric}
+            onChange={(e) => setMetric(e.target.value as Metric)}
+          >
+            {options.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
             ))}
-          </div>
-          <div className="flex gap-1" aria-label="Количество элементов">
-            {limitOptions.map((n) => (
-              <button
-                key={n}
-                className={`px-2 py-1 text-sm rounded border focus:outline-none focus:ring-2 focus:ring-primary-500 ${
-                  limit === n
-                    ? "bg-primary-500 text-white border-primary-500"
-                    : "border-neutral-300"
-                }`}
-                onClick={() => setLimit(n)}
-              >
-                {n}
-              </button>
-            ))}
-          </div>
+          </select>
         </div>
       </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div className="bg-white rounded-xl p-4 shadow flex flex-col">
-          <div className="flex items-center justify-between mb-3">
-            <h4 className="text-sm font-medium">Товары</h4>
-          </div>
-          <div className="h-96 relative">
-            {prodError ? (
-              <div className="text-error flex items-center gap-2 h-full justify-center">
-                Ошибка загрузки
-                <button className="underline" onClick={() => refetchProducts()}>
-                  Повторить
-                </button>
-              </div>
-            ) : prodLoading && !products ? (
-              <div className="absolute inset-0 flex items-end space-x-2">
-                {Array.from({ length: limit }).map((_, idx) => (
-                  <div key={idx} className="flex-1 animate-pulse bg-neutral-300" />
-                ))}
-              </div>
-            ) : topProductData.length === 0 ? (
-              <div className="flex items-center justify-center h-full text-neutral-500">
-                Нет данных
-              </div>
-            ) : (
-              <ResponsiveContainer width="100%" height="100%">
-                <BarChart
-                  data={topProductData}
-                  margin={{ top: 16, right: 8, left: 48, bottom: 32 }}
-                >
-                  <XAxis
-                    dataKey="name"
-                    axisLine={false}
-                    tickLine={false}
-                    interval={0}
-                    tick={<AxisTick />}
-                  />
-                  <YAxis tick={{ fontSize: 12 }} tickFormatter={formatValue} />
-                  <Tooltip
-                    formatter={(v: number) => formatValue(Number(v))}
-                    labelFormatter={(_, p) => p?.[0]?.payload?.fullName}
-                    contentStyle={{ fontSize: 12 }}
-                  />
-                  <Bar
-                    dataKey="value"
-                    name={metricOptions.find((m) => m.value === metric)?.label}
-                    fill="#3B82F6"
-                    onClick={(d: any) =>
-                      router.push(
-                        `/products?search=${encodeURIComponent(
-                          d.productName,
-                        )}`,
-                      )
-                    }
-                  >
-                    {topProductData.map((_, idx) => (
-                      <Cell key={idx} cursor="pointer" />
-                    ))}
-                  </Bar>
-                </BarChart>
-              </ResponsiveContainer>
-            )}
-            {prodFetching && products && (
-              <div className="absolute inset-0 flex items-center justify-center bg-white/50">
-                <div className="w-6 h-6 border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
-              </div>
-            )}
-          </div>
+      {isLoading && !data ? (
+        <div className="h-64 flex items-end space-x-2">
+          {Array.from({ length: 10 }).map((_, i) => (
+            <div key={i} className="flex-1 h-full bg-neutral-300 animate-pulse" />
+          ))}
         </div>
-        <div className="bg-white rounded-xl p-4 shadow flex flex-col">
-          <div className="flex items-center justify-between mb-3">
-            <h4 className="text-sm font-medium">Категории</h4>
-          </div>
-          <div className="h-96 relative">
-            {catError ? (
-              <div className="text-error flex items-center gap-2 h-full justify-center">
-                Ошибка загрузки
-                <button className="underline" onClick={() => refetchCategories()}>
-                  Повторить
-                </button>
-              </div>
-            ) : catLoading && !categories ? (
-              <div className="absolute inset-0 flex items-center justify-center">
-                <div className="w-32 h-32 rounded-full animate-pulse bg-neutral-300" />
-              </div>
-            ) : pieData.length === 0 || total === 0 ? (
-              <div className="flex items-center justify-center h-full text-neutral-500">
-                Нет данных
-              </div>
-            ) : (
-              <div className="h-full flex flex-col lg:flex-row">
-                <div className="flex-1">
-                  <ResponsiveContainer width="100%" height="100%">
-                    <PieChart>
-                      <Pie
-                        data={pieData}
-                        dataKey="value"
-                        nameKey="name"
-                        innerRadius={60}
-                        outerRadius={120}
-                        paddingAngle={1}
-                        label={false}
-                        labelLine={false}
-                        onClick={(d: any) =>
-                          router.push(`/products?categoryId=${d.categoryId}`)
-                        }
-                      >
-                        {pieData.map((_, idx) => (
-                          <Cell
-                            key={`cell-${idx}`}
-                            fill={COLORS[idx % COLORS.length]}
-                            cursor="pointer"
-                          />
-                        ))}
-                      </Pie>
-                      <Tooltip content={renderPieTooltip} />
-                    </PieChart>
-                  </ResponsiveContainer>
-                </div>
-                <div
-                  className="mt-4 lg:mt-0 lg:ml-4 lg:w-48 text-sm"
-                  style={{ maxHeight: "320px", overflowY: "auto" }}
-                >
-                  <ul className="space-y-1 pr-3.5">
-                    {legendItems.map((item) => (
-                      <li
-                        key={item.name}
-                        className="flex items-center gap-2"
-                      >
-                        <span className="flex items-center gap-2 min-w-0">
-                          <span
-                            className="w-3 h-3 rounded-full flex-shrink-0"
-                            style={{ backgroundColor: item.color }}
-                          />
-                          <span className="truncate">{item.name}</span>
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            )}
-            {catFetching && categories && (
-              <div className="absolute inset-0 flex items-center justify-center bg-white/50">
-                <div className="w-6 h-6 border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
-              </div>
-            )}
-          </div>
+      ) : top.length ? (
+        <div className="relative" style={{ height: 360 }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={top} layout="vertical" margin={{ left: 16, right: 16 }}>
+              <XAxis
+                type="number"
+                tickFormatter={formatValue}
+                axisLine={false}
+                tickLine={false}
+              />
+              <YAxis
+                dataKey="short"
+                type="category"
+                width={160}
+                axisLine={false}
+                tickLine={false}
+              />
+              <Tooltip
+                formatter={(value: any) => formatValue(Number(value))}
+                labelFormatter={(label, payload) =>
+                  (payload && payload[0] && (payload[0].payload as any).name) ||
+                  label
+                }
+              />
+              <Bar
+                dataKey={metric}
+                radius={[4, 4, 4, 4]}
+                barSize={20}
+                fill={metric === "quantity" ? "#3B82F6" : "#10B981"}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+          {isFetching && (
+            <div className="absolute inset-0 flex items-center justify-center bg-white/50">
+              <div className="w-6 h-6 border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
+            </div>
+          )}
         </div>
-      </div>
+      ) : (
+        <div className="h-64 flex items-center justify-center text-neutral-500">
+          Нет данных за период
+        </div>
+      )}
     </div>
-  )
-}
+  );
+};
 
-export default TopProducts
+export default TopProducts;

--- a/dashboard-ui/app/components/ui/KpiCard.tsx
+++ b/dashboard-ui/app/components/ui/KpiCard.tsx
@@ -5,11 +5,41 @@ interface KpiCardProps {
   icon: ReactNode
   label: string
   value: ReactNode
+  valueTitle?: string
   valueClassName?: string
   isLoading?: boolean
+  deltaPct?: number
 }
 
-const KpiCard = ({ icon, label, value, valueClassName, isLoading }: KpiCardProps) => {
+const KpiCard = ({
+  icon,
+  label,
+  value,
+  valueTitle,
+  valueClassName,
+  isLoading,
+  deltaPct,
+}: KpiCardProps) => {
+  let deltaEl: ReactNode = null
+  if (typeof deltaPct === 'number') {
+    const formatted = Math.abs(deltaPct).toLocaleString('ru-RU', {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    })
+    const sign = deltaPct > 0 ? '+' : deltaPct < 0 ? '-' : ''
+    const arrow = deltaPct > 0 ? '🔺' : deltaPct < 0 ? '🔻' : ''
+    const cls =
+      deltaPct > 0
+        ? 'text-success'
+        : deltaPct < 0
+          ? 'text-error'
+          : 'text-neutral-800'
+    const text = arrow
+      ? `${arrow} ${sign}${formatted}%`
+      : `${sign}${formatted}%`
+    deltaEl = <div className={clsx('text-xs ml-auto', cls)}>{text}</div>
+  }
+
   return (
     <div className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 flex items-center gap-3">
       <div className="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 bg-neutral-100">
@@ -25,11 +55,13 @@ const KpiCard = ({ icon, label, value, valueClassName, isLoading }: KpiCardProps
               'text-2xl md:text-3xl font-semibold tabular-nums whitespace-nowrap overflow-hidden text-ellipsis',
               valueClassName,
             )}
+            title={valueTitle}
           >
             {value}
           </div>
         )}
       </div>
+      {deltaEl}
     </div>
   )
 }

--- a/dashboard-ui/app/page.tsx
+++ b/dashboard-ui/app/page.tsx
@@ -7,7 +7,6 @@ import KpiCards from "@/components/dashboard/KpiCards";
 import SalesChart from "@/components/dashboard/SalesChart";
 import TopProducts from "@/components/dashboard/TopProducts";
 import WeeklyTasks from "@/components/dashboard/WeeklyTasks";
-import FinancialSummary from "@/components/dashboard/FinancialSummary";
 import { usePeriod } from "@/store/period";
 
 const metadata: Metadata = {
@@ -27,7 +26,6 @@ export default function Home() {
       </div>
       <div className="grid gap-4">
         <KpiCards />
-        <FinancialSummary />
         <SalesChart />
         <TopProducts />
         <WeeklyTasks />


### PR DESCRIPTION
## Summary
- add grouped KPI cards with trend badges and compact number formatting
- show combined sales chart with revenue line and quantity bars
- implement sortable top products widget with truncated labels

## Testing
- `npx vitest run app/components/dashboard/KpiCards.test.tsx app/components/dashboard/TopProducts.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b7615199108329a6df251595f499df