### PR TITLE
Add period hook and /home route

### DIFF
--- a/dashboard-ui/app/home/page.tsx
+++ b/dashboard-ui/app/home/page.tsx
@@ -1,0 +1,2 @@
+export { default } from '../page'
+

--- a/dashboard-ui/app/store/period.ts
+++ b/dashboard-ui/app/store/period.ts
@@ -1,4 +1,13 @@
+"use client"
+
+import { useDashboardFilter } from './dashboardFilter'
+
 export type Period = 'day' | 'week' | 'month' | 'year' | 'range'
 
 export const isValidPeriod = (p: unknown): p is Period =>
   p === 'day' || p === 'week' || p === 'month' || p === 'year' || p === 'range'
+
+export const usePeriod = () => {
+  const { filter } = useDashboardFilter()
+  return filter.period
+}


### PR DESCRIPTION
## Summary
- expose period hook for components to read current filter
- handle `/home` requests by forwarding to dashboard page

## Testing
- `yarn lint`
- `yarn test` *(fails: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b84e1030048329ad7c796fe93e00f5