### PR TITLE
Make report KPI blocks more compact

### DIFF
--- a/dashboard-ui/app/components/ui/KpiCard.tsx
+++ b/dashboard-ui/app/components/ui/KpiCard.tsx
@@ -57,7 +57,7 @@ export default function KpiCard({
   return (
     <div
       className={cn(
-        'rounded-xl shadow-card p-4 md:p-5 h-[120px] flex items-start gap-3',
+        'rounded-xl shadow-card px-4 py-3 h-[120px] flex items-start gap-3',
         bg,
         text,
         className,

--- a/dashboard-ui/app/reports/WarehouseTab.tsx
+++ b/dashboard-ui/app/reports/WarehouseTab.tsx
@@ -154,7 +154,7 @@ const WarehouseTab: FC<Props> = ({ filters }) => {
 
   return (
     <div className='flex flex-col gap-6 md:gap-8'>
-      <div className='kpi-wrap grid w-full grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4'>
+      <div className='kpi-wrap grid w-full grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3'>
         {isLoading ? (
           Array.from({ length: 3 }).map((_, i) => (
             <div

--- a/dashboard-ui/app/reports/page.tsx
+++ b/dashboard-ui/app/reports/page.tsx
@@ -222,6 +222,20 @@ export default function ReportsPage() {
           icon: '📊',
           accent: (marginPct > 0 ? 'success' : marginPct < 0 ? 'error' : 'neutral') as const,
         },
+        {
+          title: 'Выручка',
+          value: fmt.format(kpis.revenue),
+          icon: '💰',
+          accentBg: 'bg-[#D1FAE5]',
+          accentText: 'text-[#047857]',
+        },
+        {
+          title: 'Прибыль',
+          value: fmt.format(gross),
+          icon: '📈',
+          accentBg: 'bg-[#DBEAFE]',
+          accentText: 'text-[#1D4ED8]',
+        },
       ]
     : []
 
@@ -419,9 +433,9 @@ export default function ReportsPage() {
 
         {active === 'sales' && (
           <>
-            <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-4'>
+            <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-3'>
               {kpisLoading ? (
-                Array.from({ length: 3 }).map((_, i) => (
+                Array.from({ length: 5 }).map((_, i) => (
                   <div
                     key={i}
                     className='rounded-xl bg-neutral-100 shadow-card h-[92px] md:h-[100px] animate-pulse'
@@ -442,40 +456,12 @@ export default function ReportsPage() {
                     value={k.value}
                     icon={k.icon}
                     accent={k.accent}
+                    accentBg={k.accentBg}
+                    accentText={k.accentText}
                   />
                 ))
               )}
             </div>
-            {kpisLoading ? (
-              <div className='rounded-xl bg-neutral-100 shadow-card p-4 md:p-5 mb-6 text-sm text-neutral-500'>Загрузка...</div>
-            ) : kpisError ? (
-              <div className='rounded-xl bg-neutral-100 shadow-card p-4 md:p-5 mb-6 text-sm text-error'>
-                Ошибка{' '}
-                <button className='underline' onClick={() => refetchKpis()}>
-                  Повторить
-                </button>
-              </div>
-            ) : kpis ? (
-              <section className='mb-6'>
-                <h3 className='text-sm font-semibold text-neutral-900 mb-2'>Итог за период</h3>
-                <div className='grid grid-cols-1 sm:grid-cols-2 gap-4'>
-                  <KpiCard
-                    title='Выручка'
-                    value={fmt.format(kpis.revenue)}
-                    icon='💰'
-                    accentBg='bg-[#D1FAE5]'
-                    accentText='text-[#047857]'
-                  />
-                  <KpiCard
-                    title='Прибыль'
-                    value={fmt.format(gross)}
-                    icon='📈'
-                    accentBg='bg-[#DBEAFE]'
-                    accentText='text-[#1D4ED8]'
-                  />
-                </div>
-              </section>
-            ) : null}
             <SalesTab filters={appliedFilters} />
           </>
         )}


### PR DESCRIPTION
## Summary
- reduce vertical padding on KPI cards for a tighter look
- merge revenue and profit into the main KPI grid and drop the extra heading
- standardize KPI grid gaps to `gap-3` including warehouse tab

## Testing
- `yarn lint`
- `yarn test` *(fails: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8aad0685883298044276552219c29