### PR TITLE
feat: add default dashboard filter

### DIFF
--- a/dashboard-ui/app/components/dashboard/DashboardControls.tsx
+++ b/dashboard-ui/app/components/dashboard/DashboardControls.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { useDashboardFilter, Period } from "@/store/dashboardFilter";
+import { useDashboardFilter, Period, DEFAULT_FILTER } from "@/store/dashboardFilter";
 
 interface Props {
   warehouse?: string;
@@ -16,8 +16,8 @@ const periodOptions: { value: Period; label: string }[] = [
 ];
 
 const DashboardControls: React.FC<Props> = ({ warehouse, onWarehouseChange }) => {
-  const { filter, setPeriod } = useDashboardFilter();
-  const { period } = filter;
+  const { filter: ctxFilter, setPeriod } = useDashboardFilter();
+  const { period } = ctxFilter ?? DEFAULT_FILTER;
   return (
     <div className="inline-flex items-center gap-4">
       <select

--- a/dashboard-ui/app/components/dashboard/FinancialSummary.tsx
+++ b/dashboard-ui/app/components/dashboard/FinancialSummary.tsx
@@ -5,7 +5,7 @@ import { FaBriefcase } from "react-icons/fa";
 import { useQuery } from "@tanstack/react-query";
 import { AnalyticsService } from "@/services/analytics/analytics.service";
 import { getPeriodRange } from "@/utils/buckets";
-import { useDashboardFilter } from "@/store/dashboardFilter";
+import { useDashboardFilter, DEFAULT_FILTER } from "@/store/dashboardFilter";
 
 const currency = new Intl.NumberFormat("ru-RU", {
   style: "currency",
@@ -13,7 +13,8 @@ const currency = new Intl.NumberFormat("ru-RU", {
 });
 
 const FinancialSummary: React.FC = () => {
-  const { filter } = useDashboardFilter();
+  const { filter: ctxFilter } = useDashboardFilter();
+  const filter = ctxFilter ?? DEFAULT_FILTER;
   const { period } = filter;
   const { start, end } = getPeriodRange(filter);
   const { data } = useQuery({

--- a/dashboard-ui/app/components/dashboard/KpiCards.tsx
+++ b/dashboard-ui/app/components/dashboard/KpiCards.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import KpiCard from "@/components/ui/KpiCard";
 import { AnalyticsService } from "@/services/analytics/analytics.service";
 import { getPeriodRange } from "@/utils/buckets";
-import { useDashboardFilter } from "@/store/dashboardFilter";
+import { useDashboardFilter, DEFAULT_FILTER } from "@/store/dashboardFilter";
 
 type KpiData = {
   revenue: number;
@@ -60,7 +60,8 @@ function delta(curr: number, prev: number) {
 }
 
 const KpiCards: React.FC = () => {
-  const { filter } = useDashboardFilter();
+  const { filter: ctxFilter } = useDashboardFilter();
+  const filter = ctxFilter ?? DEFAULT_FILTER;
   const { period } = filter;
   const { start, end } = getPeriodRange(filter);
   const prevRange = getPrevRange(period, filter);

--- a/dashboard-ui/app/components/dashboard/Overview.tsx
+++ b/dashboard-ui/app/components/dashboard/Overview.tsx
@@ -5,7 +5,7 @@ import cn from 'classnames'
 import { useQuery } from '@tanstack/react-query'
 import { AnalyticsService } from '@/services/analytics/analytics.service'
 import KpiCard from '@/components/ui/KpiCard'
-import { useDashboardFilter } from '@/store/dashboardFilter'
+import { useDashboardFilter, DEFAULT_FILTER } from '@/store/dashboardFilter'
 import { getPeriodRange } from '@/utils/buckets'
 import DateRangePicker from '@/components/ui/DateRangePicker'
 
@@ -19,7 +19,8 @@ const intFmt = new Intl.NumberFormat('ru-RU')
 const formatISO = (d: Date) => d.toISOString().slice(0, 10)
 
 const Overview: React.FC = () => {
-  const { filter, setFilter } = useDashboardFilter()
+  const { filter: ctxFilter, setFilter } = useDashboardFilter()
+  const filter = ctxFilter ?? DEFAULT_FILTER
   const { start, end } = getPeriodRange(filter)
   const startStr = formatISO(start)
   const endStr = formatISO(end)
@@ -49,7 +50,7 @@ const Overview: React.FC = () => {
           {(['day', 'week', 'month', 'year'] as const).map((p) => (
             <button
               key={p}
-              onClick={() => setFilter({ period: p })}
+              onClick={() => setFilter({ period: p, from: null, to: null })}
               className={cn(
                 'h-9 px-3 rounded-full text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-primary-300',
                 filter.period === p

--- a/dashboard-ui/app/components/dashboard/SalesChart.tsx
+++ b/dashboard-ui/app/components/dashboard/SalesChart.tsx
@@ -15,7 +15,7 @@ import {
 } from "recharts";
 import { AnalyticsService } from "@/services/analytics/analytics.service";
 import { buildBuckets, getPeriodRange, MONTH_LABELS } from "@/utils/buckets";
-import { useDashboardFilter } from "@/store/dashboardFilter";
+import { useDashboardFilter, DEFAULT_FILTER } from "@/store/dashboardFilter";
 
 const currency = new Intl.NumberFormat("ru-RU", {
   style: "currency",
@@ -30,7 +30,8 @@ const formatDate = (date: Date) =>
     .slice(0, 10);
 
 const SalesChart: React.FC = () => {
-  const { filter } = useDashboardFilter();
+  const { filter: ctxFilter } = useDashboardFilter();
+  const filter = ctxFilter ?? DEFAULT_FILTER;
   const { period } = filter;
   const { start, end } = getPeriodRange(filter);
   const s = formatDate(start);

--- a/dashboard-ui/app/components/dashboard/TopProducts.tsx
+++ b/dashboard-ui/app/components/dashboard/TopProducts.tsx
@@ -12,7 +12,7 @@ import {
 } from "recharts";
 import { AnalyticsService } from "@/services/analytics/analytics.service";
 import { getPeriodRange } from "@/utils/buckets";
-import { useDashboardFilter } from "@/store/dashboardFilter";
+import { useDashboardFilter, DEFAULT_FILTER } from "@/store/dashboardFilter";
 
 const formatDate = (date: Date) =>
   new Date(date.getTime() - date.getTimezoneOffset() * 60000)
@@ -34,7 +34,8 @@ const options = [
 type Metric = (typeof options)[number]["value"];
 
 const TopProducts: React.FC = () => {
-  const { filter } = useDashboardFilter();
+  const { filter: ctxFilter } = useDashboardFilter();
+  const filter = ctxFilter ?? DEFAULT_FILTER;
   const { period } = filter;
   const { start, end } = getPeriodRange(filter);
   const s = formatDate(start);

--- a/dashboard-ui/app/store/period.ts
+++ b/dashboard-ui/app/store/period.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useDashboardFilter } from './dashboardFilter'
+import { useDashboardFilter, DEFAULT_FILTER } from './dashboardFilter'
 
 export type Period = 'day' | 'week' | 'month' | 'year' | 'range'
 
@@ -9,5 +9,5 @@ export const isValidPeriod = (p: unknown): p is Period =>
 
 export const usePeriod = () => {
   const { filter } = useDashboardFilter()
-  return filter.period
+  return filter?.period ?? DEFAULT_FILTER.period
 }

--- a/dashboard-ui/app/utils/buckets.ts
+++ b/dashboard-ui/app/utils/buckets.ts
@@ -1,4 +1,4 @@
-import { DashboardFilter, Period } from "@/store/dashboardFilter";
+import { DashboardFilter, DEFAULT_FILTER, Period } from "@/store/dashboardFilter";
 
 export interface Bucket {
   key: string; // ISO date (YYYY-MM-DD) or YYYY-MM for months
@@ -22,37 +22,41 @@ export const MONTH_LABELS = [
   "Дек",
 ];
 
-export function getPeriodRange(filter: DashboardFilter): { start: Date; end: Date } {
-  if (filter.period === 'range' && filter.from && filter.to) {
-    return { start: new Date(filter.from), end: new Date(filter.to) };
+export function getPeriodRange(filter?: DashboardFilter): { start: Date; end: Date } {
+  const f = filter ?? DEFAULT_FILTER
+  if (f.period === 'range') {
+    if (f.from && f.to) {
+      return { start: new Date(f.from), end: new Date(f.to) }
+    }
+    // fallback to default day when range is incomplete
   }
-  const period = filter.period;
-  const now = new Date();
-  const end = new Date(now.getFullYear(), now.getMonth(), now.getDate()); // local midnight
+  const period = f.period === 'range' ? 'day' : f.period
+  const now = new Date()
+  const end = new Date(now.getFullYear(), now.getMonth(), now.getDate()) // local midnight
   switch (period) {
     case 'day': {
-      return { start: end, end };
+      return { start: end, end }
     }
     case 'week': {
-      const day = (end.getDay() + 6) % 7; // 0=Mon
-      const start = new Date(end);
-      start.setDate(end.getDate() - day);
-      const weekEnd = new Date(start);
-      weekEnd.setDate(start.getDate() + 6);
-      return { start, end: weekEnd };
+      const day = (end.getDay() + 6) % 7 // 0=Mon
+      const start = new Date(end)
+      start.setDate(end.getDate() - day)
+      const weekEnd = new Date(start)
+      weekEnd.setDate(start.getDate() + 6)
+      return { start, end: weekEnd }
     }
     case 'month': {
-      const start = new Date(end.getFullYear(), end.getMonth(), 1);
-      const monthEnd = new Date(end.getFullYear(), end.getMonth() + 1, 0);
-      return { start, end: monthEnd };
+      const start = new Date(end.getFullYear(), end.getMonth(), 1)
+      const monthEnd = new Date(end.getFullYear(), end.getMonth() + 1, 0)
+      return { start, end: monthEnd }
     }
     case 'year': {
-      const start = new Date(end.getFullYear(), 0, 1);
-      const yearEnd = new Date(end.getFullYear(), 11, 31);
-      return { start, end: yearEnd };
+      const start = new Date(end.getFullYear(), 0, 1)
+      const yearEnd = new Date(end.getFullYear(), 11, 31)
+      return { start, end: yearEnd }
     }
     default:
-      return { start: end, end };
+      return { start: end, end }
   }
 }
 


### PR DESCRIPTION
## Summary
- provide DEFAULT_FILTER with day range and null bounds
- guard period utilities against missing or invalid filter
- fallback to shared default filter across dashboard components

## Testing
- `npx -y vitest run` *(fails: Cannot find module 'vitest/config')*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b85163cc548329a21b5f06ba11e085