### PR TITLE
style: compact report kpis

### DIFF
--- a/dashboard-ui/app/components/ui/KpiCard.tsx
+++ b/dashboard-ui/app/components/ui/KpiCard.tsx
@@ -57,7 +57,7 @@ export default function KpiCard({
   return (
     <div
       className={cn(
-        'rounded-xl shadow-card px-4 pt-3 pb-2.5 h-[120px] flex items-start gap-3',
+        'rounded-xl shadow-card px-4 pt-3 pb-2 h-[120px] flex items-start gap-3',
         bg,
         text,
         className,

--- a/dashboard-ui/app/reports/WarehouseTab.tsx
+++ b/dashboard-ui/app/reports/WarehouseTab.tsx
@@ -154,7 +154,7 @@ const WarehouseTab: FC<Props> = ({ filters }) => {
 
   return (
     <div className='flex flex-col gap-6 md:gap-8'>
-      <div className='kpi-wrap grid w-full grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3'>
+      <div className='kpi-wrap grid w-full grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2'>
         {isLoading ? (
           Array.from({ length: 3 }).map((_, i) => (
             <div

--- a/dashboard-ui/app/reports/page.tsx
+++ b/dashboard-ui/app/reports/page.tsx
@@ -435,7 +435,7 @@ export default function ReportsPage() {
           <>
             {kpisLoading ? (
               <>
-                <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-3'>
+                <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 mb-2'>
                   {Array.from({ length: 3 }).map((_, i) => (
                     <div
                       key={i}
@@ -443,7 +443,7 @@ export default function ReportsPage() {
                     />
                   ))}
                 </div>
-                <div className='grid grid-cols-1 sm:grid-cols-2 gap-3 mb-3'>
+                <div className='grid grid-cols-1 sm:grid-cols-2 gap-2 mb-2'>
                   {Array.from({ length: 2 }).map((_, i) => (
                     <div
                       key={i}
@@ -461,7 +461,7 @@ export default function ReportsPage() {
               </div>
             ) : (
               <>
-                <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-3'>
+                <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 mb-2'>
                   {kpiCards.slice(0, 3).map(k => (
                     <KpiCard
                       key={k.title}
@@ -474,7 +474,7 @@ export default function ReportsPage() {
                     />
                   ))}
                 </div>
-                <div className='grid grid-cols-1 sm:grid-cols-2 gap-3 mb-3'>
+                <div className='grid grid-cols-1 sm:grid-cols-2 gap-2 mb-2'>
                   {kpiCards.slice(3).map(k => (
                     <KpiCard
                       key={k.title}


### PR DESCRIPTION
## Summary
- tighten KPI card padding and spacing on Report page
- shrink vertical gaps in report KPI grids

## Testing
- `yarn test` *(fails: Cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_68b8b58b14648329a081bcb5ceb16725