### PR TITLE
style: color-coded warehouse KPI cards

### DIFF
--- a/dashboard-ui/app/components/products/WarehouseKpiCards.tsx
+++ b/dashboard-ui/app/components/products/WarehouseKpiCards.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import KpiCard from '@/components/ui/KpiCard'
+import clsx from 'classnames'
 import {
   Package,
   CircleDollarSign,
@@ -37,19 +37,22 @@ export default function WarehouseKpiCards({
       label: 'Товаров',
       icon: <Package className="w-5 h-5 text-info" />,
       value: numberFormatter.format(totalCount),
-      valueClass: 'text-info',
+      valueClass: 'text-info font-semibold',
+      bg: 'bg-info/20',
     },
     {
       label: 'Мало на складе',
       icon: <Archive className="w-5 h-5 text-warning" />,
       value: numberFormatter.format(lowStock),
-      valueClass: 'text-warning',
+      valueClass: 'text-warning font-semibold',
+      bg: 'bg-warning/20',
     },
     {
       label: 'Нет в наличии',
       icon: <PackageX className="w-5 h-5 text-error" />,
       value: numberFormatter.format(outOfStock),
-      valueClass: 'text-error',
+      valueClass: 'text-error font-semibold',
+      bg: 'bg-error/20',
     },
   ]
 
@@ -59,12 +62,14 @@ export default function WarehouseKpiCards({
       icon: <CircleDollarSign className="w-5 h-5 text-neutral-900" />,
       value: currencyFormatter.format(purchaseValue),
       valueClass: 'text-neutral-900',
+      bg: 'bg-neutral-200',
     },
     {
       label: 'Продажная стоимость',
       icon: <DollarSign className="w-5 h-5 text-success" />,
       value: currencyFormatter.format(saleValue),
-      valueClass: 'text-success',
+      valueClass: 'text-success font-semibold',
+      bg: 'bg-success/20',
     },
   ]
 
@@ -72,26 +77,44 @@ export default function WarehouseKpiCards({
     <div className="grid grid-cols-1 gap-4">
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {topCards.map(card => (
-          <KpiCard
+          <div
             key={card.label}
-            icon={card.icon}
-            label={card.label}
-            value={card.value}
-            valueClassName={card.valueClass}
-            isLoading={isLoading}
-          />
+            className={clsx(
+              'rounded-xl shadow-card p-4 flex flex-col items-center justify-center text-center',
+              card.bg,
+            )}
+          >
+            {card.icon}
+            {isLoading ? (
+              <div className="mt-2 h-7 w-20 bg-neutral-300 rounded animate-pulse" />
+            ) : (
+              <div className={clsx('text-2xl md:text-3xl font-bold', card.valueClass)}>
+                {card.value}
+              </div>
+            )}
+            <div className="text-sm text-neutral-800">{card.label}</div>
+          </div>
         ))}
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {bottomCards.map(card => (
-          <KpiCard
+          <div
             key={card.label}
-            icon={card.icon}
-            label={card.label}
-            value={card.value}
-            valueClassName={card.valueClass}
-            isLoading={isLoading}
-          />
+            className={clsx(
+              'rounded-xl shadow-card p-4 flex flex-col items-center justify-center text-center',
+              card.bg,
+            )}
+          >
+            {card.icon}
+            {isLoading ? (
+              <div className="mt-2 h-7 w-20 bg-neutral-300 rounded animate-pulse" />
+            ) : (
+              <div className={clsx('text-2xl md:text-3xl font-bold', card.valueClass)}>
+                {card.value}
+              </div>
+            )}
+            <div className="text-sm text-neutral-800">{card.label}</div>
+          </div>
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- redesign warehouse KPI cards with color-coded backgrounds and centered layout
- emphasize KPIs with bold numbers and clear labels

## Testing
- `yarn lint`
- `yarn test` *(fails: Cannot find package '@rolldown/pluginutils')*

------
https://chatgpt.com/codex/tasks/task_e_68b8039a788c8329ba89e3d96c3f44e9