### PR TITLE
feat: arrange warehouse KPI cards

### DIFF
--- a/dashboard-ui/app/components/products/ProductsTable.tsx
+++ b/dashboard-ui/app/components/products/ProductsTable.tsx
@@ -4,14 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Button from '@/ui/Button/Button'
 import SearchInput from '@/components/ui/SearchInput'
-import {
-  Pencil,
-  Trash2,
-  Printer,
-  Download,
-  PackageX,
-  Archive,
-} from 'lucide-react'
+import { Pencil, Trash2, Printer, Download } from 'lucide-react'
 import { createPortal } from 'react-dom'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from '@/utils/toast'
@@ -373,32 +366,10 @@ const ProductsTable = ({ isAddOpen, onCloseAdd }: ProductsTableProps) => {
         </div>
       ) : (
         <>
-          <div className="grid grid-cols-2 gap-4">
-            <div className="rounded-2xl p-4 md:p-5 shadow-sm border border-red-100 bg-red-50 text-red-700 flex flex-col justify-center">
-              <div className="flex items-center gap-2">
-                <PackageX className="w-5 h-5 text-red-600" aria-hidden="true" />
-                <span className="text-sm text-gray-600">Нет в наличии</span>
-              </div>
-              {isInitialLoading ? (
-                <div className="mt-2 h-7 w-10 bg-red-100 rounded animate-pulse" />
-              ) : (
-                <div className="mt-2 text-2xl md:text-3xl font-semibold">{stats.outOfStock}</div>
-              )}
-            </div>
-            <div className="rounded-2xl p-4 md:p-5 shadow-sm border border-orange-100 bg-orange-50 text-orange-700 flex flex-col justify-center">
-              <div className="flex items-center gap-2">
-                <Archive className="w-5 h-5 text-orange-600" aria-hidden="true" />
-                <span className="text-sm text-gray-600">Мало на складе</span>
-              </div>
-              {isInitialLoading ? (
-                <div className="mt-2 h-7 w-10 bg-orange-100 rounded animate-pulse" />
-              ) : (
-                <div className="mt-2 text-2xl md:text-3xl font-semibold">{stats.lowStock}</div>
-              )}
-            </div>
-          </div>
           <WarehouseKpiCards
             totalCount={stats.totalCount}
+            lowStock={stats.lowStock}
+            outOfStock={stats.outOfStock}
             purchaseValue={stats.purchaseValue}
             saleValue={stats.saleValue}
             isLoading={isInitialLoading}

--- a/dashboard-ui/app/components/products/WarehouseKpiCards.tsx
+++ b/dashboard-ui/app/components/products/WarehouseKpiCards.tsx
@@ -1,10 +1,18 @@
 'use client'
 
 import KpiCard from '@/components/ui/KpiCard'
-import { Package, CircleDollarSign, DollarSign } from 'lucide-react'
+import {
+  Package,
+  CircleDollarSign,
+  DollarSign,
+  PackageX,
+  Archive,
+} from 'lucide-react'
 
 interface WarehouseKpiCardsProps {
   totalCount: number
+  lowStock: number
+  outOfStock: number
   purchaseValue: number
   saleValue: number
   isLoading: boolean
@@ -18,43 +26,74 @@ const currencyFormatter = new Intl.NumberFormat('ru-RU', {
 
 export default function WarehouseKpiCards({
   totalCount,
+  lowStock,
+  outOfStock,
   purchaseValue,
   saleValue,
   isLoading,
 }: WarehouseKpiCardsProps) {
-  const cards = [
+  const topCards = [
     {
       label: 'Товаров',
-      icon: <Package className="w-5 h-5 text-info" />, 
+      icon: <Package className="w-5 h-5 text-info" />,
       value: numberFormatter.format(totalCount),
       valueClass: 'text-info',
     },
     {
+      label: 'Мало на складе',
+      icon: <Archive className="w-5 h-5 text-warning" />,
+      value: numberFormatter.format(lowStock),
+      valueClass: 'text-warning',
+    },
+    {
+      label: 'Нет в наличии',
+      icon: <PackageX className="w-5 h-5 text-error" />,
+      value: numberFormatter.format(outOfStock),
+      valueClass: 'text-error',
+    },
+  ]
+
+  const bottomCards = [
+    {
       label: 'Закупочная стоимость',
-      icon: <CircleDollarSign className="w-5 h-5 text-neutral-900" />, 
+      icon: <CircleDollarSign className="w-5 h-5 text-neutral-900" />,
       value: currencyFormatter.format(purchaseValue),
       valueClass: 'text-neutral-900',
     },
     {
       label: 'Продажная стоимость',
-      icon: <DollarSign className="w-5 h-5 text-success" />, 
+      icon: <DollarSign className="w-5 h-5 text-success" />,
       value: currencyFormatter.format(saleValue),
       valueClass: 'text-success',
     },
   ]
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 md:gap-4">
-      {cards.map(card => (
-        <KpiCard
-          key={card.label}
-          icon={card.icon}
-          label={card.label}
-          value={card.value}
-          valueClassName={card.valueClass}
-          isLoading={isLoading}
-        />
-      ))}
+    <div className="grid grid-cols-1 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {topCards.map(card => (
+          <KpiCard
+            key={card.label}
+            icon={card.icon}
+            label={card.label}
+            value={card.value}
+            valueClassName={card.valueClass}
+            isLoading={isLoading}
+          />
+        ))}
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {bottomCards.map(card => (
+          <KpiCard
+            key={card.label}
+            icon={card.icon}
+            label={card.label}
+            value={card.value}
+            valueClassName={card.valueClass}
+            isLoading={isLoading}
+          />
+        ))}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- arrange warehouse KPI cards into two responsive rows
- delegate KPI card rendering to WarehouseKpiCards with low/out-of-stock metrics

## Testing
- `yarn lint`
- `yarn test` *(fails: Cannot find package 'vite' imported from ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b8010412388329bafc41c7319c19f3