### PR TITLE
style: unify KPI card styling and icons

### DIFF
--- a/dashboard-ui/app/components/dashboard/KpiCards.tsx
+++ b/dashboard-ui/app/components/dashboard/KpiCards.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { useQuery } from "@tanstack/react-query";
+import { Wallet, TrendingUp, Percent, ShoppingCart, CreditCard } from "lucide-react";
 import KpiCard from "@/components/ui/KpiCard";
 import { AnalyticsService } from "@/services/analytics/analytics.service";
 import { getPeriodRange } from "@/utils/buckets";
@@ -109,39 +110,39 @@ const KpiCards: React.FC = () => {
       title: "Статистика",
       grid: "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4",
       items: [
-        {
-          title: "Выручка",
-          icon: "💰",
-          value: currency.format(revenue),
-          delta: delta(revenue, prevRevenue),
-        },
-        {
-          title: "Прибыль",
-          icon: "📈",
-          value: currency.format(profit),
-          delta: delta(profit, prevProfit),
-        },
-        {
-          title: "Маржа",
-          icon: "📊",
-          value: `${marginPct.toFixed(1).replace('.', ',')}%`,
-          delta: delta(marginPct, prevMarginPct),
-        },
+    {
+      title: "Выручка",
+      icon: Wallet,
+      value: currency.format(revenue),
+      delta: delta(revenue, prevRevenue),
+    },
+    {
+      title: "Прибыль",
+      icon: TrendingUp,
+      value: currency.format(profit),
+      delta: delta(profit, prevProfit),
+    },
+    {
+      title: "Маржа",
+      icon: Percent,
+      value: `${marginPct.toFixed(1).replace('.', ',')}%`,
+      delta: delta(marginPct, prevMarginPct),
+    },
       ],
     },
     {
-      title: "📦 Операционные KPI",
+      title: "Операционные KPI",
       grid: "grid grid-cols-1 sm:grid-cols-2 gap-3 md:gap-4",
       items: [
         {
           title: "Кол-во продаж",
-          icon: "🛒",
+          icon: ShoppingCart,
           value: numberCompact.format(orders),
           delta: delta(orders, prevOrders),
         },
         {
           title: "Средний чек",
-          icon: "💳",
+          icon: CreditCard,
           value: currency.format(avg),
           delta: delta(avg, prevAvg),
         },

--- a/dashboard-ui/app/components/ui/KpiCard.tsx
+++ b/dashboard-ui/app/components/ui/KpiCard.tsx
@@ -2,11 +2,12 @@ import { ReactNode, ElementType, isValidElement, cloneElement } from 'react'
 import cn from 'classnames'
 
 const ACCENTS: Record<string, { bg: string; text: string }> = {
-  success: { bg: 'bg-emerald-100', text: 'text-emerald-600' },
-  warning: { bg: 'bg-amber-100', text: 'text-amber-600' },
-  info: { bg: 'bg-blue-100', text: 'text-blue-700' },
-  error: { bg: 'bg-red-100', text: 'text-red-600' },
+  success: { bg: 'bg-success/20', text: 'text-success' },
+  warning: { bg: 'bg-warning/20', text: 'text-warning' },
+  info: { bg: 'bg-info/20', text: 'text-info' },
+  error: { bg: 'bg-error/20', text: 'text-error' },
   neutral: { bg: 'bg-neutral-100', text: 'text-neutral-600' },
+  primary: { bg: 'bg-primary-100', text: 'text-primary-500' },
 }
 
 export interface KpiCardProps {
@@ -14,7 +15,7 @@ export interface KpiCardProps {
   title: string
   /** Значение внутри карточки */
   value: ReactNode
-  /** Иконка или эмодзи */
+  /** Иконка lucide */
   icon: ReactNode | ElementType
   /** Цвет фона карточки */
   accentBg?: string
@@ -43,12 +44,10 @@ export default function KpiCard({
   const text = accentText || accentCls.text || 'text-neutral-600'
 
   let iconEl: ReactNode
-  if (typeof icon === 'string') {
-    iconEl = <span className='w-5 h-5 md:w-5 md:h-5 text-current'>{icon}</span>
-  } else if (isValidElement(icon)) {
-    iconEl = cloneElement(icon, {
-      className: cn('w-5 h-5 md:w-5 md:h-5 text-current', icon.props.className),
-    })
+  if (isValidElement(icon)) {
+      iconEl = cloneElement(icon, {
+        className: cn('w-5 h-5 md:w-5 md:h-5 text-current', icon.props.className),
+      })
   } else {
     const IconComp = icon as ElementType
     iconEl = <IconComp className='w-5 h-5 md:w-5 md:h-5 text-current' />
@@ -57,7 +56,7 @@ export default function KpiCard({
   return (
     <div
       className={cn(
-        'rounded-xl shadow-card px-4 pt-3 pb-2 h-[120px] flex items-start gap-3',
+        'rounded-xl shadow-card hover:shadow-card-hover h-[100px] flex items-start gap-3 p-3 md:p-4 pb-2 md:pb-3',
         bg,
         text,
         className,
@@ -67,7 +66,7 @@ export default function KpiCard({
         {iconEl}
       </div>
       <div className='flex-1 min-w-0 flex flex-col justify-center items-start'>
-        <div className='text-[13px] md:text-sm font-medium text-neutral-800/80 leading-5 truncate'>
+        <div className='text-[13px] md:text-sm font-medium text-neutral-900/80 leading-5 truncate'>
           {title}
         </div>
         <div className='text-2xl md:text-3xl font-bold tabular-nums text-current truncate'>

--- a/dashboard-ui/ui/theme.ts
+++ b/dashboard-ui/ui/theme.ts
@@ -1,0 +1,18 @@
+export const colors = {
+  neutral: 'neutral',
+  primary: 'primary',
+  success: 'success',
+  warning: 'warning',
+  error: 'error',
+  info: 'info',
+} as const
+
+export const radii = {
+  card: 'rounded-xl',
+  pill: 'rounded-full',
+} as const
+
+export const shadows = {
+  card: 'shadow-card',
+  cardHover: 'shadow-card-hover',
+} as const


### PR DESCRIPTION
## Summary
- add shared design token definitions for colors, radii and shadows
- refactor KpiCard to use tailwind palette accents and consistent padding/height
- replace emoji KPI icons with lucide-react icons

## Testing
- `yarn lint`
- `yarn test` *(fails: Cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_68b8c0eab6908329847145e069ae5a66