### PR TITLE
Revamp statistics section and top analytics filters

### DIFF
--- a/dashboard-ui/app/components/dashboard/KpiCards.tsx
+++ b/dashboard-ui/app/components/dashboard/KpiCards.tsx
@@ -112,7 +112,7 @@ const KpiCards: React.FC = () => {
 
   const groups = [
     {
-      title: "💰 Финансовые KPI",
+      title: "Статистика",
       grid: "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4",
       items: [
         {

--- a/dashboard-ui/app/components/dashboard/Statistics.tsx
+++ b/dashboard-ui/app/components/dashboard/Statistics.tsx
@@ -46,12 +46,10 @@ const Statistics: React.FC = () => {
   const orders = data?.orders ?? 0
 
   return (
-    <section className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 mb-6 md:mb-8 relative">
-      <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
-        <h2 className="flex items-center gap-2 text-lg font-semibold text-neutral-900">
-          💰 Финансовые KPI
-        </h2>
-        <div className="flex flex-wrap items-center gap-2">
+    <section className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 mb-6 md:mb-8 relative overflow-visible">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
+        <h2 className="text-lg font-semibold text-neutral-900">Статистика</h2>
+        <div className="flex flex-wrap items-center gap-2 md:justify-end">
           {(['day', 'week', 'month', 'year'] as const).map((p) => (
             <button
               key={p}

--- a/dashboard-ui/app/components/dashboard/TopAnalytics.test.tsx
+++ b/dashboard-ui/app/components/dashboard/TopAnalytics.test.tsx
@@ -28,11 +28,12 @@ const renderWidget = () => {
 }
 
 describe('TopAnalytics', () => {
-  it('renders tabs and metric toggle', async () => {
+  it('renders filter panel with controls', async () => {
     renderWidget()
     expect(await screen.findByText(/Топ-аналитика/)).toBeInTheDocument()
     expect(screen.getByText('По продуктам')).toBeInTheDocument()
     expect(screen.getByText('По категориям')).toBeInTheDocument()
     expect(screen.getByText('Выручка')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('5')).toBeInTheDocument()
   })
 })

--- a/dashboard-ui/app/components/dashboard/TopAnalytics.tsx
+++ b/dashboard-ui/app/components/dashboard/TopAnalytics.tsx
@@ -10,9 +10,6 @@ import {
   XAxis,
   YAxis,
   Tooltip as ReTooltip,
-  PieChart,
-  Pie,
-  Cell,
 } from "recharts";
 import { AnalyticsService } from "@/services/analytics/analytics.service";
 import { getPeriodRange } from "@/utils/buckets";
@@ -31,32 +28,22 @@ const currency = new Intl.NumberFormat("ru-RU", {
 const intFmt = new Intl.NumberFormat("ru-RU");
 
 type Metric = "revenue" | "quantity";
+type Scope = "products" | "categories";
+type TopN = 5 | 10 | 15;
 
-interface Props {
-  limit?: number;
-}
-
-const COLORS = [
-  "#2563EB",
-  "#3B82F6",
-  "#60A5FA",
-  "#93C5FD",
-  "#10B981",
-  "#34D399",
-  "#6EE7B7",
-  "#A7F3D0",
-  "#059669",
-  "#047857",
-];
-
-const TopAnalytics: React.FC<Props> = ({ limit = 5 }) => {
+const TopAnalytics: React.FC = () => {
   const { filter: ctxFilter } = useDashboardFilter();
   const filter = ctxFilter ?? DEFAULT_FILTER;
   const { start, end } = getPeriodRange(filter);
   const s = formatDate(start);
   const e = formatDate(end);
-  const [metric, setMetric] = useState<Metric>("revenue");
-  const [tab, setTab] = useState<"products" | "categories">("products");
+  const [state, setState] = useState<{ metric: Metric; scope: Scope; topN: TopN }>(
+    {
+      metric: "revenue",
+      scope: "products",
+      topN: 5,
+    },
+  );
 
   const {
     data: prodData,
@@ -65,8 +52,8 @@ const TopAnalytics: React.FC<Props> = ({ limit = 5 }) => {
     error: prodError,
     refetch: prodRefetch,
   } = useQuery({
-    queryKey: ["top-products", s, e],
-    queryFn: () => AnalyticsService.getTopProducts(limit, s, e),
+    queryKey: ["top-products", s, e, state.topN],
+    queryFn: () => AnalyticsService.getTopProducts(state.topN, s, e),
     keepPreviousData: true,
   });
 
@@ -86,205 +73,194 @@ const TopAnalytics: React.FC<Props> = ({ limit = 5 }) => {
   const isFetching = prodFetching || catFetching;
   const error = prodError || catError;
 
-  const products = useMemo(
-    () =>
-      (prodData ?? []).map((row: any, idx: number) => ({
-        idx: idx + 1,
-        name: String(row.productName ?? ""),
-        revenue: Number(row.totalRevenue ?? 0),
-        quantity: Number(row.totalUnits ?? 0),
-      })),
-    [prodData],
-  );
-
-  const barData = useMemo(
-    () =>
-      products.map((p) => ({
-        ...p,
-        value: metric === "revenue" ? p.revenue : p.quantity,
-      })),
-    [products, metric],
-  );
-
-  const categories = useMemo(
-    () =>
-      (catData ?? []).map((row: any) => ({
-        name: String(row.categoryName ?? ""),
-        revenue: Number(row.totalRevenue ?? 0),
-        quantity: Number(row.totalUnits ?? 0),
-      })),
-    [catData],
-  );
-
-  const pieData = useMemo(() => {
-    if (!categories.length) return [] as any[];
-    const total = categories.reduce((sum, c) => sum + c[metric], 0);
-    if (!total) return [] as any[];
-    const sorted = [...categories].sort((a, b) => b[metric] - a[metric]);
-    const top = sorted.slice(0, limit);
-    const topSum = top.reduce((sum, c) => sum + c[metric], 0);
-    if (topSum < total)
-      top.push({
-        name: "Другое",
-        revenue: metric === "revenue" ? total - topSum : 0,
-        quantity: metric === "quantity" ? total - topSum : 0,
-      });
-    return top.map((c) => ({
-      name: c.name,
-      value: c[metric],
-      percent: (c[metric] / total) * 100,
+  const products = useMemo(() => {
+    const items = (prodData ?? []).map((row: any) => ({
+      name: String(row.productName ?? ""),
+      revenue: Number(row.totalRevenue ?? 0),
+      quantity: Number(row.totalUnits ?? 0),
     }));
-  }, [categories, metric, limit]);
+    const sorted = [...items]
+      .sort((a, b) => b[state.metric] - a[state.metric])
+      .slice(0, state.topN);
+    return sorted.map((p, idx) => ({
+      ...p,
+      idx: idx + 1,
+      value: state.metric === "revenue" ? p.revenue : p.quantity,
+    }));
+  }, [prodData, state.metric, state.topN]);
+
+  const categories = useMemo(() => {
+    const items = (catData ?? []).map((row: any) => ({
+      name: String(row.categoryName ?? ""),
+      revenue: Number(row.totalRevenue ?? 0),
+      quantity: Number(row.totalUnits ?? 0),
+    }));
+    const sorted = [...items]
+      .sort((a, b) => b[state.metric] - a[state.metric])
+      .slice(0, state.topN);
+    return sorted.map((c, idx) => ({
+      ...c,
+      idx: idx + 1,
+      value: state.metric === "revenue" ? c.revenue : c.quantity,
+    }));
+  }, [catData, state.metric, state.topN]);
 
   const formatValue = (v: number) =>
-    metric === "revenue" ? currency.format(v) : intFmt.format(v);
-
-  if (error) {
-    return (
-      <section className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 mb-6 md:mb-8 text-error flex items-center gap-2">
-        Ошибка загрузки
-        <button
-          className="underline"
-          onClick={() => {
-            prodRefetch()
-            catRefetch()
-          }}
-        >
-          Повторить
-        </button>
-      </section>
-    )
-  }
-
-  if (isLoading) {
-    return <section className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 mb-6 md:mb-8" />
-  }
+    state.metric === "revenue" ? currency.format(v) : intFmt.format(v);
 
   return (
     <section className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 mb-6 md:mb-8 overflow-visible">
-      <div className="flex items-center justify-between mb-3">
-        <h2 className="flex items-center gap-2 text-lg font-semibold text-neutral-900">🏆 Топ-аналитика</h2>
-        <div className="flex gap-2">
-          {(["revenue", "quantity"] as Metric[]).map((m) => (
-            <button
-              key={m}
-              onClick={() => setMetric(m)}
-              className={cn(
-                "h-8 px-3 rounded-full text-sm font-medium",
-                metric === m
-                  ? "bg-primary-500 text-neutral-50"
-                  : "bg-neutral-100 hover:bg-neutral-300",
-              )}
-              aria-pressed={metric === m}
-            >
-              {m === "revenue" ? "Выручка" : "Количество"}
-            </button>
+      <h2 className="flex items-center gap-2 text-lg font-semibold text-neutral-900 mb-3">
+        🏆 Топ-аналитика
+      </h2>
+      <div className="flex flex-wrap items-center gap-2 mb-3">
+        {(["revenue", "quantity"] as Metric[]).map((m) => (
+          <button
+            key={m}
+            onClick={() => setState((s) => ({ ...s, metric: m }))}
+            className={cn(
+              "h-9 px-3 rounded-full text-sm font-medium",
+              state.metric === m
+                ? "bg-primary-500 text-neutral-50"
+                : "bg-neutral-100 hover:bg-neutral-300",
+            )}
+            aria-pressed={state.metric === m}
+          >
+            {m === "revenue" ? "Выручка" : "Количество"}
+          </button>
+        ))}
+        {(["products", "categories"] as Scope[]).map((s) => (
+          <button
+            key={s}
+            onClick={() => setState((st) => ({ ...st, scope: s }))}
+            className={cn(
+              "h-9 px-3 rounded-full text-sm font-medium",
+              state.scope === s
+                ? "bg-primary-500 text-neutral-50"
+                : "bg-neutral-100 hover:bg-neutral-300",
+            )}
+            aria-pressed={state.scope === s}
+          >
+            {s === "products" ? "По продуктам" : "По категориям"}
+          </button>
+        ))}
+        <select
+          value={state.topN}
+          onChange={(e) =>
+            setState((st) => ({ ...st, topN: Number(e.target.value) as TopN }))
+          }
+          className="h-9 px-3 rounded-full text-sm bg-neutral-100 text-neutral-900 focus:outline-none focus:ring-2 focus:ring-primary-300"
+        >
+          {[5, 10, 15].map((n) => (
+            <option key={n} value={n}>
+              {n}
+            </option>
           ))}
-        </div>
+        </select>
       </div>
 
-      <div className="flex items-center gap-2 mb-3">
-        <button
-          className={cn(
-            "px-3 py-1.5 rounded-full text-sm",
-            tab === "products"
-              ? "bg-primary-500 text-neutral-50"
-              : "bg-neutral-100 hover:bg-neutral-300",
-          )}
-          onClick={() => setTab("products")}
-          aria-pressed={tab === "products"}
-        >
-          По продуктам
-        </button>
-        <button
-          className={cn(
-            "px-3 py-1.5 rounded-full text-sm",
-            tab === "categories"
-              ? "bg-primary-500 text-neutral-50"
-              : "bg-neutral-100 hover:bg-neutral-300",
-          )}
-          onClick={() => setTab("categories")}
-          aria-pressed={tab === "categories"}
-        >
-          По категориям
-        </button>
-      </div>
-
-      {tab === "products" && (
-        <div className="w-full">
-          {barData.length ? (
-            <ResponsiveContainer width="100%" height={320}>
-              <BarChart data={barData} margin={{ top: 8, right: 12, bottom: 8, left: 56 }}>
-                <XAxis dataKey="idx" />
-                <YAxis tickFormatter={formatValue} width={56} />
-                <ReTooltip
-                  content={({ active, payload }) => {
-                    if (!active || !payload || !payload.length) return null
-                    const p = payload[0].payload as any
-                    return (
-                      <div className="bg-white p-2 rounded shadow text-sm">
-                        <div>Товар: {p.name}</div>
-                        <div>
-                          {metric === "revenue" ? "Выручка" : "Количество"}: {formatValue(p.value)}
-                        </div>
-                      </div>
-                    )
-                  }}
-                />
-                <Bar dataKey="value" radius={[4, 4, 0, 0]} fill={metric === "revenue" ? "#10B981" : "#3B82F6"} />
-              </BarChart>
-            </ResponsiveContainer>
-          ) : (
-            <div className="h-[320px] flex items-center justify-center text-neutral-500">
-              Нет данных за период
-            </div>
-          )}
+      {error ? (
+        <div className="text-error flex items-center gap-2">
+          Ошибка загрузки
+          <button
+            className="underline"
+            onClick={() => {
+              prodRefetch();
+              catRefetch();
+            }}
+          >
+            Повторить
+          </button>
         </div>
-      )}
-
-      {tab === "categories" && (
-        <div className="w-full">
-          {pieData.length ? (
-            <div className="flex items-center">
-              <ResponsiveContainer width="100%" height={320}>
-                <PieChart>
-                  <Pie data={pieData} dataKey="value" nameKey="name" outerRadius={110}>
-                    {pieData.map((entry, index) => (
-                      <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                    ))}
-                  </Pie>
-                  <ReTooltip
-                    content={({ active, payload }) => {
-                      if (!active || !payload || !payload.length) return null
-                      const p = payload[0].payload as any
-                      return (
-                        <div className="bg-white p-2 rounded shadow text-sm">
-                          <div>Категория: {p.name}</div>
-                          <div>Доля: {p.percent.toFixed(1)}%</div>
-                          <div>
-                            {metric === "revenue" ? "Выручка" : "Кол-во"}: {formatValue(p.value)}
+      ) : isLoading ? (
+        <div className="h-[320px]" />
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          {state.scope === "products" && (
+            <div>
+              <h3 className="text-base font-medium text-neutral-900 mb-2">
+                Топ-{state.topN} продуктов
+              </h3>
+              {products.length ? (
+                <ResponsiveContainer width="100%" height={320}>
+                  <BarChart
+                    data={products}
+                    margin={{ top: 8, right: 12, bottom: 8, left: 56 }}
+                  >
+                    <XAxis dataKey="idx" />
+                    <YAxis tickFormatter={formatValue} width={56} />
+                    <ReTooltip
+                      content={({ active, payload }) => {
+                        if (!active || !payload?.length) return null;
+                        const p = payload[0].payload as any;
+                        return (
+                          <div className="bg-white p-2 rounded shadow text-sm">
+                            <div>Товар: {p.name}</div>
+                            <div>
+                              {state.metric === "revenue"
+                                ? "Выручка"
+                                : "Количество"}: {formatValue(p.value)}
+                            </div>
                           </div>
-                        </div>
-                      )
-                    }}
-                  />
-                </PieChart>
-              </ResponsiveContainer>
-              <ul className="ml-4 text-sm max-h-56 overflow-auto">
-                {pieData.map((p, idx) => (
-                  <li key={p.name} className="flex items-center gap-2 mb-1">
-                    <span
-                      className="w-3 h-3 rounded-sm"
-                      style={{ backgroundColor: COLORS[idx % COLORS.length] }}
+                        );
+                      }}
                     />
-                    {p.name}
-                  </li>
-                ))}
-              </ul>
+                    <Bar
+                      dataKey="value"
+                      radius={[4, 4, 0, 0]}
+                      fill={state.metric === "revenue" ? "#10B981" : "#3B82F6"}
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              ) : (
+                <div className="h-[320px] flex items-center justify-center text-neutral-500 border-t border-neutral-300">
+                  Нет данных за период
+                </div>
+              )}
             </div>
-          ) : (
-            <div className="h-[320px] flex items-center justify-center text-neutral-500">
-              Нет данных за период
+          )}
+
+          {state.scope === "categories" && (
+            <div>
+              <h3 className="text-base font-medium text-neutral-900 mb-2">
+                Топ-{state.topN} категорий
+              </h3>
+              {categories.length ? (
+                <ResponsiveContainer width="100%" height={320}>
+                  <BarChart
+                    data={categories}
+                    margin={{ top: 8, right: 12, bottom: 8, left: 56 }}
+                  >
+                    <XAxis dataKey="idx" />
+                    <YAxis tickFormatter={formatValue} width={56} />
+                    <ReTooltip
+                      content={({ active, payload }) => {
+                        if (!active || !payload?.length) return null;
+                        const p = payload[0].payload as any;
+                        return (
+                          <div className="bg-white p-2 rounded shadow text-sm">
+                            <div>Категория: {p.name}</div>
+                            <div>
+                              {state.metric === "revenue"
+                                ? "Выручка"
+                                : "Количество"}: {formatValue(p.value)}
+                            </div>
+                          </div>
+                        );
+                      }}
+                    />
+                    <Bar
+                      dataKey="value"
+                      radius={[4, 4, 0, 0]}
+                      fill={state.metric === "revenue" ? "#10B981" : "#3B82F6"}
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              ) : (
+                <div className="h-[320px] flex items-center justify-center text-neutral-500 border-t border-neutral-300">
+                  Нет данных за период
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -296,7 +272,8 @@ const TopAnalytics: React.FC<Props> = ({ limit = 5 }) => {
         </div>
       )}
     </section>
-  )
-}
+  );
+};
 
 export default TopAnalytics;
+


### PR DESCRIPTION
## Summary
- rename financial KPI section to "Статистика" with responsive filters
- add unified metric/object/topN controls and bar charts in TopAnalytics

## Testing
- `yarn --cwd dashboard-ui lint`
- `yarn --cwd dashboard-ui test` *(fails: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b870b8e9008329a378428eaac834d7