### PR TITLE
Fix warehouse navigation link path

### DIFF
--- a/dashboard-ui/app/components/ui/header/Header.tsx
+++ b/dashboard-ui/app/components/ui/header/Header.tsx
@@ -8,7 +8,7 @@ import { User } from 'lucide-react'
 
 const routes = [
   { label: 'Главная', path: '/' },
-  { label: 'Склад', path: '/stock' },
+  { label: 'Склад', path: '/products' },
   { label: 'Задачи', path: '/tasks' },
   { label: 'Отчёты', path: '/reports' },
 ]


### PR DESCRIPTION
## Summary
- fix warehouse navigation link to point to products page

## Testing
- `yarn --cwd dashboard-ui lint`
- `yarn --cwd dashboard-ui test` *(fails: Cannot find package 'vite')*
- `yarn --cwd server test`


------
https://chatgpt.com/codex/tasks/task_e_68b821dbdb6c8329a873f8f608c6a5cf