### PR TITLE
style: expand header nav spacing

### DIFF
--- a/dashboard-ui/app/components/ui/header/Header.tsx
+++ b/dashboard-ui/app/components/ui/header/Header.tsx
@@ -65,7 +65,7 @@ export default function Header() {
           И.П. Мулиев
         </Link>
 
-        <nav className="relative hidden md:flex flex-1 items-center justify-center gap-8">
+        <nav className="relative hidden md:flex flex-1 items-center justify-evenly">
           {routes.map((r) => renderLink(r))}
         </nav>
 

--- a/dashboard-ui/test-results/.last-run.json
+++ b/dashboard-ui/test-results/.last-run.json
@@ -1,6 +1,0 @@
-{
-  "status": "failed",
-  "failedTests": [
-    "8946741c555a0c4515d8-3206903a52d09daca7c8"
-  ]
-}


### PR DESCRIPTION
## Summary
- spread header nav items evenly to use full width

## Testing
- `yarn --cwd dashboard-ui lint`
- `yarn --cwd dashboard-ui test` *(fails: Cannot find package 'vite')*
- `yarn --cwd dashboard-ui test:e2e` *(fails: Module not found: recharts tried to access react-is)*

------
https://chatgpt.com/codex/tasks/task_e_68b83352b6ac8329b6f402837c6924b0