### PR TITLE
feat: refine sticky header with icons and profile menu

### DIFF
--- a/dashboard-ui/app/assets/styles/global.scss
+++ b/dashboard-ui/app/assets/styles/global.scss
@@ -83,7 +83,7 @@ input[type='number'] {
 
 @layer components {
   .nav-link {
-    @apply px-1 py-1 text-neutral-900/70 hover:text-neutral-900 hover:bg-neutral-200 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-primary-300;
+    @apply relative px-1 py-1 text-neutral-900/70 hover:text-neutral-900 hover:bg-neutral-200 rounded transition-colors font-medium focus:outline-none focus:ring-2 focus:ring-primary-300;
   }
 
   .nav-link.active {

--- a/dashboard-ui/app/components/ui/header/Header.tsx
+++ b/dashboard-ui/app/components/ui/header/Header.tsx
@@ -7,68 +7,75 @@ import { useLayoutEffect, useRef, useState } from 'react'
 import { Menu, User } from 'lucide-react'
 
 const routes = [
-  { label: 'Главная', path: '/' },
-  { label: 'Склад', path: '/products' },
-  { label: 'Задачи', path: '/tasks' },
-  { label: 'Отчёты', path: '/reports' },
+  { label: 'Главная', path: '/', icon: '🏠' },
+  { label: 'Склад', path: '/stock', icon: '📦' },
+  { label: 'Задачи', path: '/tasks', icon: '✅' },
+  { label: 'Отчёты', path: '/reports', icon: '📊' },
 ]
 
 export default function Header() {
   const pathname = usePathname()
   const navRef = useRef<HTMLElement>(null)
   const underlineRef = useRef<HTMLSpanElement>(null)
-  const [open, setOpen] = useState(false)
+  const [mobileOpen, setMobileOpen] = useState(false)
+  const [profileOpen, setProfileOpen] = useState(false)
 
-  const openProfileMenu = () => {
-    console.info('profile')
-  }
+  const toggleProfileMenu = () => setProfileOpen((prev) => !prev)
+  const toggleMobile = () => setMobileOpen((prev) => !prev)
 
   useLayoutEffect(() => {
-    const nav = navRef.current
-    const underline = underlineRef.current
-    const activeLink = nav?.querySelector<HTMLAnchorElement>('a.active')
-    if (nav && underline && activeLink) {
-      const el = activeLink.getBoundingClientRect()
-      const navBox = nav.getBoundingClientRect()
-      underline.style.width = `${el.width}px`
-      underline.style.left = `${el.left - navBox.left}px`
+    const updateUnderline = () => {
+      const nav = navRef.current
+      const underline = underlineRef.current
+      const activeLink = nav?.querySelector<HTMLAnchorElement>('a.active')
+      if (nav && underline && activeLink) {
+        const el = activeLink.getBoundingClientRect()
+        const navBox = nav.getBoundingClientRect()
+        underline.style.width = `${el.width}px`
+        underline.style.left = `${el.left - navBox.left}px`
+      }
     }
+
+    updateUnderline()
+    window.addEventListener('resize', updateUnderline)
+    return () => window.removeEventListener('resize', updateUnderline)
   }, [pathname])
 
-  const renderLink = (route: { label: string; path: string }, isMobile = false) => {
+  const renderLink = (
+    route: { label: string; path: string; icon: string },
+    isMobile = false
+  ) => {
     const isActive = pathname === route.path
     const baseClasses = isMobile
       ? cn(
-          'px-3 py-2 rounded-lg transition-colors',
+          'px-3 py-2 rounded-lg transition-colors flex items-center',
           isActive
             ? 'bg-primary-300/40 text-neutral-900 font-semibold'
             : 'hover:bg-neutral-200'
         )
-      : cn(
-          'nav-link px-1 py-1 text-neutral-900/70 hover:text-neutral-900 hover:bg-neutral-200 rounded transition-colors',
-          isActive && 'active text-neutral-900 font-semibold'
-        )
+      : cn('nav-link inline-flex items-center', isActive && 'active')
     return (
       <Link
         key={route.path}
         href={route.path}
         className={baseClasses}
         aria-current={isActive ? 'page' : undefined}
-        onClick={() => isMobile && setOpen(false)}
+        onClick={() => isMobile && setMobileOpen(false)}
       >
+        <span className="mr-2">{route.icon}</span>
         {route.label}
       </Link>
     )
   }
 
   return (
-    <header className="sticky top-0 z-40 bg-neutral-100/90 backdrop-blur border-b border-neutral-300 shadow-sm">
-      <div className="mx-auto max-w-7xl h-16 px-4 md:px-6 flex items-center justify-between gap-6">
+    <header className="sticky top-0 z-40 bg-neutral-100/95 backdrop-blur border-b border-neutral-300 shadow-sm">
+      <div className="mx-auto max-w-7xl h-[64px] px-4 md:px-6 flex items-center justify-between gap-6">
         <Link
           href="/"
           className="font-cnbold text-xl md:text-2xl font-semibold text-neutral-900/90"
         >
-          И.П. Муллиев
+          И.П. Мулиев
         </Link>
 
         <nav ref={navRef} className="relative hidden md:flex items-center gap-8">
@@ -76,27 +83,43 @@ export default function Header() {
           <span
             id="nav-underline"
             ref={underlineRef}
-            className="absolute -bottom-[10px] h-[3px] bg-primary-500 rounded-full transition-all duration-300"
+            className="absolute -bottom-[10px] h-[3px] bg-success rounded-full transition-all duration-300"
           />
         </nav>
 
         <div className="flex items-center gap-3">
-          <button
-            id="profileBtn"
-            aria-label="Профиль"
-            className={cn(
-              'h-10 w-10 rounded-full bg-neutral-200 flex items-center justify-center hover:bg-neutral-300',
-              'focus:outline-none focus:ring-2 focus:ring-primary-300'
+          <div className="relative">
+            <button
+              id="profileBtn"
+              aria-label="Профиль"
+              className={cn(
+                'h-10 w-10 rounded-full bg-neutral-200 flex items-center justify-center hover:bg-neutral-300',
+                'focus:outline-none focus:ring-2 focus:ring-primary-300'
+              )}
+              onClick={toggleProfileMenu}
+            >
+              <User className="w-5 h-5 text-neutral-900" />
+            </button>
+
+            {profileOpen && (
+              <div className="absolute right-0 mt-2 w-44 rounded-xl bg-neutral-100 shadow-card border border-neutral-300 py-1">
+                <button className="w-full text-left px-3 py-2 hover:bg-neutral-200">
+                  Профиль
+                </button>
+                <button className="w-full text-left px-3 py-2 hover:bg-neutral-200">
+                  Настройки
+                </button>
+                <button className="w-full text-left px-3 py-2 text-error hover:bg-error/10">
+                  Выход
+                </button>
+              </div>
             )}
-            onClick={openProfileMenu}
-          >
-            <User className="w-5 h-5 text-neutral-900" />
-          </button>
+          </div>
 
           <button
             className="md:hidden h-10 w-10 rounded-xl bg-neutral-200 flex items-center justify-center hover:bg-neutral-300"
             aria-label="Открыть меню"
-            onClick={() => setOpen((prev) => !prev)}
+            onClick={toggleMobile}
           >
             <Menu className="w-5 h-5 text-neutral-900" />
           </button>
@@ -107,7 +130,7 @@ export default function Header() {
         id="mobileNav"
         className={cn(
           'md:hidden border-t border-neutral-300 bg-neutral-100',
-          open ? 'block' : 'hidden'
+          mobileOpen ? 'block' : 'hidden'
         )}
       >
         <nav className="px-3 py-2 flex flex-col">


### PR DESCRIPTION
## Summary
- add emoji icons and underline highlighting to header nav
- show profile dropdown and mobile menu toggle
- style nav links with improved hover and active states

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b828da2cd88329a49cb1a0b36b7301