### PR TITLE
Fix stats filters and report summary, correct profit and margin formulas

### DIFF
--- a/dashboard-ui/app/components/dashboard/FinancialSummary.test.tsx
+++ b/dashboard-ui/app/components/dashboard/FinancialSummary.test.tsx
@@ -35,7 +35,7 @@ describe('FinancialSummary', () => {
   it('shows positive profit in green', async () => {
     ;(AnalyticsService.getKpis as unknown as any).mockResolvedValueOnce({
       revenue: 1000,
-      margin: 700,
+      cogs: 300,
     })
     renderWidget()
     const value = await screen.findByText(/700,00/)
@@ -45,7 +45,7 @@ describe('FinancialSummary', () => {
   it('shows negative profit in red', async () => {
     ;(AnalyticsService.getKpis as unknown as any).mockResolvedValueOnce({
       revenue: 1000,
-      margin: -200,
+      cogs: 1200,
     })
     renderWidget()
     const value = await screen.findByText(/-200,00/)

--- a/dashboard-ui/app/components/dashboard/FinancialSummary.tsx
+++ b/dashboard-ui/app/components/dashboard/FinancialSummary.tsx
@@ -28,8 +28,8 @@ const FinancialSummary: React.FC = () => {
   });
 
   const revenue = data?.revenue ?? 0;
-  const purchaseCost = revenue - (data?.margin ?? 0);
-  const profit = revenue - purchaseCost;
+  const cogs = data?.cogs ?? 0;
+  const profit = revenue - cogs;
   const profitText = currency.format(profit);
   const color =
     profit > 0

--- a/dashboard-ui/app/components/dashboard/KpiCards.test.tsx
+++ b/dashboard-ui/app/components/dashboard/KpiCards.test.tsx
@@ -11,8 +11,8 @@ vi.mock('next/navigation', () => ({
 
 const getKpisMock = vi.fn()
 ;(getKpisMock as any)
-  .mockResolvedValueOnce({ revenue: 1000, orders: 2, avgCheck: 500, margin: 400 })
-  .mockResolvedValueOnce({ revenue: 800, orders: 1, avgCheck: 800, margin: 200 })
+  .mockResolvedValueOnce({ revenue: 1000, orders: 2, avgCheck: 500, cogs: 600 })
+  .mockResolvedValueOnce({ revenue: 800, orders: 1, avgCheck: 800, cogs: 600 })
 
 vi.mock('@/services/analytics/analytics.service', () => ({
   AnalyticsService: {

--- a/dashboard-ui/app/components/dashboard/KpiCards.tsx
+++ b/dashboard-ui/app/components/dashboard/KpiCards.tsx
@@ -6,13 +6,7 @@ import KpiCard from "@/components/ui/KpiCard";
 import { AnalyticsService } from "@/services/analytics/analytics.service";
 import { getPeriodRange } from "@/utils/buckets";
 import { useDashboardFilter, DEFAULT_FILTER } from "@/store/dashboardFilter";
-
-type KpiData = {
-  revenue: number;
-  orders: number;
-  avgCheck: number;
-  margin: number;
-};
+import { IKpis } from "@/shared/interfaces/kpi.interface";
 
 function getPrevRange(period: any, filter: any) {
   const { start, end } = getPeriodRange(filter);
@@ -77,12 +71,12 @@ const KpiCards: React.FC = () => {
     isFetching,
     error,
     refetch,
-  } = useQuery<KpiData>({
+  } = useQuery<IKpis>({
     queryKey: ["kpi", period, startStr, endStr],
     queryFn: () => AnalyticsService.getKpis(startStr, endStr),
     keepPreviousData: true,
   });
-  const { data: prev } = useQuery<KpiData>({
+  const { data: prev } = useQuery<IKpis>({
     queryKey: ["kpi", period, prevStartStr, prevEndStr],
     queryFn: () => AnalyticsService.getKpis(prevStartStr, prevEndStr),
     keepPreviousData: true,
@@ -101,8 +95,8 @@ const KpiCards: React.FC = () => {
 
   const revenue = curr?.revenue ?? 0;
   const prevRevenue = prev?.revenue ?? 0;
-  const profit = curr?.margin ?? 0;
-  const prevProfit = prev?.margin ?? 0;
+  const profit = curr ? curr.revenue - curr.cogs : 0;
+  const prevProfit = prev ? prev.revenue - prev.cogs : 0;
   const marginPct = revenue ? (profit / revenue) * 100 : 0;
   const prevMarginPct = prevRevenue ? (prevProfit / prevRevenue) * 100 : 0;
   const orders = curr?.orders ?? 0;
@@ -122,7 +116,7 @@ const KpiCards: React.FC = () => {
           delta: delta(revenue, prevRevenue),
         },
         {
-          title: "Финансовый итог",
+          title: "Прибыль",
           icon: "📈",
           value: currency.format(profit),
           delta: delta(profit, prevProfit),

--- a/dashboard-ui/app/components/dashboard/Statistics.tsx
+++ b/dashboard-ui/app/components/dashboard/Statistics.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import React, { useState } from 'react'
-import cn from 'classnames'
 import { useQuery } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import ru from 'date-fns/locale/ru'
@@ -31,7 +30,6 @@ const Statistics: React.FC = () => {
 
   const {
     data,
-    isLoading,
     isFetching,
     error,
     refetch,
@@ -42,28 +40,23 @@ const Statistics: React.FC = () => {
   })
 
   const revenue = data?.revenue ?? 0
-  const profit = data?.margin ?? 0
+  const cogs = data?.cogs ?? 0
+  const profit = revenue - cogs
   const orders = data?.orders ?? 0
 
   return (
     <section className="rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5 mb-6 md:mb-8 relative overflow-visible">
-      <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
-        <h2 className="flex items-center text-lg font-semibold text-neutral-900">
-          <span className="mr-2">📋</span>
-          Статистика
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-4 overflow-visible">
+        <h2 className="text-lg font-semibold text-neutral-900 flex items-center gap-2">
+          <span>📋</span>Статистика
         </h2>
-        <div className="flex flex-wrap items-center gap-2 md:justify-end">
+        <div className="flex flex-wrap items-center gap-2 md:justify-end w-auto">
           {(['day', 'week', 'month', 'year'] as const).map((p) => (
             <button
               key={p}
+              data-active={filter.period === p}
               onClick={() => setFilter({ period: p, from: null, to: null })}
-              className={cn(
-                'h-9 px-3 rounded-full text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-primary-300',
-                filter.period === p
-                  ? 'bg-primary-500 text-neutral-50'
-                  : 'bg-neutral-100 hover:bg-neutral-300',
-              )}
-              aria-pressed={filter.period === p}
+              className="h-9 px-3 rounded-full text-sm font-medium bg-neutral-100 hover:bg-neutral-300 text-neutral-900 data-[active=true]:bg-primary-500 data-[active=true]:text-neutral-50 whitespace-nowrap"
             >
               {p === 'day'
                 ? 'Сегодня'
@@ -76,14 +69,9 @@ const Statistics: React.FC = () => {
           ))}
           <button
             type="button"
+            data-active={filter.period === 'range'}
             onClick={() => setOpenRange(true)}
-            className={cn(
-              'h-9 px-3 rounded-full text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-primary-300',
-              filter.period === 'range'
-                ? 'bg-primary-500 text-neutral-50'
-                : 'bg-neutral-100 hover:bg-neutral-300',
-            )}
-            aria-pressed={filter.period === 'range'}
+            className="h-9 px-3 rounded-full text-sm font-medium bg-neutral-100 hover:bg-neutral-300 text-neutral-900 data-[active=true]:bg-primary-500 data-[active=true]:text-neutral-50 whitespace-nowrap"
             title={
               filter.from && filter.to
                 ? `${format(new Date(filter.from), 'd MMMM yyyy', { locale: ru })} — ${format(
@@ -115,10 +103,10 @@ const Statistics: React.FC = () => {
             accent="info"
           />
           <KpiCard
-            title="Финансовый итог"
+            title="Прибыль"
             icon="📈"
             value={currency.format(profit)}
-            accent="success"
+            accent={profit > 0 ? 'success' : profit < 0 ? 'error' : 'neutral'}
           />
           <KpiCard
             title="Кол-во продаж"

--- a/dashboard-ui/app/reports/SalesTab.tsx
+++ b/dashboard-ui/app/reports/SalesTab.tsx
@@ -86,21 +86,6 @@ const SalesTab: FC<Props> = ({ filters }) => {
     enabled: Boolean(filters.from && filters.to),
   })
 
-  const {
-    data: summary,
-    isLoading: summaryLoading,
-    error: summaryError,
-    refetch: refetchSummary,
-  } = useQuery({
-    queryKey: ['reports', 'sales-summary', filters],
-    queryFn: () =>
-      AnalyticsService.getKpis(
-        filters.from,
-        filters.to,
-        filters.categories,
-      ),
-    enabled: Boolean(filters.from && filters.to),
-  })
   const chartData = useMemo(() => {
     if (!salesData) return []
     const map = new Map<string, { revenue: number; count: number }>()
@@ -363,43 +348,6 @@ const SalesTab: FC<Props> = ({ filters }) => {
         ) : (
           <div className='text-sm text-neutral-500'>Нет данных</div>
         )}
-      </div>
-      <div className='rounded-2xl bg-neutral-200 shadow-card p-4 md:p-5'>
-        <h3 className='flex items-center gap-2 text-base md:text-lg font-semibold text-neutral-900 mb-4'>
-          <span>📊</span>
-          <span>Итог за период</span>
-        </h3>
-        {summaryLoading ? (
-          <div className='text-sm text-neutral-500'>Загрузка...</div>
-        ) : summaryError ? (
-          <div className='text-sm text-error'>
-            Ошибка{' '}
-            <button className='underline' onClick={() => refetchSummary()}>
-              Повторить
-            </button>
-          </div>
-        ) : summary ? (
-          <div className='grid grid-cols-1 sm:grid-cols-3 gap-4'>
-            <div className='text-center'>
-              <div className='text-2xl md:text-3xl font-semibold tabular-nums'>
-                {formatCurrency(summary.revenue)}
-              </div>
-              <div className='text-sm'>Выручка</div>
-            </div>
-            <div className='text-center'>
-              <div className='text-2xl md:text-3xl font-semibold tabular-nums'>
-                {new Intl.NumberFormat('ru-RU').format(summary.orders)}
-              </div>
-              <div className='text-sm'>Количество продаж</div>
-            </div>
-            <div className='text-center'>
-              <div className='text-2xl md:text-3xl font-semibold tabular-nums'>
-                {formatCurrency(summary.margin)}
-              </div>
-              <div className='text-sm'>Прибыль</div>
-            </div>
-          </div>
-        ) : null}
       </div>
     </div>
   )

--- a/dashboard-ui/app/reports/page.tsx
+++ b/dashboard-ui/app/reports/page.tsx
@@ -14,6 +14,7 @@ import TasksTab from './TasksTab'
 import { ICategory } from '@/shared/interfaces/category.interface'
 import { formatCurrency } from '@/utils/formatCurrency'
 import KpiCard from '@/components/ui/KpiCard'
+import { IKpis } from '@/shared/interfaces/kpi.interface'
 
 const presets = [
   { label: 'Сегодня', value: 'today' },
@@ -179,7 +180,7 @@ export default function ReportsPage() {
     isLoading: kpisLoading,
     error: kpisError,
     refetch: refetchKpis,
-  } = useQuery({
+  } = useQuery<IKpis>({
     queryKey: ['reports', 'kpis', appliedFilters],
     queryFn: () =>
       AnalyticsService.getKpis(
@@ -189,6 +190,9 @@ export default function ReportsPage() {
       ),
     enabled: Boolean(appliedFilters.from && appliedFilters.to),
   })
+
+  const gross = kpis ? kpis.revenue - kpis.cogs : 0
+  const marginPct = kpis && kpis.revenue > 0 ? (gross / kpis.revenue) * 100 : 0
 
   const kpiCards = kpis
     ? [
@@ -209,9 +213,9 @@ export default function ReportsPage() {
         },
         {
           title: 'Маржа',
-          value: formatCurrency(kpis.margin),
+          value: `${marginPct.toFixed(1)}%`,
           icon: '📊',
-          accent: (kpis.margin >= 0 ? 'success' : 'error') as const,
+          accent: (marginPct > 0 ? 'success' : marginPct < 0 ? 'error' : 'neutral') as const,
         },
       ]
     : []
@@ -410,7 +414,7 @@ export default function ReportsPage() {
 
         {active === 'sales' && (
           <>
-            <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6'>
+            <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-4'>
               {kpisLoading ? (
                 Array.from({ length: 3 }).map((_, i) => (
                   <div
@@ -437,6 +441,40 @@ export default function ReportsPage() {
                 ))
               )}
             </div>
+            {kpisLoading ? (
+              <div className='rounded-xl bg-neutral-100 shadow-card p-4 md:p-5 mb-6 text-sm text-neutral-500'>Загрузка...</div>
+            ) : kpisError ? (
+              <div className='rounded-xl bg-neutral-100 shadow-card p-4 md:p-5 mb-6 text-sm text-error'>
+                Ошибка{' '}
+                <button className='underline' onClick={() => refetchKpis()}>
+                  Повторить
+                </button>
+              </div>
+            ) : kpis ? (
+              <section className='rounded-xl bg-neutral-100 shadow-card p-4 md:p-5 mb-6'>
+                <h3 className='text-sm font-semibold text-neutral-900 mb-2'>Итог за период</h3>
+                <div className='grid grid-cols-1 sm:grid-cols-2 gap-3'>
+                  <div className='text-center'>
+                    <div className='text-2xl md:text-3xl font-semibold tabular-nums'>
+                      {formatCurrency(kpis.revenue)}
+                    </div>
+                    <div className='text-sm'>Выручка</div>
+                  </div>
+                  <div className='text-center'>
+                    <div className='text-2xl md:text-3xl font-semibold tabular-nums'>
+                      {formatCurrency(gross)}
+                    </div>
+                    <div className='text-sm'>Прибыль</div>
+                  </div>
+                  <div className='text-center'>
+                    <div className={`text-2xl md:text-3xl font-semibold tabular-nums ${marginPct > 0 ? 'text-emerald-600' : marginPct < 0 ? 'text-red-600' : 'text-neutral-600'}`}>
+                      {marginPct.toFixed(1)}%
+                    </div>
+                    <div className='text-sm'>Маржа</div>
+                  </div>
+                </div>
+              </section>
+            ) : null}
             <SalesTab filters={appliedFilters} />
           </>
         )}

--- a/dashboard-ui/app/services/analytics/analytics.service.ts
+++ b/dashboard-ui/app/services/analytics/analytics.service.ts
@@ -3,6 +3,7 @@ import { ITopProduct } from '@/shared/interfaces/top-product.interface'
 import { ICategorySales } from '@/shared/interfaces/category-sales.interface'
 import { ISalesStat } from '@/shared/interfaces/sales-stat.interface'
 import { ITurnover } from '@/shared/interfaces/turnover.interface'
+import { IKpis } from '@/shared/interfaces/kpi.interface'
 
 export const AnalyticsService = {
   async getTopProducts(
@@ -57,7 +58,7 @@ export const AnalyticsService = {
     if (startDate) params.startDate = startDate
     if (endDate) params.endDate = endDate
     if (categories && categories.length) params.categories = categories.join(',')
-    const res = await axios.get(
+    const res = await axios.get<IKpis>(
       '/analytics/kpis',
       { params }
     )

--- a/dashboard-ui/app/shared/interfaces/kpi.interface.ts
+++ b/dashboard-ui/app/shared/interfaces/kpi.interface.ts
@@ -1,0 +1,9 @@
+export interface IKpis {
+  revenue: number;
+  orders: number;
+  unitsSold: number;
+  avgCheck: number;
+  cogs: number;
+  grossProfit: number;
+  marginPct: number;
+}

--- a/server/src/analytics/analytics.service.spec.ts
+++ b/server/src/analytics/analytics.service.spec.ts
@@ -97,7 +97,7 @@ describe('AnalyticsService', () => {
         revenue: '100',
         orders: '5',
         unitsSold: '20',
-        margin: '30'
+        cogs: '60'
       })
       const result = await service.getKpis('2024-01-01', '2024-01-31', [1])
 
@@ -113,7 +113,9 @@ describe('AnalyticsService', () => {
         orders: 5,
         unitsSold: 20,
         avgCheck: 20,
-        margin: 30
+        cogs: 60,
+        grossProfit: 40,
+        marginPct: 40
       })
     })
   })

--- a/server/src/analytics/analytics.service.ts
+++ b/server/src/analytics/analytics.service.ts
@@ -290,7 +290,9 @@ export class AnalyticsService {
                 orders: number
                 unitsSold: number
                 avgCheck: number
-                margin: number
+                cogs: number
+                grossProfit: number
+                marginPct: number
         }> {
                 const whereSales: any = {}
                 if (startDate || endDate) {
@@ -317,11 +319,10 @@ export class AnalyticsService {
                                         fn(
                                                 'SUM',
                                                 literal(
-                                                        '("product"."sale_price" - "product"."purchase_price") * ' +
-                                                                '"SaleModel"."quantity_sold"'
+                                                        '"product"."purchase_price" * "SaleModel"."quantity_sold"'
                                                 )
                                         ),
-                                        'margin'
+                                        'cogs'
                                 ]
                         ],
                         where: whereSales,
@@ -332,10 +333,12 @@ export class AnalyticsService {
                 const revenue = parseFloat(kpiRow?.revenue) || 0
                 const orders = parseInt(kpiRow?.orders) || 0
                 const unitsSold = parseInt(kpiRow?.unitsSold) || 0
-                const margin = parseFloat(kpiRow?.margin) || 0
+                const cogs = parseFloat(kpiRow?.cogs) || 0
                 const avgCheck = orders > 0 ? revenue / orders : 0
+                const grossProfit = revenue - cogs
+                const marginPct = revenue > 0 ? (grossProfit / revenue) * 100 : 0
 
-                return { revenue, orders, unitsSold, avgCheck, margin }
+                return { revenue, orders, unitsSold, avgCheck, cogs, grossProfit, marginPct }
         }
 
         /**


### PR DESCRIPTION
## Summary
- allow statistics period chips to wrap and render date picker popover above content
- show "Итог за период" card below report KPIs with revenue, profit and margin
- compute profit and margin from revenue and COGS in API and UI widgets

## Testing
- `yarn test` (server)
- `yarn lint` (server) *(fails: Key "@typescript-eslint/no-extraneous-class" additional property "allowEmptyCase")*
- `yarn test` (dashboard-ui) *(fails: Couldn't find the node_modules state file)*
- `yarn lint` (dashboard-ui) *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_68b898b587f48329bcfe20a5e8258adb