### PR TITLE
feat: stack KPI modules on dashboard

### DIFF
--- a/dashboard-ui/app/components/dashboard/KpiCards.tsx
+++ b/dashboard-ui/app/components/dashboard/KpiCards.tsx
@@ -168,7 +168,7 @@ const KpiCards: React.FC = () => {
   ];
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+    <div className="grid grid-cols-1 gap-6 md:gap-8">
       {groups.map((g) => (
         <div
           key={g.title}

--- a/dashboard-ui/app/page.tsx
+++ b/dashboard-ui/app/page.tsx
@@ -24,7 +24,7 @@ export default function Home() {
       <div className="flex justify-end mb-4">
         <DashboardControls />
       </div>
-      <div className="grid gap-4">
+      <div className="grid gap-6 md:gap-8">
         <KpiCards />
         <SalesChart />
         <TopProducts />


### PR DESCRIPTION
## Summary
- Stack financial and operational KPI modules vertically with full-width layout
- Increase spacing between dashboard modules for consistent gaps

## Testing
- `yarn lint`
- `npx vitest run` *(fails: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b769efe9248329b555fd2262047f2a