### PR TITLE
Fix string icon handling in KpiCard

### DIFF
--- a/dashboard-ui/app/components/ui/KpiCard.tsx
+++ b/dashboard-ui/app/components/ui/KpiCard.tsx
@@ -45,9 +45,11 @@ export default function KpiCard({
 
   let iconEl: ReactNode
   if (isValidElement(icon)) {
-      iconEl = cloneElement(icon, {
-        className: cn('w-5 h-5 md:w-5 md:h-5 text-current', icon.props.className),
-      })
+    iconEl = cloneElement(icon, {
+      className: cn('w-5 h-5 md:w-5 md:h-5 text-current', icon.props.className),
+    })
+  } else if (typeof icon === 'string') {
+    iconEl = <span className='w-5 h-5 md:w-5 md:h-5 text-current'>{icon}</span>
   } else {
     const IconComp = icon as ElementType
     iconEl = <IconComp className='w-5 h-5 md:w-5 md:h-5 text-current' />


### PR DESCRIPTION
## Summary
- render string-based icons directly in KpiCard to avoid InvalidCharacterError

## Testing
- `yarn lint`
- `yarn test` *(fails: Cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_68b8c3340910832983c9a51d3e791284