### PR TITLE
Remove completed tasks KPI from report page

### DIFF
--- a/dashboard-ui/app/reports/page.tsx
+++ b/dashboard-ui/app/reports/page.tsx
@@ -213,12 +213,6 @@ export default function ReportsPage() {
           icon: '📊',
           accent: (kpis.margin >= 0 ? 'success' : 'error') as const,
         },
-        {
-          title: 'Выполненные задачи',
-          value: new Intl.NumberFormat('ru-RU').format(kpis.completedTasks),
-          icon: '✅',
-          accent: 'info' as const,
-        },
       ]
     : []
 
@@ -416,9 +410,9 @@ export default function ReportsPage() {
 
         {active === 'sales' && (
           <>
-            <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4 mb-6'>
+            <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6'>
               {kpisLoading ? (
-                Array.from({ length: 4 }).map((_, i) => (
+                Array.from({ length: 3 }).map((_, i) => (
                   <div
                     key={i}
                     className='rounded-xl bg-neutral-100 shadow-card h-[92px] md:h-[100px] animate-pulse'

--- a/server/src/analytics/analytics.service.spec.ts
+++ b/server/src/analytics/analytics.service.spec.ts
@@ -99,8 +99,6 @@ describe('AnalyticsService', () => {
         unitsSold: '20',
         margin: '30'
       })
-      taskRepo.count.mockResolvedValue(2)
-
       const result = await service.getKpis('2024-01-01', '2024-01-31', [1])
 
       expect(saleRepo.findOne).toHaveBeenCalledWith(expect.objectContaining({
@@ -110,14 +108,12 @@ describe('AnalyticsService', () => {
         include: [expect.objectContaining({ where: { categoryId: { [Op.in]: [1] } } })],
         raw: true
       }))
-      expect(taskRepo.count).toHaveBeenCalled()
       expect(result).toEqual({
         revenue: 100,
         orders: 5,
         unitsSold: 20,
         avgCheck: 20,
-        margin: 30,
-        completedTasks: 2
+        margin: 30
       })
     })
   })

--- a/server/src/analytics/analytics.service.ts
+++ b/server/src/analytics/analytics.service.ts
@@ -291,7 +291,6 @@ export class AnalyticsService {
                 unitsSold: number
                 avgCheck: number
                 margin: number
-                completedTasks: number
         }> {
                 const whereSales: any = {}
                 if (startDate || endDate) {
@@ -336,20 +335,7 @@ export class AnalyticsService {
                 const margin = parseFloat(kpiRow?.margin) || 0
                 const avgCheck = orders > 0 ? revenue / orders : 0
 
-                const whereTasks: any = { status: TaskStatus.Completed }
-                if (startDate || endDate) {
-                        if (startDate && endDate) {
-                                whereTasks.deadline = { [Op.between]: [startDate, endDate] }
-                        } else if (startDate) {
-                                whereTasks.deadline = { [Op.gte]: startDate }
-                        } else if (endDate) {
-                                whereTasks.deadline = { [Op.lte]: endDate }
-                        }
-                }
-
-                const completedTasks = await this.taskRepo.count({ where: whereTasks })
-
-                return { revenue, orders, unitsSold, avgCheck, margin, completedTasks }
+                return { revenue, orders, unitsSold, avgCheck, margin }
         }
 
         /**


### PR DESCRIPTION
## Summary
- remove completed tasks KPI card and data from report page
- drop completed task metrics from analytics service and tests
- adjust report KPI grid for three columns

## Testing
- `yarn test` (dashboard-ui)
- `yarn test` (server)


------
https://chatgpt.com/codex/tasks/task_e_68b85b4fd1bc8329bdec95a5c47d02dc