### PR TITLE
feat: style KPI cards

### DIFF
--- a/dashboard-ui/app/components/dashboard/FinancialSummary.tsx
+++ b/dashboard-ui/app/components/dashboard/FinancialSummary.tsx
@@ -37,7 +37,7 @@ const FinancialSummary: React.FC = () => {
         : "text-neutral-900";
 
   return (
-    <div className="rounded-2xl shadow-card p-4 md:p-5 bg-neutral-200 flex items-center gap-3">
+    <div className="rounded-xl shadow-card p-4 md:p-5 bg-neutral-100 flex items-center gap-3">
       <span className="w-10 h-10 rounded-full flex items-center justify-center bg-primary-300 text-neutral-900">
         <FaBriefcase />
       </span>

--- a/dashboard-ui/app/components/dashboard/KpiCards.tsx
+++ b/dashboard-ui/app/components/dashboard/KpiCards.tsx
@@ -167,10 +167,7 @@ const KpiCards: React.FC = () => {
   return (
     <div className="grid grid-cols-1 gap-6 md:gap-8">
       {groups.map((g) => (
-        <div
-          key={g.title}
-          className="rounded-2xl bg-neutral-200 shadow-card p-4 relative"
-        >
+        <div key={g.title} className="relative">
           <h3 className="text-lg font-semibold mb-4">{g.title}</h3>
           <div className={g.grid}>
             {g.items.map((item) => (

--- a/dashboard-ui/app/components/ui/KpiCard.tsx
+++ b/dashboard-ui/app/components/ui/KpiCard.tsx
@@ -40,7 +40,7 @@ const KpiCard = ({
   }
 
   return (
-    <div className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 flex items-center gap-3">
+    <div className="rounded-xl bg-neutral-100 shadow-card p-4 md:p-5 flex items-center gap-3">
       <div className="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 bg-neutral-100">
         {icon}
       </div>


### PR DESCRIPTION
## Summary
- add neutral background and soft shadow to KPI card component
- align financial summary card with new KPI style
- simplify KPI groups to let individual cards stand out

## Testing
- `yarn --cwd dashboard-ui lint`
- `yarn --cwd dashboard-ui test` *(fails: Cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_68b7ffea525c8329a17a61364568f96e