### PR TITLE
Refactor KPI cards with unified compact tile style

### DIFF
--- a/dashboard-ui/app/components/dashboard/KpiCards.tsx
+++ b/dashboard-ui/app/components/dashboard/KpiCards.tsx
@@ -111,57 +111,42 @@ const KpiCards: React.FC = () => {
   const groups = [
     {
       title: "💰 Финансовые KPI",
-      grid: "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4",
+      grid: "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4",
       items: [
         {
-          label: "Выручка",
+          title: "Выручка",
           icon: "💰",
           value: currency.format(revenue),
-          valueTitle: currency.format(revenue),
-          valueClass: "text-[#059669]",
-          className: "bg-[#D1FAE5]",
           delta: delta(revenue, prevRevenue),
         },
         {
-          label: "Финансовый итог",
+          title: "Финансовый итог",
           icon: "📈",
           value: currency.format(profit),
-          valueTitle: currency.format(profit),
-          valueClass: "text-[#047857]",
-          className: "bg-[#A7F3D0]",
           delta: delta(profit, prevProfit),
         },
         {
-          label: "Маржа",
+          title: "Маржа",
           icon: "📊",
           value: `${marginPct.toFixed(1).replace('.', ',')}%`,
-          valueTitle: `${marginPct.toFixed(2).replace('.', ',')}%`,
-          valueClass: marginPct < 0 ? "text-[#DC2626]" : "text-[#7C3AED]",
-          className: "bg-[#EDE9FE]",
           delta: delta(marginPct, prevMarginPct),
         },
       ],
     },
     {
       title: "📦 Операционные KPI",
-      grid: "grid grid-cols-1 sm:grid-cols-2 gap-4",
+      grid: "grid grid-cols-1 sm:grid-cols-2 gap-3 md:gap-4",
       items: [
         {
-          label: "Кол-во продаж",
+          title: "Кол-во продаж",
           icon: "🛒",
           value: numberCompact.format(orders),
-          valueTitle: numberFull.format(orders),
-          valueClass: "text-[#2563EB]",
-          className: "bg-[#DBEAFE]",
           delta: delta(orders, prevOrders),
         },
         {
-          label: "Средний чек",
+          title: "Средний чек",
           icon: "💳",
           value: currency.format(avg),
-          valueTitle: currency.format(avg),
-          valueClass: "text-[#D97706]",
-          className: "bg-[#FEF3C7]",
           delta: delta(avg, prevAvg),
         },
       ],
@@ -181,15 +166,11 @@ const KpiCards: React.FC = () => {
           <div className={g.grid}>
             {g.items.map((item) => (
               <KpiCard
-                key={item.label}
-                label={item.label}
+                key={item.title}
+                title={item.title}
                 icon={item.icon}
                 value={item.value}
-                valueTitle={item.valueTitle}
-                valueClassName={item.valueClass}
-                className={item.className}
-                isLoading={isLoading && !curr}
-                delta={item.delta}
+                accent={item.delta < 0 ? 'error' : item.delta > 0 ? 'success' : 'neutral'}
               />
             ))}
           </div>

--- a/dashboard-ui/app/components/products/WarehouseKpiCards.tsx
+++ b/dashboard-ui/app/components/products/WarehouseKpiCards.tsx
@@ -34,75 +34,87 @@ export default function WarehouseKpiCards({
   isLoading,
 }: WarehouseKpiCardsProps) {
   const topCards: {
-    label: string
+    title: string
     icon: LucideIcon
     value: string
-    className: string
+    accent: 'info' | 'warning' | 'error'
   }[] = [
     {
-      label: 'Товары',
+      title: 'Товары',
       icon: Package,
       value: numberFormatter.format(totalCount),
-      className: 'bg-blue-100 text-blue-600',
+      accent: 'info',
     },
     {
-      label: 'Мало на складе',
+      title: 'Мало на складе',
       icon: AlertTriangle,
       value: numberFormatter.format(lowStock),
-      className: 'bg-yellow-100 text-yellow-700',
+      accent: 'warning',
     },
     {
-      label: 'Нет в наличии',
+      title: 'Нет в наличии',
       icon: XCircle,
       value: numberFormatter.format(outOfStock),
-      className: 'bg-red-100 text-red-600',
+      accent: 'error',
     },
   ]
 
   const bottomCards: {
-    label: string
+    title: string
     icon: LucideIcon
     value: string
-    className: string
+    accent: 'info' | 'success'
   }[] = [
     {
-      label: 'Закупочная стоимость',
+      title: 'Закупочная стоимость',
       icon: Wallet,
       value: currencyFormatter.format(purchaseValue),
-      className: 'bg-indigo-100 text-indigo-700',
+      accent: 'info',
     },
     {
-      label: 'Продажная стоимость',
+      title: 'Продажная стоимость',
       icon: DollarSign,
       value: currencyFormatter.format(saleValue),
-      className: 'bg-green-100 text-green-600',
+      accent: 'success',
     },
   ]
 
   return (
-    <div className="grid grid-cols-1 gap-4">
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+    <div className="grid grid-cols-1 gap-3 md:gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4">
         {topCards.map(card => (
-          <KpiCard
-            key={card.label}
-            label={card.label}
-            value={card.value}
-            icon={<card.icon className="w-6 h-6 md:w-7 md:h-7" />}
-            className={card.className}
-            isLoading={isLoading}
-          />
+          isLoading ? (
+            <div
+              key={card.title}
+              className="rounded-xl bg-neutral-100 shadow-card h-[92px] md:h-[100px] animate-pulse"
+            />
+          ) : (
+            <KpiCard
+              key={card.title}
+              title={card.title}
+              value={card.value}
+              icon={card.icon}
+              accent={card.accent}
+            />
+          )
         ))}
       </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 md:gap-4">
         {bottomCards.map(card => (
-          <KpiCard
-            key={card.label}
-            label={card.label}
-            value={card.value}
-            icon={<card.icon className="w-6 h-6 md:w-7 md:h-7" />}
-            className={card.className}
-            isLoading={isLoading}
-          />
+          isLoading ? (
+            <div
+              key={card.title}
+              className="rounded-xl bg-neutral-100 shadow-card h-[92px] md:h-[100px] animate-pulse"
+            />
+          ) : (
+            <KpiCard
+              key={card.title}
+              title={card.title}
+              value={card.value}
+              icon={card.icon}
+              accent={card.accent}
+            />
+          )
         ))}
       </div>
     </div>

--- a/dashboard-ui/app/components/ui/KpiCard.tsx
+++ b/dashboard-ui/app/components/ui/KpiCard.tsx
@@ -1,94 +1,63 @@
+import { ElementType, ReactNode } from 'react'
 import clsx from 'classnames'
-import { ReactNode } from 'react'
 
-interface KpiCardProps {
-  /**
-   * Заголовок карточки
-   */
-  label: string
-  /**
-   * Значение, отображаемое в карточке
-   */
-  value: ReactNode
-  /**
-   * Подсказка для значения
-   */
-  valueTitle?: string
-  /**
-   * CSS класс для цвета текста
-   */
-  valueClassName?: string
-  /**
-   * CSS класс для контейнера карточки
-   */
-  className?: string
-  /**
-   * Иконка, отображаемая сверху
-   */
-  icon?: ReactNode
-  /**
-   * Индикатор загрузки
-   */
-  isLoading?: boolean
-  /**
-   * Дельта в процентах
-   */
-  delta?: number | string
+const ACCENTS: Record<string, string> = {
+  success: '#10b981',
+  warning: '#f59e0b',
+  info: '#3b82f6',
+  error: '#ef4444',
+  neutral: '#c8b08d',
 }
 
-const KpiCard = ({
-  label,
+export interface KpiCardProps {
+  /** Заголовок карточки */
+  title: string
+  /** Значение внутри карточки */
+  value: ReactNode
+  /** Иконка или эмодзи */
+  icon: ElementType | string
+  /** Цветовой акцент */
+  accent?: keyof typeof ACCENTS
+  /** Дополнительные классы */
+  className?: string
+}
+
+export default function KpiCard({
+  title,
   value,
-  valueTitle,
-  valueClassName,
+  icon: Icon,
+  accent = 'neutral',
   className,
-  icon,
-  isLoading,
-  delta,
-}: KpiCardProps) => {
-  let deltaEl: ReactNode = null
-  const d = Number(delta)
-  if (!Number.isNaN(d)) {
-    const isUp = d > 0
-    const isDown = d < 0
-    const cls = isUp ? 'text-success' : isDown ? 'text-error' : 'text-neutral-800'
-    const formatted = (Math.abs(d) * 100).toLocaleString('ru-RU', {
-      minimumFractionDigits: 1,
-      maximumFractionDigits: 1,
-    })
-    deltaEl = (
-      <div className={clsx('flex items-center gap-1 text-sm', cls)}>
-        {isUp && <span>▲</span>}
-        {isDown && <span>▼</span>}
-        <span>{formatted}%</span>
-      </div>
-    )
-  }
+}: KpiCardProps) {
+  const iconEl = typeof Icon === 'string' ? (
+    <span className='text-base md:text-lg'>{Icon}</span>
+  ) : (
+    <Icon className='w-5 h-5 md:w-5 md:h-5 text-current' />
+  )
 
   return (
     <div
       className={clsx(
-        'rounded-xl shadow-card p-3 md:p-4 flex flex-col items-center text-center gap-2',
+        'kpi-card relative rounded-xl bg-neutral-100 shadow-card p-3 md:p-4 flex items-center gap-3 h-[92px] md:h-[100px]',
         className,
-        valueClassName,
       )}
+      style={{ ['--kpi-accent' as any]: ACCENTS[accent] }}
     >
-      {icon && (
-        <div className="w-10 h-10 flex items-center justify-center rounded-full bg-white/70 text-current text-lg md:text-xl">
-          {icon}
+      <span
+        className='absolute inset-x-0 top-0 h-1 rounded-t-xl bg-[var(--kpi-accent,#c8b08d)]'
+        aria-hidden
+      />
+      <div className='kpi-icon w-10 h-10 md:w-11 md:h-11 rounded-full bg-white/70 flex items-center justify-center flex-shrink-0'>
+        {iconEl}
+      </div>
+      <div className='flex-1 min-w-0 flex flex-col justify-center'>
+        <div className='kpi-title text-[13px] md:text-sm font-semibold text-neutral-900 leading-5 truncate'>
+          {title}
         </div>
-      )}
-      <div className="text-sm font-medium text-neutral-700">{label}</div>
-      {isLoading ? (
-        <div className="h-6 w-16 bg-neutral-300 rounded animate-pulse" />
-      ) : (
-        <div className="text-xl md:text-2xl font-bold tabular-nums text-current" title={valueTitle}>
+        <div className='kpi-value text-xl md:text-2xl font-bold tabular-nums text-neutral-900 whitespace-nowrap overflow-hidden text-ellipsis'>
           {value}
         </div>
-      )}
-      {deltaEl}
+      </div>
     </div>
   )
 }
-
-export default KpiCard

--- a/dashboard-ui/app/reports/WarehouseTab.tsx
+++ b/dashboard-ui/app/reports/WarehouseTab.tsx
@@ -18,6 +18,7 @@ import {
 import { ProductService } from '@/services/product/product.service'
 import { IProduct } from '@/shared/interfaces/product.interface'
 import { ISale } from '@/shared/interfaces/sale.interface'
+import KpiCard from '@/components/ui/KpiCard'
 
 interface Filters {
   from: string
@@ -153,12 +154,12 @@ const WarehouseTab: FC<Props> = ({ filters }) => {
 
   return (
     <div className='flex flex-col gap-6 md:gap-8'>
-      <div className='kpi-wrap grid w-full grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4'>
+      <div className='kpi-wrap grid w-full grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4'>
         {isLoading ? (
           Array.from({ length: 3 }).map((_, i) => (
             <div
               key={i}
-              className='h-24 rounded-2xl bg-neutral-200 shadow-card animate-pulse'
+              className='rounded-xl bg-neutral-100 shadow-card h-[92px] md:h-[100px] animate-pulse'
             />
           ))
         ) : error ? (
@@ -171,47 +172,31 @@ const WarehouseTab: FC<Props> = ({ filters }) => {
         ) : (
           [
             {
-              label: 'Общий остаток',
-              value: totalRemains,
+              title: 'Общий остаток',
+              value: compactFmt.format(totalRemains),
               icon: '📦',
+              accent: 'info' as const,
             },
             {
-              label: 'Мало на складе',
-              value: lowCount,
+              title: 'Мало на складе',
+              value: compactFmt.format(lowCount),
               icon: '⚠️',
+              accent: 'warning' as const,
             },
             {
-              label: 'Неликвиды',
-              value: nonMovingPercent,
-              percent: true,
+              title: 'Неликвиды',
+              value: `${nonMovingPercent.toFixed(1)}%`,
               icon: '🧊',
+              accent: 'info' as const,
             },
           ].map(k => (
-            <div
-              key={k.label}
-              className='rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 flex items-center gap-3'
-            >
-              <div className='w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 bg-neutral-300'>
-                <span className='text-xl' aria-hidden='true'>
-                  {k.icon}
-                </span>
-              </div>
-              <div className='flex-1 min-w-0'>
-                <div className='text-sm text-neutral-800 truncate'>{k.label}</div>
-                <div
-                  className='text-2xl md:text-3xl font-semibold tabular-nums whitespace-nowrap overflow-hidden text-ellipsis'
-                  title={
-                    k.percent
-                      ? `${k.value.toFixed(1)}%`
-                      : numberFmt.format(k.value)
-                  }
-                >
-                  {k.percent
-                    ? `${k.value.toFixed(1)}%`
-                    : compactFmt.format(k.value)}
-                </div>
-              </div>
-            </div>
+            <KpiCard
+              key={k.title}
+              title={k.title}
+              value={k.value}
+              icon={k.icon}
+              accent={k.accent}
+            />
           ))
         )}
       </div>

--- a/dashboard-ui/app/reports/page.tsx
+++ b/dashboard-ui/app/reports/page.tsx
@@ -13,6 +13,7 @@ import WarehouseTab from './WarehouseTab'
 import TasksTab from './TasksTab'
 import { ICategory } from '@/shared/interfaces/category.interface'
 import { formatCurrency } from '@/utils/formatCurrency'
+import KpiCard from '@/components/ui/KpiCard'
 
 const presets = [
   { label: 'Сегодня', value: 'today' },
@@ -192,34 +193,31 @@ export default function ReportsPage() {
   const kpiCards = kpis
     ? [
         {
-          label: 'Количество продаж',
-          value: kpis.orders,
+          title: 'Количество продаж',
+          value: new Intl.NumberFormat('ru-RU', {
+            notation: 'compact',
+            compactDisplay: 'short',
+          }).format(kpis.orders),
           icon: '📦',
-          iconClass: 'bg-primary-300 text-neutral-900',
-          valueClass: 'text-neutral-900',
+          accent: 'info' as const,
         },
         {
-          label: 'Средний чек',
-          value: kpis.avgCheck,
-          currency: true,
+          title: 'Средний чек',
+          value: formatCurrency(kpis.avgCheck, { compact: true }),
           icon: '🛒',
-          iconClass: 'bg-warning/10 text-warning',
-          valueClass: 'text-warning',
+          accent: 'warning' as const,
         },
         {
-          label: 'Маржа',
-          value: kpis.margin,
-          currency: true,
+          title: 'Маржа',
+          value: formatCurrency(kpis.margin),
           icon: '📊',
-          iconClass: 'bg-success/10 text-success',
-          valueClass: kpis.margin >= 0 ? 'text-success' : 'text-error',
+          accent: (kpis.margin >= 0 ? 'success' : 'error') as const,
         },
         {
-          label: 'Выполненные задачи',
-          value: kpis.completedTasks,
+          title: 'Выполненные задачи',
+          value: new Intl.NumberFormat('ru-RU').format(kpis.completedTasks),
           icon: '✅',
-          iconClass: 'bg-info/10 text-info',
-          valueClass: 'text-info',
+          accent: 'info' as const,
         },
       ]
     : []
@@ -418,12 +416,12 @@ export default function ReportsPage() {
 
         {active === 'sales' && (
           <>
-            <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6'>
+            <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4 mb-6'>
               {kpisLoading ? (
                 Array.from({ length: 4 }).map((_, i) => (
                   <div
                     key={i}
-                    className='rounded-2xl bg-neutral-200 p-4 shadow-card animate-pulse h-20'
+                    className='rounded-xl bg-neutral-100 shadow-card h-[92px] md:h-[100px] animate-pulse'
                   />
                 ))
               ) : kpisError ? (
@@ -435,34 +433,13 @@ export default function ReportsPage() {
                 </div>
               ) : (
                 kpiCards.map(k => (
-                  <div
-                    key={k.label}
-                    className='rounded-2xl shadow-card p-4 md:p-5 bg-neutral-200 flex items-center gap-3'
-                  >
-                    <div
-                      className={`w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 ${k.iconClass}`}
-                    >
-                      {k.icon}
-                    </div>
-                    <div className='flex-1 min-w-0'>
-                      <div className='text-sm text-neutral-800 truncate'>{k.label}</div>
-                      <div
-                        className={`max-w-full overflow-hidden text-ellipsis whitespace-nowrap tabular-nums font-semibold text-xl sm:text-2xl md:text-3xl ${k.valueClass}`}
-                        title={
-                          k.currency
-                            ? formatCurrency(k.value)
-                            : new Intl.NumberFormat('ru-RU').format(k.value)
-                        }
-                      >
-                        {k.currency
-                          ? formatCurrency(k.value, { compact: true })
-                          : new Intl.NumberFormat('ru-RU', {
-                              notation: 'compact',
-                              compactDisplay: 'short',
-                            }).format(k.value)}
-                      </div>
-                    </div>
-                  </div>
+                  <KpiCard
+                    key={k.title}
+                    title={k.title}
+                    value={k.value}
+                    icon={k.icon}
+                    accent={k.accent}
+                  />
                 ))
               )}
             </div>


### PR DESCRIPTION
## Summary
- implement reusable `<KpiCard>` component with accent stripe, reduced padding and icon size
- refactor KPI sections on dashboard, warehouse and reports to use unified card
- update grids for consistent tile layout across pages

## Testing
- `yarn --cwd dashboard-ui test`
- `yarn --cwd server test`


------
https://chatgpt.com/codex/tasks/task_e_68b83719afd08329907c4d5a73b45716