### PR TITLE
Fix incorrect closing tag in SalesChart

### DIFF
--- a/dashboard-ui/app/components/dashboard/SalesChart.tsx
+++ b/dashboard-ui/app/components/dashboard/SalesChart.tsx
@@ -194,7 +194,7 @@ const SalesChart: React.FC = () => {
           </div>
         )}
       </div>
-    </div>
+    </section>
   );
 };
 


### PR DESCRIPTION
## Summary
- replace stray closing `div` with `section` in SalesChart to resolve JSX syntax error

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b86662b15083298ce3e5821994d8cf