### PR TITLE
Unify KPI card styling on reports page

### DIFF
--- a/dashboard-ui/app/components/ui/KpiCard.tsx
+++ b/dashboard-ui/app/components/ui/KpiCard.tsx
@@ -1,10 +1,10 @@
-import { ElementType, ReactNode } from 'react'
-import clsx from 'classnames'
+import { ReactNode, ElementType, isValidElement, cloneElement } from 'react'
+import cn from 'classnames'
 
 const ACCENTS: Record<string, { bg: string; text: string }> = {
   success: { bg: 'bg-emerald-100', text: 'text-emerald-600' },
   warning: { bg: 'bg-amber-100', text: 'text-amber-600' },
-  info: { bg: 'bg-blue-100', text: 'text-blue-600' },
+  info: { bg: 'bg-blue-100', text: 'text-blue-700' },
   error: { bg: 'bg-red-100', text: 'text-red-600' },
   neutral: { bg: 'bg-neutral-100', text: 'text-neutral-600' },
 }
@@ -15,8 +15,14 @@ export interface KpiCardProps {
   /** Значение внутри карточки */
   value: ReactNode
   /** Иконка или эмодзи */
-  icon: ElementType | string
-  /** Цветовой акцент */
+  icon: ReactNode | ElementType
+  /** Цвет фона карточки */
+  accentBg?: string
+  /** Цвет текста карточки */
+  accentText?: string
+  /** Изменение в процентах (0-1) */
+  deltaPct?: number
+  /** Предустановленный акцент (для обратной совместимости) */
   accent?: keyof typeof ACCENTS
   /** Дополнительные классы */
   className?: string
@@ -25,52 +31,65 @@ export interface KpiCardProps {
 export default function KpiCard({
   title,
   value,
-  icon: Icon,
+  icon,
+  accentBg,
+  accentText,
+  deltaPct,
   accent = 'neutral',
   className,
 }: KpiCardProps) {
-  const iconEl = typeof Icon === 'string' ? (
-    <span className='text-base md:text-lg'>{Icon}</span>
-  ) : (
-    <Icon className='w-5 h-5 md:w-5 md:h-5 text-current' />
-  )
+  const accentCls = ACCENTS[accent] || { bg: '', text: '' }
+  const bg = accentBg || accentCls.bg || 'bg-neutral-100'
+  const text = accentText || accentCls.text || 'text-neutral-600'
 
-  const accentCls = ACCENTS[accent]
+  let iconEl: ReactNode
+  if (typeof icon === 'string') {
+    iconEl = <span className='w-5 h-5 md:w-5 md:h-5 text-current'>{icon}</span>
+  } else if (isValidElement(icon)) {
+    iconEl = cloneElement(icon, {
+      className: cn('w-5 h-5 md:w-5 md:h-5 text-current', icon.props.className),
+    })
+  } else {
+    const IconComp = icon as ElementType
+    iconEl = <IconComp className='w-5 h-5 md:w-5 md:h-5 text-current' />
+  }
 
   return (
     <div
-      className={clsx(
-        'kpi-card relative rounded-xl shadow-card p-3 md:p-4 flex items-center gap-3 h-[92px] md:h-[100px]',
-        accentCls.bg,
+      className={cn(
+        'rounded-xl shadow-card p-4 md:p-5 h-[120px] flex items-start gap-3',
+        bg,
+        text,
         className,
       )}
     >
-      <div
-        className={clsx(
-          'kpi-icon w-10 h-10 md:w-11 md:h-11 rounded-full flex items-center justify-center flex-shrink-0 bg-white/70',
-          accentCls.text,
-        )}
-      >
+      <div className='w-10 h-10 md:w-11 md:h-11 rounded-full bg-white/70 flex items-center justify-center flex-shrink-0'>
         {iconEl}
       </div>
-      <div className='flex-1 min-w-0 flex flex-col justify-center'>
-        <div
-          className={clsx(
-            'kpi-title text-[13px] md:text-sm font-semibold leading-5 truncate',
-            accentCls.text,
-          )}
-        >
+      <div className='flex-1 min-w-0 flex flex-col justify-center items-start'>
+        <div className='text-[13px] md:text-sm font-medium text-neutral-800/80 leading-5 truncate'>
           {title}
         </div>
-        <div
-          className={clsx(
-            'kpi-value text-xl md:text-2xl font-bold tabular-nums whitespace-nowrap overflow-hidden text-ellipsis',
-            accentCls.text,
-          )}
-        >
+        <div className='text-2xl md:text-3xl font-bold tabular-nums text-current truncate'>
           {value}
         </div>
+        {typeof deltaPct === 'number' && !Number.isNaN(deltaPct) && (
+          <div
+            className={cn(
+              'text-xs mt-0.5',
+              deltaPct > 0
+                ? 'text-success'
+                : deltaPct < 0
+                  ? 'text-error'
+                  : 'text-neutral-800',
+            )}
+          >
+            {deltaPct > 0 ? '▲' : deltaPct < 0 ? '▼' : ''}{' '}
+            {Math.abs(deltaPct * 100).toFixed(1)}%
+          </div>
+        )}
       </div>
     </div>
   )
 }
+

--- a/dashboard-ui/app/reports/page.tsx
+++ b/dashboard-ui/app/reports/page.tsx
@@ -459,24 +459,20 @@ export default function ReportsPage() {
               <section className='mb-6'>
                 <h3 className='text-sm font-semibold text-neutral-900 mb-2'>Итог за период</h3>
                 <div className='grid grid-cols-1 sm:grid-cols-2 gap-4'>
-                  <div className="rounded-xl shadow-card p-4 md:p-5 h-[120px] flex bg-[#D1FAE5] text-[#047857]">
-                    <div className="mr-3 text-2xl leading-none select-none">💰</div>
-                    <div className="flex-1 min-w-0 flex flex-col">
-                      <div className="text-[13px] md:text-sm text-neutral-800/80">Выручка</div>
-                      <div className="text-2xl md:text-3xl font-bold tabular-nums truncate">
-                        {fmt.format(kpis.revenue)}
-                      </div>
-                    </div>
-                  </div>
-                  <div className="rounded-xl shadow-card p-4 md:p-5 h-[120px] flex bg-[#DBEAFE] text-[#1D4ED8]">
-                    <div className="mr-3 text-2xl leading-none select-none">📈</div>
-                    <div className="flex-1 min-w-0 flex flex-col">
-                      <div className="text-[13px] md:text-sm text-neutral-800/80">Прибыль</div>
-                      <div className="text-2xl md:text-3xl font-bold tabular-nums truncate">
-                        {fmt.format(gross)}
-                      </div>
-                    </div>
-                  </div>
+                  <KpiCard
+                    title='Выручка'
+                    value={fmt.format(kpis.revenue)}
+                    icon='💰'
+                    accentBg='bg-[#D1FAE5]'
+                    accentText='text-[#047857]'
+                  />
+                  <KpiCard
+                    title='Прибыль'
+                    value={fmt.format(gross)}
+                    icon='📈'
+                    accentBg='bg-[#DBEAFE]'
+                    accentText='text-[#1D4ED8]'
+                  />
                 </div>
               </section>
             ) : null}


### PR DESCRIPTION
## Summary
- refactor `KpiCard` to support configurable colors and delta percentage
- reuse `KpiCard` for period totals on reports page with consistent KPI styling

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68b8a7eb7f788329aaf7d6cab3b04079