### PR TITLE
style: adjust KPI layout and padding

### DIFF
--- a/dashboard-ui/app/components/ui/KpiCard.tsx
+++ b/dashboard-ui/app/components/ui/KpiCard.tsx
@@ -57,7 +57,7 @@ export default function KpiCard({
   return (
     <div
       className={cn(
-        'rounded-xl shadow-card px-4 py-3 h-[120px] flex items-start gap-3',
+        'rounded-xl shadow-card px-4 pt-3 pb-2.5 h-[120px] flex items-start gap-3',
         bg,
         text,
         className,

--- a/dashboard-ui/app/reports/page.tsx
+++ b/dashboard-ui/app/reports/page.tsx
@@ -433,35 +433,62 @@ export default function ReportsPage() {
 
         {active === 'sales' && (
           <>
-            <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-3'>
-              {kpisLoading ? (
-                Array.from({ length: 5 }).map((_, i) => (
-                  <div
-                    key={i}
-                    className='rounded-xl bg-neutral-100 shadow-card h-[92px] md:h-[100px] animate-pulse'
-                  />
-                ))
-              ) : kpisError ? (
-                <div className='col-span-full text-error text-sm'>
-                  Ошибка загрузки{' '}
-                  <button className='underline' onClick={() => refetchKpis()}>
-                    Повторить
-                  </button>
+            {kpisLoading ? (
+              <>
+                <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-3'>
+                  {Array.from({ length: 3 }).map((_, i) => (
+                    <div
+                      key={i}
+                      className='rounded-xl bg-neutral-100 shadow-card h-[92px] md:h-[100px] animate-pulse'
+                    />
+                  ))}
                 </div>
-              ) : (
-                kpiCards.map(k => (
-                  <KpiCard
-                    key={k.title}
-                    title={k.title}
-                    value={k.value}
-                    icon={k.icon}
-                    accent={k.accent}
-                    accentBg={k.accentBg}
-                    accentText={k.accentText}
-                  />
-                ))
-              )}
-            </div>
+                <div className='grid grid-cols-1 sm:grid-cols-2 gap-3 mb-3'>
+                  {Array.from({ length: 2 }).map((_, i) => (
+                    <div
+                      key={i}
+                      className='rounded-xl bg-neutral-100 shadow-card h-[92px] md:h-[100px] animate-pulse'
+                    />
+                  ))}
+                </div>
+              </>
+            ) : kpisError ? (
+              <div className='text-error text-sm mb-3'>
+                Ошибка загрузки{' '}
+                <button className='underline' onClick={() => refetchKpis()}>
+                  Повторить
+                </button>
+              </div>
+            ) : (
+              <>
+                <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-3'>
+                  {kpiCards.slice(0, 3).map(k => (
+                    <KpiCard
+                      key={k.title}
+                      title={k.title}
+                      value={k.value}
+                      icon={k.icon}
+                      accent={k.accent}
+                      accentBg={k.accentBg}
+                      accentText={k.accentText}
+                    />
+                  ))}
+                </div>
+                <div className='grid grid-cols-1 sm:grid-cols-2 gap-3 mb-3'>
+                  {kpiCards.slice(3).map(k => (
+                    <KpiCard
+                      key={k.title}
+                      title={k.title}
+                      value={k.value}
+                      icon={k.icon}
+                      accent={k.accent}
+                      accentBg={k.accentBg}
+                      accentText={k.accentText}
+                    />
+                  ))}
+                </div>
+              </>
+            )}
             <SalesTab filters={appliedFilters} />
           </>
         )}


### PR DESCRIPTION
## Summary
- stretch "Выручка" and "Прибыль" KPI cards on report page into a two-column grid
- trim bottom padding across KPI cards for a tighter look

## Testing
- `yarn lint`
- `NODE_OPTIONS=--max_old_space_size=4096 yarn test` *(fails: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8af4cf44083299dd2f74c87897b1f