### PR TITLE
chore: tighten kpi card spacing on reports page

### DIFF
--- a/dashboard-ui/app/reports/WarehouseTab.tsx
+++ b/dashboard-ui/app/reports/WarehouseTab.tsx
@@ -154,7 +154,7 @@ const WarehouseTab: FC<Props> = ({ filters }) => {
 
   return (
     <div className='flex flex-col gap-6 md:gap-8'>
-      <div className='kpi-wrap grid w-full grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2'>
+      <div className='kpi-wrap grid w-full grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-2 gap-y-1 mb-1'>
         {isLoading ? (
           Array.from({ length: 3 }).map((_, i) => (
             <div

--- a/dashboard-ui/app/reports/page.tsx
+++ b/dashboard-ui/app/reports/page.tsx
@@ -435,7 +435,7 @@ export default function ReportsPage() {
           <>
             {kpisLoading ? (
               <>
-                <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 mb-2'>
+                <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-2 gap-y-1 mb-1'>
                   {Array.from({ length: 3 }).map((_, i) => (
                     <div
                       key={i}
@@ -443,7 +443,7 @@ export default function ReportsPage() {
                     />
                   ))}
                 </div>
-                <div className='grid grid-cols-1 sm:grid-cols-2 gap-2 mb-2'>
+                <div className='grid grid-cols-1 sm:grid-cols-2 gap-x-2 gap-y-1 mb-1'>
                   {Array.from({ length: 2 }).map((_, i) => (
                     <div
                       key={i}
@@ -461,7 +461,7 @@ export default function ReportsPage() {
               </div>
             ) : (
               <>
-                <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 mb-2'>
+                <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-2 gap-y-1 mb-1'>
                   {kpiCards.slice(0, 3).map(k => (
                     <KpiCard
                       key={k.title}
@@ -474,7 +474,7 @@ export default function ReportsPage() {
                     />
                   ))}
                 </div>
-                <div className='grid grid-cols-1 sm:grid-cols-2 gap-2 mb-2'>
+                <div className='grid grid-cols-1 sm:grid-cols-2 gap-x-2 gap-y-1 mb-1'>
                   {kpiCards.slice(3).map(k => (
                     <KpiCard
                       key={k.title}


### PR DESCRIPTION
## Summary
- compact KPI card grids on report overview
- reduce Warehouse KPI grid spacing for denser layout

## Testing
- `yarn test` *(fails: Cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_68b8ba1be0d0832998c365102359bbd7