### PR TITLE
feat(home): redesign KPI and top analytics

### DIFF
--- a/dashboard-ui/app/components/dashboard/SalesChart.tsx
+++ b/dashboard-ui/app/components/dashboard/SalesChart.tsx
@@ -89,18 +89,18 @@ const SalesChart: React.FC = () => {
 
   if (error) {
     return (
-      <div className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 text-error flex items-center gap-2">
+      <section className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 mb-6 md:mb-8 text-error flex items-center gap-2">
         Ошибка загрузки
         <button className="underline" onClick={() => { refetchRev(); refetchQty(); }}>
           Повторить
         </button>
-      </div>
+      </section>
     );
   }
 
   return (
-    <div className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5">
-      <h3 className="text-lg font-semibold mb-4">📊 Продажи</h3>
+    <section className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 mb-6 md:mb-8">
+      <h2 className="flex items-center gap-2 text-lg font-semibold text-neutral-900 mb-4">📊 Продажи</h2>
       <div className="relative h-[340px]">
         {loading ? (
           <div className="absolute inset-0 flex items-end space-x-2">

--- a/dashboard-ui/app/components/dashboard/Statistics.tsx
+++ b/dashboard-ui/app/components/dashboard/Statistics.tsx
@@ -46,10 +46,12 @@ const Statistics: React.FC = () => {
   const orders = data?.orders ?? 0
 
   return (
-    <section className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 mb-6 relative overflow-visible">
-      <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
-        <h2 className="text-lg font-semibold text-neutral-900">Статистика</h2>
-        <div className="flex flex-wrap items-center gap-2 md:justify-end">
+    <section className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 mb-6 md:mb-8 relative">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+        <h2 className="flex items-center gap-2 text-lg font-semibold text-neutral-900">
+          💰 Финансовые KPI
+        </h2>
+        <div className="flex flex-wrap items-center gap-2">
           {(['day', 'week', 'month', 'year'] as const).map((p) => (
             <button
               key={p}
@@ -109,19 +111,19 @@ const Statistics: React.FC = () => {
             title="Выручка"
             icon="💰"
             value={currency.format(revenue)}
-            accent="neutral"
+            accent="info"
           />
           <KpiCard
             title="Финансовый итог"
             icon="📈"
             value={currency.format(profit)}
-            accent="neutral"
+            accent="success"
           />
           <KpiCard
             title="Кол-во продаж"
             icon="🛒"
             value={intFmt.format(orders)}
-            accent="neutral"
+            accent="warning"
           />
         </div>
       )}

--- a/dashboard-ui/app/components/dashboard/TopAnalytics.test.tsx
+++ b/dashboard-ui/app/components/dashboard/TopAnalytics.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { vi } from 'vitest'
-import TopProducts from './TopProducts'
+import TopAnalytics from './TopAnalytics'
 import { DashboardFilterProvider } from '@/store/dashboardFilter'
 
 vi.mock('@/services/analytics/analytics.service', () => ({
@@ -21,17 +21,18 @@ const renderWidget = () => {
   render(
     <QueryClientProvider client={client}>
       <DashboardFilterProvider>
-        <TopProducts />
+        <TopAnalytics />
       </DashboardFilterProvider>
     </QueryClientProvider>,
   )
 }
 
-describe('TopProducts', () => {
-  it('renders headers and toggle', async () => {
+describe('TopAnalytics', () => {
+  it('renders tabs and metric toggle', async () => {
     renderWidget()
-    expect(await screen.findByText(/Топ продуктов/)).toBeInTheDocument()
-    expect(await screen.findByText(/Топ категорий/)).toBeInTheDocument()
+    expect(await screen.findByText(/Топ-аналитика/)).toBeInTheDocument()
+    expect(screen.getByText('По продуктам')).toBeInTheDocument()
+    expect(screen.getByText('По категориям')).toBeInTheDocument()
     expect(screen.getByText('Выручка')).toBeInTheDocument()
   })
 })

--- a/dashboard-ui/app/components/dashboard/TopAnalytics.tsx
+++ b/dashboard-ui/app/components/dashboard/TopAnalytics.tsx
@@ -37,25 +37,26 @@ interface Props {
 }
 
 const COLORS = [
+  "#2563EB",
   "#3B82F6",
+  "#60A5FA",
+  "#93C5FD",
   "#10B981",
-  "#F59E0B",
-  "#EF4444",
-  "#8B5CF6",
-  "#6366F1",
-  "#14B8A6",
-  "#F472B6",
-  "#A3E635",
-  "#FB923C",
+  "#34D399",
+  "#6EE7B7",
+  "#A7F3D0",
+  "#059669",
+  "#047857",
 ];
 
-const TopProducts: React.FC<Props> = ({ limit = 5 }) => {
+const TopAnalytics: React.FC<Props> = ({ limit = 5 }) => {
   const { filter: ctxFilter } = useDashboardFilter();
   const filter = ctxFilter ?? DEFAULT_FILTER;
   const { start, end } = getPeriodRange(filter);
   const s = formatDate(start);
   const e = formatDate(end);
   const [metric, setMetric] = useState<Metric>("revenue");
+  const [tab, setTab] = useState<"products" | "categories">("products");
 
   const {
     data: prodData,
@@ -140,51 +141,77 @@ const TopProducts: React.FC<Props> = ({ limit = 5 }) => {
 
   if (error) {
     return (
-      <section className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 text-error flex items-center gap-2">
+      <section className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 mb-6 md:mb-8 text-error flex items-center gap-2">
         Ошибка загрузки
         <button
           className="underline"
           onClick={() => {
-            prodRefetch();
-            catRefetch();
+            prodRefetch()
+            catRefetch()
           }}
         >
           Повторить
         </button>
       </section>
-    );
+    )
   }
 
   if (isLoading) {
-    return (
-      <section className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5" />
-    );
+    return <section className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 mb-6 md:mb-8" />
   }
 
   return (
-    <section className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 overflow-visible">
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <div>
-          <div className="flex items-center justify-between mb-4 gap-2">
-            <h3 className="text-lg font-semibold">Топ продуктов</h3>
-            <div className="flex gap-2">
-              {(["revenue", "quantity"] as Metric[]).map((m) => (
-                <button
-                  key={m}
-                  onClick={() => setMetric(m)}
-                  className={cn(
-                    "h-8 px-3 rounded-full text-sm font-medium",
-                    metric === m
-                      ? "bg-primary-500 text-neutral-50"
-                      : "bg-neutral-100 hover:bg-neutral-300",
-                  )}
-                  aria-pressed={metric === m}
-                >
-                  {m === "revenue" ? "Выручка" : "Количество"}
-                </button>
-              ))}
-            </div>
-          </div>
+    <section className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 mb-6 md:mb-8 overflow-visible">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="flex items-center gap-2 text-lg font-semibold text-neutral-900">🏆 Топ-аналитика</h2>
+        <div className="flex gap-2">
+          {(["revenue", "quantity"] as Metric[]).map((m) => (
+            <button
+              key={m}
+              onClick={() => setMetric(m)}
+              className={cn(
+                "h-8 px-3 rounded-full text-sm font-medium",
+                metric === m
+                  ? "bg-primary-500 text-neutral-50"
+                  : "bg-neutral-100 hover:bg-neutral-300",
+              )}
+              aria-pressed={metric === m}
+            >
+              {m === "revenue" ? "Выручка" : "Количество"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 mb-3">
+        <button
+          className={cn(
+            "px-3 py-1.5 rounded-full text-sm",
+            tab === "products"
+              ? "bg-primary-500 text-neutral-50"
+              : "bg-neutral-100 hover:bg-neutral-300",
+          )}
+          onClick={() => setTab("products")}
+          aria-pressed={tab === "products"}
+        >
+          По продуктам
+        </button>
+        <button
+          className={cn(
+            "px-3 py-1.5 rounded-full text-sm",
+            tab === "categories"
+              ? "bg-primary-500 text-neutral-50"
+              : "bg-neutral-100 hover:bg-neutral-300",
+          )}
+          onClick={() => setTab("categories")}
+          aria-pressed={tab === "categories"}
+        >
+          По категориям
+        </button>
+      </div>
+
+      {tab === "products" && (
+        <div className="w-full">
           {barData.length ? (
             <ResponsiveContainer width="100%" height={320}>
               <BarChart data={barData} margin={{ top: 8, right: 12, bottom: 8, left: 56 }}>
@@ -192,8 +219,8 @@ const TopProducts: React.FC<Props> = ({ limit = 5 }) => {
                 <YAxis tickFormatter={formatValue} width={56} />
                 <ReTooltip
                   content={({ active, payload }) => {
-                    if (!active || !payload || !payload.length) return null;
-                    const p = payload[0].payload as any;
+                    if (!active || !payload || !payload.length) return null
+                    const p = payload[0].payload as any
                     return (
                       <div className="bg-white p-2 rounded shadow text-sm">
                         <div>Товар: {p.name}</div>
@@ -201,7 +228,7 @@ const TopProducts: React.FC<Props> = ({ limit = 5 }) => {
                           {metric === "revenue" ? "Выручка" : "Количество"}: {formatValue(p.value)}
                         </div>
                       </div>
-                    );
+                    )
                   }}
                 />
                 <Bar dataKey="value" radius={[4, 4, 0, 0]} fill={metric === "revenue" ? "#10B981" : "#3B82F6"} />
@@ -213,8 +240,10 @@ const TopProducts: React.FC<Props> = ({ limit = 5 }) => {
             </div>
           )}
         </div>
-        <div>
-          <h3 className="text-lg font-semibold mb-4">Топ категорий</h3>
+      )}
+
+      {tab === "categories" && (
+        <div className="w-full">
           {pieData.length ? (
             <div className="flex items-center">
               <ResponsiveContainer width="100%" height={320}>
@@ -226,8 +255,8 @@ const TopProducts: React.FC<Props> = ({ limit = 5 }) => {
                   </Pie>
                   <ReTooltip
                     content={({ active, payload }) => {
-                      if (!active || !payload || !payload.length) return null;
-                      const p = payload[0].payload as any;
+                      if (!active || !payload || !payload.length) return null
+                      const p = payload[0].payload as any
                       return (
                         <div className="bg-white p-2 rounded shadow text-sm">
                           <div>Категория: {p.name}</div>
@@ -236,7 +265,7 @@ const TopProducts: React.FC<Props> = ({ limit = 5 }) => {
                             {metric === "revenue" ? "Выручка" : "Кол-во"}: {formatValue(p.value)}
                           </div>
                         </div>
-                      );
+                      )
                     }}
                   />
                 </PieChart>
@@ -259,14 +288,15 @@ const TopProducts: React.FC<Props> = ({ limit = 5 }) => {
             </div>
           )}
         </div>
-      </div>
+      )}
+
       {isFetching && (
         <div className="absolute inset-0 flex items-center justify-center bg-white/50">
           <div className="w-6 h-6 border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
         </div>
       )}
     </section>
-  );
-};
+  )
+}
 
-export default TopProducts;
+export default TopAnalytics;

--- a/dashboard-ui/app/components/dashboard/WeeklyTasks.tsx
+++ b/dashboard-ui/app/components/dashboard/WeeklyTasks.tsx
@@ -84,12 +84,12 @@ const WeeklyTasks = () => {
   list = list.slice(0, 10);
 
   return (
-    <div className="bg-neutral-200 p-4 md:p-5 rounded-2xl shadow-card relative overflow-hidden">
+    <section className="bg-neutral-200 p-4 md:p-5 rounded-2xl shadow-card relative overflow-hidden mb-6 md:mb-8">
       {isFetching && (
         <div className="absolute inset-0 bg-neutral-200/50 animate-pulse" />
       )}
       <div className="flex justify-between items-center mb-4">
-        <h3 className="text-lg font-semibold flex items-center gap-2">✅ Задачи недели</h3>
+        <h2 className="flex items-center gap-2 text-lg font-semibold text-neutral-900">✅ Задачи недели</h2>
         <Link
           href={`/tasks?start=${encodeURIComponent(startIso)}&end=${encodeURIComponent(
             endIso
@@ -174,7 +174,7 @@ const WeeklyTasks = () => {
           })}
         </ul>
       )}
-    </div>
+    </section>
   );
 };
 

--- a/dashboard-ui/app/components/ui/KpiCard.tsx
+++ b/dashboard-ui/app/components/ui/KpiCard.tsx
@@ -1,12 +1,12 @@
 import { ElementType, ReactNode } from 'react'
 import clsx from 'classnames'
 
-const ACCENTS: Record<string, string> = {
-  success: '#10b981',
-  warning: '#f59e0b',
-  info: '#3b82f6',
-  error: '#ef4444',
-  neutral: '#c8b08d',
+const ACCENTS: Record<string, { bg: string; text: string }> = {
+  success: { bg: 'bg-emerald-100', text: 'text-emerald-600' },
+  warning: { bg: 'bg-amber-100', text: 'text-amber-600' },
+  info: { bg: 'bg-blue-100', text: 'text-blue-600' },
+  error: { bg: 'bg-red-100', text: 'text-red-600' },
+  neutral: { bg: 'bg-neutral-100', text: 'text-neutral-600' },
 }
 
 export interface KpiCardProps {
@@ -35,26 +35,39 @@ export default function KpiCard({
     <Icon className='w-5 h-5 md:w-5 md:h-5 text-current' />
   )
 
+  const accentCls = ACCENTS[accent]
+
   return (
     <div
       className={clsx(
-        'kpi-card relative rounded-xl bg-neutral-100 shadow-card p-3 md:p-4 flex items-center gap-3 h-[92px] md:h-[100px]',
+        'kpi-card relative rounded-xl shadow-card p-3 md:p-4 flex items-center gap-3 h-[92px] md:h-[100px]',
+        accentCls.bg,
         className,
       )}
-      style={{ ['--kpi-accent' as any]: ACCENTS[accent] }}
     >
-      <span
-        className='absolute inset-x-0 top-0 h-1 rounded-t-xl bg-[var(--kpi-accent,#c8b08d)]'
-        aria-hidden
-      />
-      <div className='kpi-icon w-10 h-10 md:w-11 md:h-11 rounded-full bg-white/70 flex items-center justify-center flex-shrink-0'>
+      <div
+        className={clsx(
+          'kpi-icon w-10 h-10 md:w-11 md:h-11 rounded-full flex items-center justify-center flex-shrink-0 bg-white/70',
+          accentCls.text,
+        )}
+      >
         {iconEl}
       </div>
       <div className='flex-1 min-w-0 flex flex-col justify-center'>
-        <div className='kpi-title text-[13px] md:text-sm font-semibold text-neutral-900 leading-5 truncate'>
+        <div
+          className={clsx(
+            'kpi-title text-[13px] md:text-sm font-semibold leading-5 truncate',
+            accentCls.text,
+          )}
+        >
           {title}
         </div>
-        <div className='kpi-value text-xl md:text-2xl font-bold tabular-nums text-neutral-900 whitespace-nowrap overflow-hidden text-ellipsis'>
+        <div
+          className={clsx(
+            'kpi-value text-xl md:text-2xl font-bold tabular-nums whitespace-nowrap overflow-hidden text-ellipsis',
+            accentCls.text,
+          )}
+        >
           {value}
         </div>
       </div>

--- a/dashboard-ui/app/page.tsx
+++ b/dashboard-ui/app/page.tsx
@@ -4,7 +4,7 @@ import React, { useEffect } from "react";
 import type { Metadata } from "next";
 import Statistics from "@/components/dashboard/Statistics";
 import SalesChart from "@/components/dashboard/SalesChart";
-import TopProducts from "@/components/dashboard/TopProducts";
+import TopAnalytics from "@/components/dashboard/TopAnalytics";
 import WeeklyTasks from "@/components/dashboard/WeeklyTasks";
 import { useDashboardFilter } from "@/store/dashboardFilter";
 
@@ -20,10 +20,10 @@ export default function Home() {
 
   return (
     <Layout>
-      <div className="grid gap-6 md:gap-8">
+      <div>
         <Statistics />
         <SalesChart />
-        <TopProducts />
+        <TopAnalytics />
         <WeeklyTasks />
       </div>
     </Layout>


### PR DESCRIPTION
## Summary
- unify financial KPI header with period filter and pastel KPI cards
- combine top products and categories into tabbed "Top-analytics" module
- standardize section spacing and headings across dashboard

## Testing
- `yarn --cwd dashboard-ui test`

------
https://chatgpt.com/codex/tasks/task_e_68b8626d08388329a1e476ddcd55a396