### PR TITLE
feat: localize sales tooltip

### DIFF
--- a/dashboard-ui/app/components/dashboard/SalesChart.tsx
+++ b/dashboard-ui/app/components/dashboard/SalesChart.tsx
@@ -156,11 +156,14 @@ const SalesChart: React.FC = () => {
                 axisLine={false}
               />
               <Tooltip
-                formatter={(value: any, name) =>
-                  name === "revenue"
-                    ? currency.format(Number(value))
-                    : `${intFmt.format(Number(value))} шт`}
-                labelFormatter={(label) => label}
+                formatter={(value: any, name) => {
+                  if (name === "revenue")
+                    return [currency.format(Number(value)), "Доход"];
+                  if (name === "quantity")
+                    return [intFmt.format(Number(value)), "Количество"];
+                  return [value, name];
+                }}
+                labelFormatter={(label) => `Дата: ${label}`}
                 contentStyle={{ fontSize: 12 }}
               />
               <Bar dataKey="quantity" yAxisId="right" barSize={20} fill="#3B82F6" />


### PR DESCRIPTION
## Summary
- localize tooltip labels for revenue and quantity on sales chart

## Testing
- `yarn --cwd dashboard-ui lint`
- `yarn --cwd dashboard-ui test` *(fails: Cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_68b7fe875e788329adb5e3cb4d5c1aac