### PR TITLE
feat: add KPI card colors and layout

### DIFF
--- a/dashboard-ui/app/components/dashboard/KpiCards.tsx
+++ b/dashboard-ui/app/components/dashboard/KpiCards.tsx
@@ -111,50 +111,57 @@ const KpiCards: React.FC = () => {
   const groups = [
     {
       title: "💰 Финансовые KPI",
+      grid: "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4",
       items: [
         {
           label: "Выручка",
+          icon: "💰",
           value: currency.format(revenue),
           valueTitle: currency.format(revenue),
-          valueClass: "text-success",
-          className: "bg-success/20",
+          valueClass: "text-[#059669]",
+          className: "bg-[#D1FAE5]",
           delta: delta(revenue, prevRevenue),
         },
         {
-          label: "Фин. итог",
+          label: "Финансовый итог",
+          icon: "📈",
           value: currency.format(profit),
           valueTitle: currency.format(profit),
-          valueClass: profit >= 0 ? "text-success" : "text-error",
-          className: "bg-success/30",
+          valueClass: "text-[#047857]",
+          className: "bg-[#A7F3D0]",
           delta: delta(profit, prevProfit),
         },
         {
           label: "Маржа",
+          icon: "📊",
           value: `${marginPct.toFixed(1).replace('.', ',')}%`,
           valueTitle: `${marginPct.toFixed(2).replace('.', ',')}%`,
-          valueClass: marginPct > 0 ? "text-success" : marginPct < 0 ? "text-error" : "text-purple-700",
-          className: "bg-purple-200",
+          valueClass: marginPct < 0 ? "text-[#DC2626]" : "text-[#7C3AED]",
+          className: "bg-[#EDE9FE]",
           delta: delta(marginPct, prevMarginPct),
         },
       ],
     },
     {
       title: "📦 Операционные KPI",
+      grid: "grid grid-cols-1 sm:grid-cols-2 gap-4",
       items: [
         {
           label: "Кол-во продаж",
+          icon: "🛒",
           value: numberCompact.format(orders),
           valueTitle: numberFull.format(orders),
-          valueClass: "text-info",
-          className: "bg-info/20",
+          valueClass: "text-[#2563EB]",
+          className: "bg-[#DBEAFE]",
           delta: delta(orders, prevOrders),
         },
         {
           label: "Средний чек",
+          icon: "💳",
           value: currency.format(avg),
           valueTitle: currency.format(avg),
-          valueClass: "text-warning",
-          className: "bg-warning/20",
+          valueClass: "text-[#D97706]",
+          className: "bg-[#FEF3C7]",
           delta: delta(avg, prevAvg),
         },
       ],
@@ -171,11 +178,12 @@ const KpiCards: React.FC = () => {
           <h2 className="text-lg font-semibold text-neutral-900 flex items-center gap-2">
             {g.title}
           </h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div className={g.grid}>
             {g.items.map((item) => (
               <KpiCard
                 key={item.label}
                 label={item.label}
+                icon={item.icon}
                 value={item.value}
                 valueTitle={item.valueTitle}
                 valueClassName={item.valueClass}

--- a/dashboard-ui/app/components/ui/KpiCard.tsx
+++ b/dashboard-ui/app/components/ui/KpiCard.tsx
@@ -2,12 +2,37 @@ import clsx from 'classnames'
 import { ReactNode } from 'react'
 
 interface KpiCardProps {
+  /**
+   * Заголовок карточки
+   */
   label: string
+  /**
+   * Значение, отображаемое в карточке
+   */
   value: ReactNode
+  /**
+   * Подсказка для значения
+   */
   valueTitle?: string
+  /**
+   * CSS класс для значения
+   */
   valueClassName?: string
+  /**
+   * CSS класс для контейнера карточки
+   */
   className?: string
+  /**
+   * Иконка, отображаемая сверху
+   */
+  icon?: ReactNode
+  /**
+   * Индикатор загрузки
+   */
   isLoading?: boolean
+  /**
+   * Дельта в процентах
+   */
   delta?: number | string
 }
 
@@ -17,6 +42,7 @@ const KpiCard = ({
   valueTitle,
   valueClassName,
   className,
+  icon,
   isLoading,
   delta,
 }: KpiCardProps) => {
@@ -42,20 +68,17 @@ const KpiCard = ({
   return (
     <div
       className={clsx(
-        'rounded-xl p-4 md:p-5 shadow-card text-center flex flex-col items-center justify-center gap-1',
-        'bg-neutral-100',
+        'rounded-xl shadow-card p-4 md:p-5 flex flex-col items-center justify-center text-center gap-2',
         className,
       )}
     >
-      <div className="text-sm text-neutral-800 truncate">{label}</div>
+      {icon && <div className="text-3xl">{icon}</div>}
+      <div className="text-sm font-medium text-neutral-800 truncate">{label}</div>
       {isLoading ? (
-        <div className="mt-1 h-7 w-20 bg-neutral-300 rounded animate-pulse" />
+        <div className="h-7 w-20 bg-neutral-300 rounded animate-pulse" />
       ) : (
         <div
-          className={clsx(
-            'text-2xl md:text-3xl font-bold tabular-nums whitespace-nowrap overflow-hidden text-ellipsis',
-            valueClassName,
-          )}
+          className={clsx('text-2xl font-bold tabular-nums', valueClassName)}
           title={valueTitle}
         >
           {value}


### PR DESCRIPTION
## Summary
- add icon support and new layout for KPI cards
- style KPI groups with specific colors and responsive grids

## Testing
- `yarn lint`
- `yarn test` *(fails: Cannot find package 'vite')*


------
https://chatgpt.com/codex/tasks/task_e_68b809a08cac8329a5ec2f8b47bb9241